### PR TITLE
Make build Python3 compatible

### DIFF
--- a/external/google-closure-library/closure/bin/build/source.py
+++ b/external/google-closure-library/closure/bin/build/source.py
@@ -21,6 +21,7 @@ Simple class to scan a JavaScript file and express its dependencies.
 __author__ = 'nnaze@google.com'
 
 
+import io
 import re
 
 _BASE_REGEX_STRING = '^\s*goog\.%s\(\s*[\'"](.+)[\'"]\s*\)'
@@ -107,7 +108,7 @@ def GetFileContents(path):
     IOError: An error occurred opening or reading the file.
 
   """
-  fileobj = open(path)
+  fileobj = io.open(path, encoding='utf-8')
   try:
     return fileobj.read()
   finally:


### PR DESCRIPTION
Python3 opens files in user default encoding, and it can be non-unicode. In this case opening
utf-8 encoded file might raise an exception.

Use io library (available since 2.6) and explicitly open files in utf-8
