### PR TITLE
Update release notes for 1.14

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -10,6 +10,8 @@ The highlights of this release are:
 
 ## Compatibility ##
 
+### Backwards-compatible changes ###
+
 Data files from RethinkDB versions 1.13.0 onward will be automatically
 migrated to version 1.14.x. As with any major release, back up your data files
 before performing the upgrade. If you are upgrading from a release earlier
@@ -17,19 +19,26 @@ than 1.13.0, follow the migration instructions before upgrading:
 
 http://rethinkdb.com/docs/migration/
 
-Secondary indexes now use a new format. Old indexes will continue to work, but
+Secondary indexes now use a new format; old indexes will continue to work, but
 you should rebuild indexes after upgrading to 1.14.x. A warning about outdated
-indexes will be issued on startup. Indexes can be migrated to the new format
-with the `rethinkdb index-rebuild` utility. Consult the troubleshooting
-document for more information.
+indexes will be issued on startup.
+
+Indexes can be migrated to the new format with the `rethinkdb index-rebuild`
+utility. Consult the troubleshooting document for more information:
 
 http://rethinkdb.com/docs/troubleshooting#my-secondary-index-is-outdated
 
+### API-breaking changes ###
+
 The `return_vals` optional argument for `insert`, `delete` and `update` has
-been changed to `return_changes`, and works with all write operations (not
-just single-document writes as previously). The returned object is in a new
-format that is backwards-incompatible with previous versions. Consult the API
-documentation for more information.
+been changed to `return_changes`, and works with all write operations
+(previously, this only worked with single-document writes). The returned
+object is in a new format that is backwards-incompatible with previous
+versions. Consult the API documentation for these commands for details:
+
+http://rethinkdb.com/api/javascript/insert  
+http://rethinkdb.com/api/javascript/delete  
+http://rethinkdb.com/api/javascript/update
 
 The `upsert` optional argument to `insert` has been replaced with `conflict`
 and new allowed values of `error`, `replace` or `update`. This is a
