### PR TITLE
make vertical scrollbar always visible to prevent ui from shifting between tabs

### DIFF
--- a/admin/static/less/styles.less
+++ b/admin/static/less/styles.less
@@ -44,6 +44,10 @@ html, body {
     // fix poor font rendering on OS X webkit
     -webkit-font-smoothing: antialiased;
 }
+html {
+    overflow: -moz-scrollbars-vertical; 
+    overflow-y: scroll;
+}
 #sticky-wrap { min-height: 100%; }
 #main-container {
     padding-bottom: 95px;


### PR DESCRIPTION
Longer pages have vertical overflow while shorter ones do not, making page width changing.
