### PR TITLE
fix `__builtins__` field access

### DIFF
--- a/drivers/python/rethinkdb/__init__.py
+++ b/drivers/python/rethinkdb/__init__.py
@@ -6,7 +6,7 @@ from .errors import *
 from .ast import *
 from . import docs
 
-class r(__builtins__['object']): # defends against re-importing obscuring object
+class r(__builtins__.object): # defends against re-importing obscuring object
     pass
 
 for module in (net, query, ast, errors):


### PR DESCRIPTION
Fields from `__builtins__` should be accessed using a field syntax (`a.b`). 
The `__builtins__['some_field']` syntax is CPython related and not supported by PyPy. The standard way to do it is  `__builtins__.some_field` - this works with CPython, PyPy and other Python implementations.