### PR TITLE
run-tests: no hard coded default build_dir

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -90,7 +90,11 @@ absdir () {
 
 # Path to the rethinkdb repository
 root=$(absdir "$(dirname "$0")/..")
-test -z "$build_dir" && build_dir=$root/build/debug
+test -z "$build_dir" && build_dir=$(ls -d $root/build/{release,debug} 2>/dev/null | head -n 1)
+if ! test -d "$build_dir"; then
+    echo "Error: no rethinkdb is build"
+    exit 1
+fi
 build_dir=$(absdir "$build_dir")
 
 # The tests depend on these variables being set


### PR DESCRIPTION
When I just want to run scripts/run-test.sh with "-l" option only
to list all testcase, it stucks there and with the following error:

```
./scripts/run-tests.sh: line 88: cd: /home/yliu/project/rethinkdb/build/debug: No such file or directory
```

Fix it by getting the build dir dynamically and correctly instead
of from a hard coded path.

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
