### PR TITLE
Reuse `timeout` and `authKey` when reconnecting JS.

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -233,7 +233,8 @@ class Connection extends events.EventEmitter
             closeCb = (err) =>
                 @rawSocket.removeAllListeners()
                 @rawSocket = null # The rawSocket has been closed
-                @constructor.call @, {host:@host, port:@port}, (err, conn) ->
+                @constructor.call @, {host:@host, port:@port
+                                      timeout:@timeout, authKey:@authKey}, (err, conn) ->
                     if err?
                         reject err
                     else


### PR DESCRIPTION
This looks like a test case should exist for all drivers. Python and Ruby already have this feature. If I need to provide a test then just say so.
