### PR TITLE
driver/python: fix import_format error

### DIFF
--- a/drivers/python/rethinkdb/_import.py
+++ b/drivers/python/rethinkdb/_import.py
@@ -188,7 +188,11 @@ def parse_options():
 
         # Verify valid --format option
         if options.import_format is None:
-            res["import_format"] = "json"
+            options.import_format = os.path.split(options.import_file)[1].split(".")[-1]
+            if options.import_format not in ["csv", "json"]:
+                options.import_format = "json"
+
+            res["import_format"] = options.import_format
         elif options.import_format not in ["csv", "json"]:
             raise RuntimeError("Error: Unknown format '%s', valid options are 'csv' and 'json'" % options.import_format)
         else:


### PR DESCRIPTION
I tried to import a csv file with import subcommand, however, it failed
due to import_format was set to "json" by default if --format is not
given:

```
$ rethinkdb import -f x.csv --table test.csv_example
[                                        ]   0%
0 rows imported in 1 table
Traceback: [('/usr/lib64/python2.7/site-packages/rethinkdb/_import.py', 458,....)]
RuntimeError: Error: JSON format not recognized - file does not begin with an object or array
In file: /path/to/x.csv
Errors occurred during import
```

I guess we can do better by trying to get the proper format from the
filename, and then set it to "json" if failed.

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
