### PR TITLE
Fix uninitialised variable warning

### DIFF
--- a/src/rdb_protocol/geo/karney/geodesic.cc
+++ b/src/rdb_protocol/geo/karney/geodesic.cc
@@ -768,8 +768,8 @@ real geod_geninverse(const struct geod_geodesic* g,
       for (tripn = FALSE, tripb = FALSE; numit < maxit2; ++numit) {
         /* the WGS84 test set: mean = 1.47, sd = 1.25, max = 16
          * WGS84 and random input: mean = 2.85, sd = 0.60 */
-        real dv,
-          v = (Lambda12(g, sbet1, cbet1, dn1, sbet2, cbet2, dn2, salp1, calp1,
+        real dv = 0;
+        real v = (Lambda12(g, sbet1, cbet1, dn1, sbet2, cbet2, dn2, salp1, calp1,
                         &salp2, &calp2, &sig12, &ssig1, &csig1, &ssig2, &csig2,
                         &eps, &omg12, numit < maxit1, &dv, C1a, C2a, C3a)
                - lam12);


### PR DESCRIPTION
```
[87/375] CC build/release/obj/rdb_protocol/geo/karney/geodesic.o
src/rdb_protocol/geo/karney/geodesic.cc: In function ?real geod_geninverse(const geod_geodesic*, real,
real, real, real, real*, real*, real*, real*, real*, real*, real*)?: src/rdb_protocol/geo/karney/geodesic.cc:784:28:
error: 'dv' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         if (numit < maxit1 && dv > 0) {
                            ^
cc1plus: all warnings being treated as errors
src/build.mk:379: recipe for target 'build/release/obj/rdb_protocol/geo/karney/geodesic.o' failed
make[1]: *** [build/release/obj/rdb_protocol/geo/karney/geodesic.o] Error 1
make[1]: *** Waiting for unfinished jobs....
Makefile:52: recipe for target 'make' failed
make: *** [make] Error 2
```

```
sathya@sathya:~/code/rethinkdb$ clang -v 
Debian clang version 3.4.2-8 (tags/RELEASE_34/dot2-final) (based on LLVM 3.4.2)
```
