### PR TITLE
Added explore button to each database table row

### DIFF
--- a/admin/static/coffee/tables/index.coffee
+++ b/admin/static/coffee/tables/index.coffee
@@ -281,8 +281,16 @@ module 'TablesView', ->
     class @TableView extends Backbone.View
         className: 'table_container'
         template: Handlebars.templates['table-template']
+
+        events:
+           'click button.explore-table': 'explore_table'
+
         initialize: =>
             @listenTo @model, 'change', @render
+
+        explore_table: =>
+          window.localStorage.current_query = JSON.stringify "r.db('#{@model.get('db')}').table('#{@model.get('name')}')"
+          location.hash = 'dataexplorer'
 
         render: =>
             @$el.html @template
@@ -295,6 +303,7 @@ module 'TablesView', ->
                 replicas: @model.get 'replicas'
                 replicas_ready: @model.get 'replicas_ready'
                 status: @model.get 'status'
+                displayExploreButton: window.hasOwnProperty('localStorage')
             @
 
         remove: =>

--- a/admin/static/handlebars/tables/table-template.handlebars
+++ b/admin/static/handlebars/tables/table-template.handlebars
@@ -1,9 +1,14 @@
 
     <div class="checkbox-container">
-        <input type="checkbox" id="checkbox_table_list_{{id}}" class="checkbox-table"  data-database="{{db_json}}" data-table="{{name_json}}"></input><label for="checkbox_table_list_{{id}}"></label>    
+        <input type="checkbox" id="checkbox_table_list_{{id}}" class="checkbox-table"  data-database="{{db_json}}" data-table="{{name_json}}"></input><label for="checkbox_table_list_{{id}}"></label>
     </div>
     <div class="element-details">
         <p class="name"><a href="#tables/{{id}}">{{name}}</a></p>
+        {{#if displayExploreButton}}
+          <p class="explore">
+            <button class="btn explore-table">Explore</button>
+          </p>
+        {{/if}}
         <p class="quick_info">
             {{shards}} {{pluralize_noun "shard" shards}}, {{replicas}} {{pluralize_noun "replica" replicas}}
         </p>

--- a/admin/static/less/styles.less
+++ b/admin/static/less/styles.less
@@ -1250,7 +1250,7 @@ TODO: retire this
                     margin: 0;
                     font-family: @sans;
                 }
-                .name, .quick_info, .status {
+                .name, .quick_info, .status, .explore {
                     @offset: 8px;
                     padding: 0 @offset * 2;
                     border-left: thin solid #e4e4e4;
@@ -1275,6 +1275,14 @@ TODO: retire this
                     text-overflow: ellipsis;
                     .flex-grow(2);
                 }
+                .explore {
+                  border-left: none;
+
+                  .btn {
+                    opacity: 0;
+                    .transition(~"0.1s opacity ease-out");
+                  }
+                }
                 .quick_info {
                     .with-icon('images/graph-icon.png');
                     color: #626264;
@@ -1292,6 +1300,11 @@ TODO: retire this
                     &.label-partial-success {
                         .with-icon('images/yellow-light_glow.png');
                     }
+                }
+
+
+                &:hover .explore .btn {
+                  opacity: 1;
                 }
             }
         }


### PR DESCRIPTION
My quick attempt at completing issue #3856 and #3509. 

![screen shot 2015-03-02 at 2 56 20 pm](https://cloud.githubusercontent.com/assets/46142/6435207/59ee0952-c0ec-11e4-9d93-4f4e9c5b2f6c.png)

Each row gets a new 'Explore' button, visible only on row hover (to avoid the clutter of lots of repeating buttons).
Clicking the button navigates to the data explorer, profiled in with the query `r.db('databaseName').table('tableName')`

I wasn't sure of the best way to do this, so I went for the simplest approach:

``` coffee
explore_table: =>
  window.localStorage.current_query = JSON.stringify "r.db('#{@model.get('db')}').table('#{@model.get('name')}')"
  location.hash = 'dataexplorer'
```

Because it relies on localStorage to refill in the command, the button is only displayed in browsers that support localStorage.

Thoughts?
