### PR TITLE
Ruby: reconnect() no longer dies when closing the old connection

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -247,7 +247,7 @@ module RethinkDB
       self.noreply_wait() if opts[:noreply_wait]
 
       stop_listener
-      @socket.close if @socket
+      @socket.close rescue nil if @socket
       @socket = TCPSocket.open(@host, @port)
       @waiters = {}
       @opts = {}


### PR DESCRIPTION
@socket.close() may raise "IOError: closed stream" when the connection has
abruptly closed.
