### PR TITLE
Update instructions for migration

### DIFF
--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -13,7 +13,8 @@ connects to a machine in your cluster.  This will write everything in your
 cluster to disk, so make sure you have enough space.
 
 2. Upgrade RethinkDB on all your servers, then move or delete all your
-`rethinkdb_data` directories (they are incompatible with the new version).
+`rethinkdb_data` and `data` directories (they are incompatible with the new 
+version).
 
 3. Run `import_export.rb --import --host HOST --port PORT`.  This will re-import
 all the data on disk into your cluster.  You must run this in the same directory


### PR DESCRIPTION
Today when I upgraded, I found that I had to also move/delete the data dir (not only the rethinkdb_data dir, as the readme says) in my instance folder. Updated the description to reflect this.

Here is a log that shows it:

```
$ sudo /etc/init.d/rethinkdb stop
$ mv rethinkdb_data/ bu_rd_data
```

....SNIP UPGRADE SNIP...

```
$ sudo /etc/init.d/rethinkdb start
rethinkdb: logger: Starting instance. (logging to `/var/lib/rethinkdb/logger/data/log_file')
```

-- Checked admin UI. Not responding.

```
/var/lib/rethinkdb/logger$ more data/log_file
.......SNIP
2013-06-14T12:25:50.237999367 19958.094500s info: Storage engine shut down.
2013-06-14T12:26:36.428862914 0.010244s info: Running rethinkdb 1.6.0-0ubuntu1~precise (GCC 4.6.3)...
2013-06-14T12:26:36.435715970 0.017096s info: Running on Linux 3.2.0-40-virtual x86_64
2013-06-14T12:26:36.435775856 0.017156s info: Loading data from directory /var/lib/rethinkdb/logger/data
2013-06-14T12:26:36.452642142 0.034023s error: File version is incorrect. This file was created with RethinkDB's serializer version 1.5, but you are trying to read it with version 1.6.
2013-06-14T12:27:21.795479013 0.009312s info: Running rethinkdb 1.6.0-0ubuntu1~precise (GCC 4.6.3)...
2013-06-14T12:27:21.799406545 0.013239s info: Running on Linux 3.2.0-40-virtual x86_64
2013-06-14T12:27:21.799459035 0.013292s info: Loading data from directory /var/lib/rethinkdb/logger/data
2013-06-14T12:27:21.804126474 0.017959s error: File version is incorrect. This file was created with RethinkDB's serializer version 1.5, but you are trying to read it with version 1.6.
$ sudo mv data bu_data
$ sudo /etc/init.d/rethinkdb start
```

-- Web interface responding. Log file all good.

Although the solution was simple, especially after reading the log, I think the README should be correct as well. Hence this pull request.

Great work on 1.6 btw!