@@ -40,22 +49,22 @@ information.
 
 * Server
   * Return old/new values for multi-row write operations (#1382)
-  * `upsert` replaced with `conflict` argument (#1838)
-  * Binary data type support (#137, #2612, #2931)
-  * `binary_format="raw"` added (#2762)
-  * Secondary indexes can be renamed (#2794)
+  * `upsert` replaced with `conflict` argument for `insert` (#1838)
+  * Added binary data type support via `binary` (#137, #2612, #2931)
+  * `binary_format="raw"` added to `run` (#2762)
+  * Secondary indexes can be renamed with `index_rename` (#2794)
   * Secondary indexes can be duplicated (#2797)
-  * Old secondary indexes logged on startup (#2798)
-  * `r.http` can return binary format (#2806)
+  * Out of date secondary indexes logged on startup (#2798)
+  * `r.http` can return a binary object (#2806)
 * Python driver
-  * Python 3 support (#2502)
-* Data explorer
-  * Support for printing binary types (#2804, #2865)
+  * Added Python 3 support (#2502)
+* Data Explorer
+  * Support for displaying binary types (#2804, #2865)
 
 ## Improvements ##
 
 * Server
-  * Server names default to hostname, not random name (#236, #2548)
+  * Server names now default to the hostname of the machine (#236, #2548)
   * `distinct` is faster and now works on indexes (#1864)
   * Improve secondary index queue handling (#1947)
   * The array limit is now configurable (#2059)
@@ -68,55 +77,56 @@ information.
   * Table names in the CLI are disambiguated (#2360, #2550)
 * Python driver
   * Cleanup unneeded files (#2610)
-  * Examples made PEP8 compliant (#2534, #2548)
+  * Documentation examples are now PEP8 compliant (#2534)
 * Testing
   * Polyglot targets for Ruby 1.8, 1.9, 2.0, 2.1 (#773)
-  * Can test multiple Python versions simultaneously
+  * Multiple versions of Python can be tested simultaneously
 * Web UI
-  * Add button to rebuild secondary indexes (#2799)
+  * Added a notification and helpful message for out-of-date secondary indexes
+    (#2799)
 
 ## Fixed bugs ##
 
 * Server
-  * --runuser/rungroup work as expected with create (#1722)
-  * Write acks improved (#2039)
-  * fix getaddrinfo error handling (#2110)
+  * `--runuser` and `--rungroup` set proper permissions when used with
+    `rethinkdb create` (#1722)
+  * Improved behavior and error messages for write acks (#2039)
+  * Fix `getaddrinfo` error handling (#2110)
   * Fix a bug with machine name generation (#2552, #2569)
-  * Fix a bug compiling on gcc 4.7.2 (#2572)
+  * Fix a bug when compiling on GCC 4.7.2 (#2572)
   * Fix memory corruption error (#2589)
   * Fix stream cache error (#2607)
   * Fix linking issue with RE2 (#2685)
   * Miscellaneous build fixes (#2666, #2827)
   * Fix rare conflict bug in cluster config (#2738)
   * Fix variable initialization error (#2741)
-  * Fix bug in RPCSemilatticeTest.MetadataExchange (#2758)
+  * Fix bug in `RPCSemilatticeTest.MetadataExchange` (#2758)
   * Changefeeds work on multiple joined servers (#2761)
   * Secondary index functions ignore global optargs (#2767)
   * Secondary indexes sort correctly (#2774, #2789)
   * Fix crashing bug with undefined ordering (#2777)
   * Fix dependency includes in Makefile (#2779)
-  * Convert query_params to a map (#2812)
-  * Convert header_lines into a map (#2818)
+  * Convert `query_params` to a `map` (#2812)
+  * Convert `header_lines` into a `map` (#2818)
   * Improve robustness with big documents (#2832)
   * Wipe out old secondary index tree when post-constructing (#2925)
 * ReQL
   * Fix a bug in `delete_at` (#2696)
-  * insert/splice now check array size limit (#2697)
+  * `insert` and `splice` now check array size limit (#2697)
   * Fix error in undocumented `batch_conf` option (#2709)
 * Web UI
-  * Make interval notation for infinity pedantically correct (#2081, #2635)
-  * Data Explorer keeps current query on disconnects (#2460)
-  * Fix to text typeahead (#2593)
+  * Improve interval notation for shard boundaries (#2081, #2635)
+  * The Data Explorer now remembers the current query on disconnects (#2460)
+  * The Data Explorer now hides overflowing text in its popup containers
+    (#2593)
 * Testing
-  * Chain callbacks in JS http tests (#2396)
-  * Create fewer zombies (#2583)
-  * Misc. testing improvements (#2760, #2788, #2795)
-  * Fix hard-coding of directory paths in Ruby test script (#2787)
+  * Miscellaneous testing improvements (#2396, #2583, #2760, #2787, #2788,
+    #2795)
   * Update testing scripts for drivers (#2815)
 * Python driver
   * Make `all` and `any` behave like `and_` and `or_` (#2659)
   * Use `os.path.splitext` to check file extensions (#2681)
-* Javascript driver
+* JavaScript driver
   * Return errors rather than throw them (#2852, #2883)
 
 ## Contributors ##
@@ -135,7 +145,7 @@ us ship RethinkDB 1.14. In no particular order:
 * Juuso Haavisto (@9uuso)
 * Nick Verlinde (@npiv)
 * Ayman Mackouly (@1N50MN14)
-* @grandquista
+* Adam Grandquist (@grandquista)
 
 --
 


### PR DESCRIPTION
Pinging @larkost and really everyone else. This is almost entirely from the closed tickets on the 1.14 milestone excluding bugs that seemed like they never made it into releases, but there are likely things missed and/or things that should be excluded. I tried to mention the bits of backward incompatibility in the "Compatibility" block.
