### PR TITLE
Introduce new RqlConnectionError

### DIFF
--- a/drivers/javascript/errors.coffee
+++ b/drivers/javascript/errors.coffee
@@ -4,6 +4,8 @@ class RqlDriverError extends Error
         @msg = msg
         @message = msg
 
+class RqlConnectionError extends RqlDriverError
+
 class RqlServerError extends Error
     constructor: (msg, term, frames) ->
         @name = @constructor.name

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -47,7 +47,7 @@ class Connection extends events.EventEmitter
             if e instanceof err.RqlDriverError
                 callback e
             else
-                callback new err.RqlDriverError "Could not connect to #{@host}:#{@port}.\n#{e.message}"
+                callback new err.RqlConnectionError "Could not connect to #{@host}:#{@port}.\n#{e.message}"
         @once 'error', errCallback
 
         conCallback = =>
@@ -171,7 +171,7 @@ class Connection extends events.EventEmitter
         unless typeof callback is 'function'
             throw new err.RqlDriverError "First argument to noreplyWait must be a callback function."
         unless @open
-            callback(new err.RqlDriverError "Connection is closed.")
+            callback(new err.RqlConnectionError "Connection is closed.")
             return
 
         # Assign token
@@ -214,7 +214,7 @@ class Connection extends events.EventEmitter
         @db = db
 
     _start: (term, cb, opts) ->
-        unless @open then throw new err.RqlDriverError "Connection is closed."
+        unless @open then throw new err.RqlConnectionError "Connection is closed."
 
         # Assign token
         token = @nextToken++
@@ -314,7 +314,7 @@ class TcpConnection extends Connection
 
         timeout = setTimeout( (()=>
             @rawSocket.destroy()
-            @emit 'error', new err.RqlDriverError "Handshake timedout"
+            @emit 'error', new err.RqlConnectionError "Handshake timedout"
         ), @timeout*1000)
 
         @rawSocket.once 'error', => clearTimeout(timeout)
@@ -347,7 +347,7 @@ class TcpConnection extends Connection
                             @emit 'connect'
                             return
                         else
-                            @emit 'error', new err.RqlDriverError "Server dropped connection with message: \"" + status_str.trim() + "\""
+                            @emit 'error', new err.RqlConnectionError "Server dropped connection with message: \"" + status_str.trim() + "\""
                             return
 
 
@@ -412,7 +412,7 @@ class HttpConnection extends Connection
                     @_connId = (new DataView xhr.response).getInt32(0, true)
                     @emit 'connect'
                 else
-                    @emit 'error', new err.RqlDriverError "XHR error, http status #{xhr.status}."
+                    @emit 'error', new err.RqlConnectionError "XHR error, http status #{xhr.status}."
         xhr.send()
 
         @xhr = xhr # We allow only one query at a time per HTTP connection

--- a/drivers/python/rethinkdb/errors.py
+++ b/drivers/python/rethinkdb/errors.py
@@ -29,6 +29,10 @@ class RqlDriverError(Exception):
     def __str__(self):
         return self.message
 
+class RqlConnectionError(RqlDriverError):
+    def __init__(self, message):
+        super(RqlConnectionError, self).__init__(message)
+
 class QueryPrinter(object):
     def __init__(self, root, frames=[]):
         self.root = root

--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -95,7 +95,7 @@ class Connection(object):
         try:
             self.socket = socket.create_connection((self.host, self.port), self.timeout)
         except Exception as err:
-            raise RqlDriverError("Could not connect to %s:%s. Error: %s" % (self.host, self.port, err))
+            raise RqlConnectionError("Could not connect to %s:%s. Error: %s" % (self.host, self.port, err))
 
         self._sock_sendall(struct.pack("<L", p.VersionDummy.V0_2))
         self._sock_sendall(struct.pack("<L", len(self.auth_key)) + str.encode(self.auth_key, 'ascii'))
@@ -110,7 +110,7 @@ class Connection(object):
 
         if response != b"SUCCESS":
             self.close(noreply_wait=False)
-            raise RqlDriverError("Server dropped connection with message: \"%s\"" % response.strip())
+            raise RqlConnectionError("Server dropped connection with message: \"%s\"" % response.strip())
 
         # Connection is now initialized
 
@@ -230,7 +230,7 @@ class Connection(object):
                 while len(response_header) < 4:
                     chunk = self._sock_recv(4)
                     if len(chunk) == 0:
-                        raise RqlDriverError("Connection is closed.")
+                        raise RqlConnectionError("Connection is closed.")
                     response_header += chunk
 
                 # The first 4 bytes give the expected length of this response
@@ -239,7 +239,7 @@ class Connection(object):
                 while len(response_buf) < response_len:
                     chunk = self._sock_recv(response_len - len(response_buf))
                     if len(chunk) == 0:
-                        raise RqlDriverError("Connection is broken.")
+                        raise RqlConnectionError("Connection is broken.")
                     response_buf += chunk
             except KeyboardInterrupt as err:
                 # When interrupted while waiting for a response cancel the outstanding
@@ -280,7 +280,7 @@ class Connection(object):
     def _send_query(self, query, term, opts={}, async=False):
         # Error if this connection has closed
         if not self.socket:
-            raise RqlDriverError("Connection is closed.")
+            raise RqlConnectionError("Connection is closed.")
 
         query.accepts_r_json = True
 

--- a/drivers/ruby/lib/exc.rb
+++ b/drivers/ruby/lib/exc.rb
@@ -1,6 +1,7 @@
 module RethinkDB
   class RqlError < RuntimeError; end
   class RqlRuntimeError < RqlError; end
+  class RqlConnectionError < RqlRuntimeError; end
   class RqlDriverError < RqlError; end
   class RqlCompileError < RqlError; end
 


### PR DESCRIPTION
RqlRuntimeError has too large of a scope and it
is not possible to easily determine which of these
instances are retry-able errors.

RqlConnectionError is to be used for retry-able connection
and server errors.

A separate exception should be introduced for cases where
the cluster is unwritable due to loss of the primary shard.