### PR TITLE
fixing cJSON comparison returning incorrect recursive result

### DIFF
--- a/src/rdb_protocol/rdb_protocol_json.cc
+++ b/src/rdb_protocol/rdb_protocol_json.cc
@@ -53,11 +53,12 @@ public:
 
 class compare_functor {
 public:
-    bool operator()(const std::pair<std::string, cJSON *> &l, const std::pair<std::string, cJSON *> &r) {
-        if (l.first != r.first) {
-            return l.first < r.first;
+    bool operator()(const std::pair<char *, cJSON *> &l, const std::pair<char *, cJSON *> &r) {
+        int key_compare = strcmp(l.first, r.first);
+        if (key_compare != 0) {
+            return key_compare < 0;
         } else {
-            return json_cmp(l.second, r.second);
+            return json_cmp(l.second, r.second) < 0;
         }
     }
 };


### PR DESCRIPTION
When json_cmp was recursing in object compare due to two identical keys, it was returning the same result for `l < r` and `l > r`.  This was due to the coercion of the result of `json_cmp` to a bool, where `json_cmp` can return -1, 0, or 1.  Thus, a result of -1 was returning true (correct), a result of 0 was returning false (correct), and a result of 1 was returning true (incorrect).

This commit fixes that by performing the correct conversion to a bool.

Also, some std::strings were using in the comparison function, which I've changed to char *s, as they are in the original objects, to reduce allocation.
