### PR TITLE
fix compiling item counts by not including MKDIRs in the item list

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -109,7 +109,6 @@ endif
 # foo/bar: baz | foo/.
 # 	zap $< > $@
 %/.:
-	$P MKDIR $(patsubst %/.,%,$@)
 	mkdir -p $@
 
 ##### Make recursive make less error-prone


### PR DESCRIPTION
'make' ends at [315/318], but the build was successful.
The problem was that 'mkdir -p' sometimes creates multiple targets at once, that makes the difference of item counts between dry run and actual build. (such as MKDIR build/blah/, then MKDIR build/, the latter is ignored in actual building)
Alternative solution to this could be making mkdir parent directory a dependency, but it looks pretty painful to me.
