### PR TITLE
Machine name cannot be generated on "rethinkdb create"

### DIFF
--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -891,7 +891,7 @@ options::help_section_t get_machine_options(std::vector<options::option_t> *opti
     options::help_section_t help("Machine name options");
     options_out->push_back(options::option_t(options::names_t("--machine-name", "-n"),
                                              options::OPTIONAL,
-                                             ""));
+                                             get_machine_name()));
     help.add("-n [ --machine-name ] arg",
              "the name for this machine (as will appear in the metadata).  If not"
              " specified, it will be randomly chosen from a short list of names.");
@@ -1275,10 +1275,6 @@ int main_rethinkdb_create(int argc, char *argv[]) {
         base_path_t base_path(get_single_option(opts, "--directory"));
 
         std::string machine_name_str = get_single_option(opts, "--machine-name");
-        if (machine_name_str == "") {
-            machine_name_str = get_machine_name(get_single_int(opts, "--port-offset"));
-        }
-
         name_string_t machine_name;
         if (!machine_name.assign_value(machine_name_str)) {
             fprintf(stderr, "ERROR: machine-name '%s' is invalid.  (%s)\n", machine_name_str.c_str(), name_string_t::valid_char_msg);
@@ -1644,10 +1640,6 @@ int main_rethinkdb_porcelain(int argc, char *argv[]) {
         base_path_t base_path(get_single_option(opts, "--directory"));
 
         std::string machine_name_str = get_single_option(opts, "--machine-name");
-        if (machine_name_str == "") {
-            machine_name_str = get_machine_name(get_single_int(opts, "--port-offset"));
-        }
-
         name_string_t machine_name;
         if (!machine_name.assign_value(machine_name_str)) {
             fprintf(stderr, "ERROR: machine-name '%s' is invalid.  (%s)\n", machine_name_str.c_str(), name_string_t::valid_char_msg);

--- a/src/clustering/administration/main/names.cc
+++ b/src/clustering/administration/main/names.cc
@@ -9,7 +9,9 @@
 #include "utils.hpp"
 #include "clustering/administration/main/names.hpp"
 
-const char* names[] = {
+static const int RAND_SEQ_LEN = 3;
+
+static const char* names[] = {
     "Akasha",
     "Alchemist",
     "Azwraith",
@@ -105,14 +107,13 @@ bool is_invalid_char(char ch) {
     return ! (isalpha(ch) || isdigit(ch) || ch == '_');
 }
 
-std::string get_machine_name(const int port_offset) {
+std::string get_machine_name() {
     char h[64];
 
     h[0] = '\0';
     if (gethostname(h, sizeof(h) - 1) < 0 || strlen(h) == 0) {
         return get_random_machine_name();
     }
-    h[sizeof(h) - 1] = '\0';
 
     std::string sanitized(h);
     std::replace_if(sanitized.begin(), sanitized.end(), is_invalid_char, '_');
@@ -120,13 +121,15 @@ std::string get_machine_name(const int port_offset) {
         sanitized[0] = '_';
     }
 
-    if (port_offset > 0) {
-        std::stringstream ss;
-        ss << port_offset;
-        if (sanitized[sanitized.size() - 1] != '_') {
-            sanitized += '_';
-        }
-        sanitized += ss.str();
+    std::stringstream ss;
+    for (int i=0;i<RAND_SEQ_LEN;i++) {
+        int ch = randint(10 + 26);
+        ss << (char)(ch < 10 ? '0' + ch : 'a' + ch - 10);
     }
+    if (sanitized[sanitized.size() - 1] != '_') {
+        sanitized += '_';
+    }
+    sanitized += ss.str();
+
     return sanitized;
 }

--- a/src/clustering/administration/main/names.hpp
+++ b/src/clustering/administration/main/names.hpp
@@ -5,6 +5,6 @@
 #include <set>
 #include <string>
 
-std::string get_machine_name(const int port_offset);
+std::string get_machine_name();
 
 #endif // CLUSTERING_ADMINISTRATION_MAIN_NAMES_HPP_


### PR DESCRIPTION
I got an error when running `rethinkdb create`. The problem comes from the new machine name generating code #2548 that is recently merged, which was intended to fix #236. This bug also breaks some of the tests that rely on the cluster creation.

As there's no point in setting `--port-offset` when making a data directory, we cannot utilize a port number for a machine name. So we simply skip the call to `get_single_int()`, and use the default value of `0` from `port_defaults::port_offset`.
