### PR TITLE
Properly destroy the timeout (for ajax/distribution) for a namespace mod...

### DIFF
--- a/admin/static/coffee/namespaces/namespace.coffee
+++ b/admin/static/coffee/namespaces/namespace.coffee
@@ -120,6 +120,7 @@ module 'NamespaceView', ->
 
         destroy: =>
             namespaces.off 'remove', @check_if_still_exists
+            @model.clear_timeout()
             @title.destroy()
             @profile.destroy()
             @replicas.destroy()


### PR DESCRIPTION
When the users goes to `table/<id_table>`, we call `load_key_distr` which is going to make ajax requests to `/ajax/distribution?...` every 5 seconds.

We forgot somehow to call `clear_timeout` to remove the timeout/interval, meaning that if the users goes to a table and leaves and repeat both these two actions X times, we will make X requests to `/ajax/distribution...` every 5 seconds.
