### PR TITLE
Changes footer links to open inside a new tab

### DIFF
--- a/admin/static/handlebars/body.html
+++ b/admin/static/handlebars/body.html
@@ -20,12 +20,12 @@
     <div id="footer">
         <div class="container">
             <ul>
-                <li><a href="http://rethinkdb.com/docs/">Documentation</a></li>
-                <li><a href="http://rethinkdb.com/api/">API</a></li>
-                <li><a href="http://groups.google.com/group/rethinkdb">Google Groups</a></li>
-                <li><a href="irc://chat.freenode.net/#rethinkdb">#rethinkdb on freenode</a></li>
-                <li><a href="https://github.com/rethinkdb/rethinkdb/issues">Github</a></li>
-                <li><a href="http://rethinkdb.com/community/">Community</a></li>
+                <li><a target="_blank" href="http://rethinkdb.com/docs/">Documentation</a></li>
+                <li><a target="_blank" href="http://rethinkdb.com/api/">API</a></li>
+                <li><a target="_blank" href="http://groups.google.com/group/rethinkdb">Google Groups</a></li>
+                <li><a target="_blank" href="irc://chat.freenode.net/#rethinkdb">#rethinkdb on freenode</a></li>
+                <li><a target="_blank" href="https://github.com/rethinkdb/rethinkdb/issues">Github</a></li>
+                <li><a target="_blank" href="http://rethinkdb.com/community/">Community</a></li>
                 {{!
                         We use an invisible span with no content to preload the monospace font for the data explorer:
                         This ensures that data explorer suggestions won't be delayed while loading the font.


### PR DESCRIPTION
This pull request simply modifies the footer links so that they will open up in a new tab when clicked. This can sometimes be important, especially if you're writing (for example) a long query, then click away to IRC to ask for help - and lose all your progress on the query.

Great database :+1: 
