### PR TITLE
Fix for #2461 JS driver lost variable digits

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -456,7 +456,7 @@ class MakeObject extends RDBOp
 
 class Var extends RDBOp
     tt: protoTermType.VAR
-    compose: (args) -> ['var_'+args[0]]
+    compose: (args) -> ['var_'+args]
 
 class JavaScript extends RDBOp
     tt: protoTermType.JAVASCRIPT


### PR DESCRIPTION
It fixes #2461.
JS driver will lost variable digits when args is String.
If args is a single Array, it will be unfolded as String during composing variable name.
I think it is safe but please review it.
