### PR TITLE
Clarify ORDERBY protocol documentation

### DIFF
--- a/src/rdb_protocol/ql2.proto
+++ b/src/rdb_protocol/ql2.proto
@@ -255,7 +255,7 @@ message Term {
         // Map a function over a sequence and then concatenate the results together.
         CONCATMAP = 40; // Sequence, Function(1) -> Sequence
         // Order a sequence based on one or more attributes.
-        ORDERBY   = 41; // Sequence, !STRING... -> Sequence
+        ORDERBY   = 41; // Sequence, (STRING|ASC|DESC)... -> Sequence
         // Get all distinct elements of a sequence (like `uniq`).
         DISTINCT  = 42; // Sequence -> Sequence
         // Count the number of elements in a sequence.


### PR DESCRIPTION
Hey guys,

While working on mfenniak/rethinkdb-net, I found that the existing documentation does not show how ASC and DESC terms can be used.  I made a small update to the protocol doc to include this detail.
