### PR TITLE
Proof-of-concept `r.json` method using Oj gem

### DIFF
--- a/drivers/ruby/lib/json_to_rql.rb
+++ b/drivers/ruby/lib/json_to_rql.rb
@@ -1,0 +1,81 @@
+require 'oj'
+
+module RethinkDB
+  # Convert JSON to RQL protocol buffers
+  class JSONToRQL < Oj::Saj
+    def initialize
+      @parents = []
+      @current = nil
+    end
+
+    # Return resulting Term object
+    def result
+      @current
+    end
+
+    # Add table to current container
+    def hash_start(key)
+      add_container(Term::TermType::MAKE_OBJ, key)
+    end
+
+    # Leave current container
+    def hash_end(key)
+      leave_container
+    end
+
+    # Add a new array to current container
+    def array_start key
+      add_container(Term::TermType::MAKE_ARRAY, key)
+    end
+
+    # Leave current container
+    def array_end(key)
+      leave_container
+    end
+
+    # Add a new value to an array or key/value pair to table
+    def add_value val, key
+      if val.is_a? Term
+        val = val
+      else
+        val = RethinkDB::Shim.native_to_datum_term(val)
+      end
+
+      if key # Table
+        pair = Term::AssocPair.new
+        pair.key = key.to_s  # Probably already string
+        pair.val = val
+
+        @current.optargs << pair
+      else # Array
+        @current.args << val
+      end
+    end
+
+    def add_container(container_type, key = nil)
+      @parents << @current unless @current.nil?
+
+      container = Term.new
+      container.type = container_type
+
+      if @current
+        add_value(container, key)
+      end
+
+      @current = container
+    end
+
+    def leave_container
+      @current = @parents.pop unless @parents.empty?
+    end
+  end
+
+  class RQL
+    # Convert JSON string or IO object to RQL expression
+    def json(input)
+      converter = JSONToRQL.new
+      Oj.saj_parse(converter, input)
+      RQL.new(converter.result)
+    end
+  end
+end

--- a/drivers/ruby/rethinkdb.gemspec
+++ b/drivers/ruby/rethinkdb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license   = 'Apache-2'
   s.files     = Dir['lib/*.rb']
 
-  s.add_runtime_dependency "json"
+  s.add_runtime_dependency "oj", "~>2.0.12"
   s.add_runtime_dependency "ruby_protobuf"
 end
 


### PR DESCRIPTION
As discussed in #252, it sure is convenient to pass JSON strings directly to RethinkDB, or at least not have to instantiate all the objects just to convert them to RQL.

So I threw together a slightly different approach to the `r.json` method using the [Oj](http://www.ohler.com/oj/) JSON parser. Sorry, no tests because I can't get RethinkDB to build on my current machine. But some manual testing showed that the basic functionality works, at least.

Here is a quick benchmark using a 660KB JSON file ([code](https://gist.github.com/presidentbeef/724743fd7a11b57cfbf0#file-r_json_bm-rb)):

```
Rehearsal -------------------------------------------------------
JSON.parse + r.expr   8.600000   0.030000   8.630000 (  8.635941)
Oj.load + r.expr      8.440000   0.010000   8.450000 (  8.440146)
r.json                0.620000   0.000000   0.620000 (  0.617726)
r.json stream         0.560000   0.000000   0.560000 (  0.562764)
--------------------------------------------- total: 18.260000sec

                          user     system      total        real
JSON.parse + r.expr   7.950000   0.000000   7.950000 (  7.955163)
Oj.load + r.expr      7.960000   0.000000   7.960000 (  7.969099)
r.json                0.540000   0.000000   0.540000 (  0.538718)
r.json stream         0.540000   0.000000   0.540000 (  0.537156)
```

My conclusion: it's the conversion to RQL that is slow, not the JSON parsing.

I was a little surprised that streaming the file didn't perform better, but it may be that Oj is not actually streaming the data efficiently like I thought it would.
