### PR TITLE
Improved check for count filter argument.

### DIFF
--- a/drivers/python/rethinkdb/ast.py
+++ b/drivers/python/rethinkdb/ast.py
@@ -404,7 +404,7 @@ class RqlQuery(object):
     # NB: Can't overload __len__ because Python doesn't
     #     allow us to return a non-integer
     def count(self, filter=()):
-        if filter == ():
+        if filter is ():
             return Count(self)
         else:
             return Count(self, func_wrap(filter))


### PR DESCRIPTION
Because equals operator can be overloaded for filter, use `is` to verify that `filter` argument is omitted.

This should fix #1992
