### PR TITLE
Prepend CLOSURE_NO_DEPS value instead of appending

### DIFF
--- a/drivers/javascript/src/build.mk
+++ b/drivers/javascript/src/build.mk
@@ -53,7 +53,7 @@ $(JS_DRIVER_LIB): $(JS_BUILD_DIR) $(PB_JS_FILE) $(DRIVER_COMPILED_COFFEE)
 	    --root=$(JS_BUILD_DIR) \
 	    --namespace=rethinkdb.root \
 	    --output_mode=$(JS_OUTPUT_MODE) \
-	) >> $@
+	) > $@
 
 .PHONY: publish
 publish: $(JS_DRIVER_LIB)


### PR DESCRIPTION
We have to prepend CLOSURE_NO_DEPS=true and not append it.

We probably didn't properly refreshed last time.
@atnnn can you take a look and merge if you are ok with the changes?
