### PR TITLE
Do not strip the rethinkdb executable when building the debian package

### DIFF
--- a/packaging/debian.template/rules
+++ b/packaging/debian.template/rules
@@ -15,7 +15,7 @@ clean:
 install: build
 	dh_clean
 	dh_installdirs
-	$(MAKE) DEBUG=$(DEBUG) DESTDIR=$(CURDIR)/debian/$(package) PVERSION=$(PVERSION) install
+	$(MAKE) DEBUG=$(DEBUG) DESTDIR=$(CURDIR)/debian/$(package) PVERSION=$(PVERSION) STRIP_ON_INSTALL=0 install
 
 build:
 	$(MAKE) DEBUG=$(DEBUG) PVERSION=$(PVERSION) VERBOSE=1


### PR DESCRIPTION
Debhelper will strip the executable for us and use the unstripped executable to create
the rethinkdb-dbg package.

Issue #624
