### PR TITLE
Fix order_by on empty sequences.

### DIFF
--- a/src/rdb_protocol/terms/sort.cc
+++ b/src/rdb_protocol/terms/sort.cc
@@ -138,12 +138,12 @@ private:
         counted_t<val_t> index = optarg(env, "index");
         if (seq.has() && seq->is_exhausted()){
             /* Do nothing for empty sequence */
-            if (! index.has()){
+            if (!index.has()) {
                 rcheck(!comparisons.empty(), base_exc_t::GENERIC,
                        "Must specify something to order by.");
             }
         /* Add a sorting to the table if we're doing indexed sorting. */
-        }else if (index.has()) {
+        } else if (index.has()) {
             rcheck(tbl.has(), base_exc_t::GENERIC,
                    "Indexed order_by can only be performed on a TABLE.");
             rcheck(!seq.has(), base_exc_t::GENERIC,


### PR DESCRIPTION
It fixes #2307 but not sure it's ok, test ql-py-polyglot passed though.
