### PR TITLE
remove DebianV8Version var from makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -663,8 +663,6 @@ install-deb: install
 		gzip -c9 | \
 		install -m644 -T /dev/stdin $(DESTDIR)$(doc_dir)/changelog.Debian.gz
 
-DebianV8Version:=$(shell apt-cache show libv8-dev | grep '^Version:' | sed -e 's/^Version: \\([0-9]*\\(\\.[0-9]*\\)*\\).*$$/\\1/g' || true ; )
-
 build-deb-support: $(TC_LESSC_INT_EXE) $(TC_COFFEE_INT_EXE)
 
 build-deb-src-control:


### PR DESCRIPTION
This does not appear to be used anywhere
