### PR TITLE
page_cache: fix unused parameter build error

### DIFF
--- a/src/buffer_cache/alt/page_cache.cc
+++ b/src/buffer_cache/alt/page_cache.cc
@@ -848,6 +848,7 @@ page_txn_t::~page_txn_t() {
 }
 
 void page_txn_t::add_acquirer(current_page_acq_t *acq) {
+    (void)acq;
     rassert(acq->access_ == access_t::write);
     ++live_acqs_;
 }


### PR DESCRIPTION
To fix a build error introduced by commit 8fac813("Made live_acqs_
merely be a size_t"):

  src/buffer_cache/alt/page_cache.cc:850:6: error: unused parameter ‘acq’ [-Werror=unused-parameter]
  cc1plus: all warnings being treated as errors
  make[1]: **\* [build/release/obj/buffer_cache/alt/page_cache.o] Error 1

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
