### PR TITLE
config options with keys as String

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -141,9 +141,10 @@ module RethinkDB
         @abort_module = Faux_Abort
       end
 
+      opts = Hash[opts.map{|(k,v)| [k.to_sym,v]}] if opts.is_a?(Hash)
       opts = {:host => opts} if opts.is_a?(String)
       @host = opts[:host] || "localhost"
-      @port = opts[:port] || 28015
+      @port = opts[:port].to_i || 28015
       @default_db = opts[:db]
       @auth_key = opts[:auth_key] || ""
 


### PR DESCRIPTION
Currently it does not work in this case
```ruby
r.connect('host' => 'localhost', 'port' => 28015)
```
because keys of config are String.
I suggest to convert the keys to Symbol.

It useful for case if connection config is located in yaml file, for example
```ruby
r.connect YAML.load_file('config/database.yml')
```

and `config/database.yml` is

```yaml
  db: 'test'
  host: '127.0.0.1'
  port: 28015
```