### PR TITLE
javscript: Emit connection error

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -399,7 +399,7 @@ class TcpConnection extends Connection
         @rawSocket.on 'error', (args...) =>
             if @isOpen()
                 @close({noreplyWait:false})
-            @emit 'close'
+            @emit 'error', new err.RqlDriverError "Could not connect to " + @host + ":" + @port
 
         @rawSocket.on 'close', =>
             if @isOpen()

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -396,10 +396,7 @@ class TcpConnection extends Connection
 
             @rawSocket.on 'data', handshake_callback
 
-        @rawSocket.on 'error', (args...) =>
-            if @isOpen()
-                @close({noreplyWait:false})
-            @emit 'error', new err.RqlDriverError "Could not connect to " + @host + ":" + @port
+        @rawSocket.on 'error', (err) => @emit 'error', err
 
         @rawSocket.on 'close', =>
             if @isOpen()


### PR DESCRIPTION
`timeout` configuration option has no effect in case of connection refused error (server down). Timeout is cleared in `@rawSocket.once` and no error ever emitted. Since `@rawSocket.on "close"` event is called directly after `@rawSocket.on "error"` we can just emit a connection error.