### PR TITLE
test: http_admin: fix wrong pack of ack_expectations[uuid]

### DIFF
--- a/test/common/http_admin.py
+++ b/test/common/http_admin.py
@@ -536,7 +536,7 @@ class ClusterAccess(object):
             aff_dict[self.find_datacenter(datacenter).uuid] = count
         ack_dict = { }
         for datacenter, count in ack_expectations.iteritems():
-            ack_dict[self.find_datacenter(datacenter).uuid] = count
+            ack_dict[self.find_datacenter(datacenter).uuid] = { 'expectation': count }
         if database is None:
             database_uuid = None
         else:


### PR DESCRIPTION
ack_expectations[uuid] needs an object instead of a number.

ack_expectations[uuid] used to need a number before commit 
7b52a05("Fix log, refactorget_durability, fix switch primary"), 
which changed it to accept a object. However that commit forgot
to change it on http_admin.py side, thus introduced following error
while running regress-852 test:

```
Traceback (most recent call last):
  File "$RETHINKDBtest/regression/issue_852.py", line 41, in <module>
    affinities = {dc: 1}, ack_expectations = {dc: 2})
  File "$RETHINKDB/test/common/http_admin.py", line 562, in add_namespace
    info = self.do_query("POST", "/ajax/semilattice/%s_namespaces/new" % protocol, data_to_post)
  File "$RETHINKDB/test/common/http_admin.py", line 349, in do_query
    return self.do_query_specific(host, http_port, method, route, payload)
  File "$RETHINKDB/test/common/http_admin.py", line 361, in do_query_specific
    return json.loads(self.do_query_specific_plaintext(host, http_port, method, route, payload, headers))
  File "$RETHINKDB/test/common/http_admin.py", line 374, in do_query_specific_plaintext
    raise BadServerResponse(response.status, response.reason)
http_admin.BadServerResponse: Server returned error code: 400 Bad Request
```

And you can see following error from rethinkdb log:

```
info: HTTP request throw a schema_mismatch_exc_t with what = Expected object instead got: 2
```

This patch does make the "400 Bad Request" error dispear, but the
testcase still failed due to rethinkdb crash.

Signed-off-by: Liu Aleaxander Aleaxander@gmail.com
