### PR TITLE
driver/python: silient none-useful tracebacks

### DIFF
--- a/drivers/python/rethinkdb/_import.py
+++ b/drivers/python/rethinkdb/_import.py
@@ -580,13 +580,6 @@ def spawn_import_clients(options, files_info):
         error_queue.put((RuntimeError, RuntimeError("Error: Items remaining in the task queue"), None))
 
     if not error_queue.empty():
-        # multiprocessing queues don't handling tracebacks, so they've already been stringified in the queue
-        while not error_queue.empty():
-            error = error_queue.get()
-            print >> sys.stderr, "Traceback: %s" % (error[2])
-            print >> sys.stderr, "%s: %s" % (error[0].__name__, error[1])
-            if len(error) == 4:
-                print >> sys.stderr, "In file: %s" % (error[3])
         raise RuntimeError("Errors occurred during import")
 
 def get_import_info_for_file(filename, db_filter, table_filter):


### PR DESCRIPTION
Qutoes comments by coffeemug from issue #2098:

  I noticed from #2097 that some user errors are printed as Python
  exceptions (with Traceback and everything). They shouldn't be -- we
  should just print proper error messages and return user values. Printing
  Python exceptions and tracebacks is really unfriendly in those cases.

Link: https://github.com/rethinkdb/rethinkdb/issues/2098

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
