### PR TITLE
Missing requirement for protobuf

### DIFF
--- a/drivers/python/setup.py
+++ b/drivers/python/setup.py
@@ -8,4 +8,5 @@ setup(name="rethinkdb"
      ,maintainer="RethinkDB Inc."
      ,maintainer_email="bugs@rethinkdb.com"
      ,packages=['rethinkdb']
+     ,install_requires = ['protobuf']
      )


### PR DESCRIPTION
If this require is missing you need to install by hand the protobuf module via:
pip install protobuf
