### PR TITLE
Encode connection authorization key once.

### DIFF
--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -123,7 +123,7 @@ class Connection(object):
         self.host = host
         self.next_token = 1
         self.db = db
-        self.auth_key = self.auth_key.encode('ascii')
+        self.auth_key = auth_key.encode('ascii')
         self.timeout = timeout
         self.cursor_cache = { }
 


### PR DESCRIPTION
#2952 and the EPIPE fix got rolled back somewhere, and are missing both `next` and `v1.15.x`.
