### PR TITLE
node: use semver correctly

### DIFF
--- a/drivers/javascript/package.json
+++ b/drivers/javascript/package.json
@@ -14,5 +14,5 @@
     , "url" : "http://github.com/rethinkdb/rethinkdb.git"
     }
 , "engines" : { "node": ">= 0.10.0" }
-, "dependencies" : { "bluebird": ">= 2.3.2" }
+, "dependencies" : { "bluebird": "^2.3.2" }
 }


### PR DESCRIPTION
If bluebird releases a version 3, then a breaking change was introduced, and there's a good chance your entire driver could break. Luckily, the maintainer of bluebird is actually good so I doubt this would actually happen.