### PR TITLE
Allow the Python driver to accept any iterable or mapping to `r.expr`.

### DIFF
--- a/drivers/python/rethinkdb/ast.py
+++ b/drivers/python/rethinkdb/ast.py
@@ -57,7 +57,7 @@ def expr(val, nesting_depth=20):
         return ISO8601(val.isoformat())
     elif isinstance(val, RqlBinary):
         return Binary(val)
-    elif isinstance(val, str):
+    elif isinstance(val, (str, unicode)):
         return Datum(val)
     elif isinstance(val, bytes):
         return Binary(val)


### PR DESCRIPTION
Most of my use for this would be passing `tuples` to the driver without having to run nested `list` casting.
