### PR TITLE
consider directory is new if 'metadata' does not exists

### DIFF
--- a/src/clustering/administration/main/directory_lock.hpp
+++ b/src/clustering/administration/main/directory_lock.hpp
@@ -12,7 +12,7 @@ class directory_lock_t {
 public:
     // Possibly creates, then opens and locks the specified directory
     // Returns true if the directory was created, false otherwise
-    directory_lock_t(const base_path_t &path, bool create, bool *created_out);
+    directory_lock_t(const base_path_t &path, bool create, bool *is_new_directory);
     ~directory_lock_t();
 
     // Prevents deletion of the directory tree at destruction, if


### PR DESCRIPTION
"rethinkdb -d /empty/dir" fails with error messages

with error message:
error: Inaccessible database file: "/the/empty/dir/metadata": No such file or directory
       Some possible reasons:
       - the database file couldn't be created or opened for reading and writing
       - the user which was used to start the database is not an owner of the file

Similarly "rethinkdb create -d /empty/dir" also fails because creating an db on an existing directory is forbidden.

However I think these actions should be allowed. What I think users will normally do is to create an empty dir, and then let DB initialize it. (What I am doing all the time with mysql, mongo, etc)

This commit tries to ensure this behavior: Detect whether 'metadata' is in the directory, consider the directory is not initialized as a rethinkdb instance if 'metadata' does not exist, and then start to initialize it if needed.
