### PR TITLE
Ruby: Fix mutable backtrace

### DIFF
--- a/drivers/ruby/lib/rethinkdb.rb
+++ b/drivers/ruby/lib/rethinkdb.rb
@@ -11,9 +11,22 @@ load 'shim.rb'
 load 'func.rb'
 load 'rpp.rb'
 
+class Term::AssocPair
+  def deep_dup
+    dup.tap { |pair| pair.val = pair.val.deep_dup }
+  end
+end
+
 class Term
   attr_accessor :context
   attr_accessor :is_error
+
+  def deep_dup
+    dup.tap {|term|
+      term.args.map!(&:deep_dup)
+      term.optargs.map!(&:deep_dup)
+    }
+  end
 
   def bt_tag bt
     @is_error = true

--- a/drivers/ruby/lib/shim.rb
+++ b/drivers/ruby/lib/shim.rb
@@ -88,9 +88,8 @@ module RethinkDB
         else raise RqlRuntimeError, "Unexpected response: #{r.inspect}"
         end
       rescue RqlError => e
-        term = orig_term.dup
+        term = orig_term.deep_dup
         term.bt_tag(bt)
-        $t = term
         raise e.class, "#{e.message}\nBacktrace:\n#{RPP.pp(term)}"
       end
     end


### PR DESCRIPTION
This program:

``` ruby
require 'rethinkdb'
extend RethinkDB::Shortcuts
r.connect.repl

q = r.table("non_existent_table").orderby({:index => r.asc("id")}).limit(1)
puts q.pp
q.run rescue nil
puts q.pp
```

Outputs:

```
r.table("non_existent_table").limit(1)
r.table("non_existent_table").limit(1)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Erroneous_Portion_Constructed:
        from test.rb:5:in `<main>'
Called:
```

Expected output:

```
r.table("non_existent_table").limit(1)
r.table("non_existent_table").limit(1)
```

Issue: the driver should not mutate queries.
