### PR TITLE
fix rdb_protocol test.py

### DIFF
--- a/test/rdb_workloads/test.py
+++ b/test/rdb_workloads/test.py
@@ -31,7 +31,7 @@ class RDBTest(unittest.TestCase):
         cls.table_name = os.environ.get('TABLE_NAME', 'test')
         cls.table = cls.db.table(cls.table_name)
         try:
-            cls.db.table_create(cls.table_name)
+            cls.db.table_create(cls.table_name).run()
         except:
             pass
 


### PR DESCRIPTION
Congrats on shipping :-)

without this, test.py has a bunch of errors like:

"ExecutionError: Error while executing query on server: Error during operation `EVAL_TABLE test`: No entry with that name."
