### PR TITLE
rql_test: remove previous tested database dir before reusing it

### DIFF
--- a/test/rql_test/test_util.py
+++ b/test/rql_test/test_util.py
@@ -127,6 +127,7 @@ class RethinkDBTestServer(object):
 
     def create(self):
         directory = 'run/server_%s/' % self.cpp_port
+        call(['rm', '-rf', directory])
         rdbfile = directory+'rdb'
         call(['mkdir', '-p', directory])
         self.log_file = directory+'server-log.txt'


### PR DESCRIPTION
We will assign a random port to each server, and then use it to
construct a database dir in form of "run/server_${port}".

As we don't use same port number in one run, we met no issues. However,
we never delete those databases, thus we are, of course, in a high
chance that we will use a same dir we used before, which results to a
following error:

```
======================================================================
ERROR: test_repl (__main__.TestConnection)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "connections/connection.py", line 180, in setUp
    r.db_create('test').run(conn)
  File "../../drivers/python/rethinkdb/ast.py", line 108, in run
    return c._start(self, **global_opt_args)
  File "../../drivers/python/rethinkdb/net.py", line 193, in _start
    return self._send_query(query, term, global_opt_args)
  File "../../drivers/python/rethinkdb/net.py", line 300, in _send_query
    self._check_error_response(response, term)
  File "../../drivers/python/rethinkdb/net.py", line 268, in _check_error_response
    raise RqlRuntimeError(message, term, frames)
RqlRuntimeError: Database `test` already exists. in:
r.db_create('test')
^^^^^^^^^^^^^^^^^^^
```

It happens because we _did_ already create "test" database before.

Unconditionally removing a database directory if we are going to use
it again will fix it.

BTW, why it is worth to keep them? Can we just remove them after test?
Or, if you are considering for later check, I guess it's better to
store them at test_result dir, then it will keep the database director
being uniq?

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
