### PR TITLE
Fixing linking of gtest

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -448,7 +448,8 @@ endif
 endif
 
 ifeq ($(UNIT_TESTS),1)
-UNIT_LDFLAGS+=-L/usr/local/lib -lgtest
+UNIT_STATIC_LIBRARIES+=gtest
+UNIT_STATIC_LIBRARY_PATHS+=$(foreach lib,$(UNIT_STATIC_LIBRARIES),$(shell /sbin/ldconfig -p | awk '/lib$(lib).so / { gsub("\\.so$$", ".a", $$NF); print $$NF; exit 0; }'))
 endif
 
 UNIT_TEST_FILTER?=*
@@ -1104,13 +1105,13 @@ ifeq ($(VERBOSE),0)
 	@echo "    LD $@"
 endif
 ifeq ($(IGNORE_SOME_ICC_LD_WARNINGS),0)
-	$(QUIET) $(CXX) $(LDFLAGS) $(UNIT_LDFLAGS) $(SERVER_UNIT_TEST_OBJS) $(STATIC_LIBRARY_PATHS) -o $(BUILD_DIR)/$(SERVER_UNIT_TEST_NAME)
+	$(QUIET) $(CXX) $(LDFLAGS) $(SERVER_UNIT_TEST_OBJS) $(STATIC_LIBRARY_PATHS) $(UNIT_STATIC_LIBRARY_PATHS) -o $(BUILD_DIR)/$(SERVER_UNIT_TEST_NAME)
 else
 # Note: that is the copy of the problem description that we have above in server linking section.
 # The following line runs CXX in linking mode (supplying only the object files and libraries) and then
 # pass the output through a filter which filters out bogus (?) icc-related problems.
 # FIXME: figure out why we get these problems
-	$(QUIET) ($(CXX) $(LDFLAGS) $(UNIT_LDFLAGS) $(SERVER_UNIT_TEST_OBJS) $(STATIC_LIBRARY_PATHS) -o $(BUILD_DIR)/$(SERVER_UNIT_TEST_NAME) 2>&1 >&3 | (grep -v "warning: relocation refers to discarded section" || true) >&2) 3>&1
+	$(QUIET) ($(CXX) $(LDFLAGS) $(SERVER_UNIT_TEST_OBJS) $(STATIC_LIBRARY_PATHS) $(UNIT_STATIC_LIBRARY_PATHS) -o $(BUILD_DIR)/$(SERVER_UNIT_TEST_NAME) 2>&1 >&3 | (grep -v "warning: relocation refers to discarded section" || true) >&2) 3>&1
 endif
 
 $(BUILD_DIR)/$(START_DB_NAME):


### PR DESCRIPTION
Previously, if you specified UNIT_TESTS=1 during make, the Makefile would add dependencies in both `rethinkdb` and `rethinkdb-unittest` on the `libgtest.so.0` shared-object file.  This is obviously wrong, but in addition, gtest no longer supports installing a shared object file.

These commits change the build such that gtest is now statically linked, and only for the `rethinkdb-unittest` build.  The normal `rethinkdb` binary now does nothing regarding gtest.
