### PR TITLE
Guarantee a successful index read before reading block data

### DIFF
--- a/src/buffer_cache/mirrored/mirrored.cc
+++ b/src/buffer_cache/mirrored/mirrored.cc
@@ -163,6 +163,7 @@ void mc_inner_buf_t::load_inner_buf(bool should_lock, file_account_t *io_account
         subtree_recency = cache->serializer->get_recency(block_id);
         // TODO: Merge this initialization with the read itself eventually
         data_token = cache->serializer->index_read(block_id);
+        guarantee(data_token);
         cache->serializer->block_read(data_token, data.get(), io_account);
     }
 


### PR DESCRIPTION
Guarantee that we've got a token from the index lookup before we go ahead and try to read that block. (mirrored buffer cache)

This makes crashes like this one https://github.com/rethinkdb/rethinkdb/issues/52 cleaner and easier to debug.
