### PR TITLE
Case const string into no-const.

### DIFF
--- a/src/clustering/administration/cli/admin_command_parser.cc
+++ b/src/clustering/administration/cli/admin_command_parser.cc
@@ -344,7 +344,7 @@ admin_command_parser_t::admin_term_cap_t::admin_term_cap_t(fd_t fd) {
     }
 
     // Command to disable all formatting
-    char *normal_cstr = tgetstr("me", NULL);
+    char *normal_cstr = tgetstr((char *)"me", NULL);
     if (normal_cstr != NULL) {
         normal_str.assign(normal_cstr);
     } else {
@@ -353,13 +353,13 @@ admin_command_parser_t::admin_term_cap_t::admin_term_cap_t(fd_t fd) {
     }
 
     // Command to enable double-bright mode (bold)
-    char *bold_cstr = tgetstr("md", NULL);
+    char *bold_cstr = tgetstr((char *)"md", NULL);
     if (bold_cstr != NULL) {
         bold_str.assign(bold_cstr);
     }
 
     // Command to enable underline mode
-    char *underline_cstr = tgetstr("us", NULL);
+    char *underline_cstr = tgetstr((char *)"us", NULL);
     if (underline_cstr != NULL) {
         underline_str.assign(underline_cstr);
     }


### PR DESCRIPTION
This fixes "deprecated conversion from string constant to ‘char*’ [-Werror=write-strings]" warning

This closes bug #1499
