### PR TITLE
Avoid self where not required

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -57,7 +57,7 @@ module RethinkDB
       preview = preview_res.pretty_inspect[0...-1]
       state = @run ? "(exhausted)" : "(enumerable)"
       extra = out_of_date ? " (Connection #{@conn.inspect} is closed.)" : ""
-      "#<RethinkDB::Cursor:#{self.object_id} #{state}#{extra}: #{RPP.pp(@msg)}" +
+      "#<RethinkDB::Cursor:#{object_id} #{state}#{extra}: #{RPP.pp(@msg)}" +
         (@run ? "" : "\n#{preview}") + ">"
     end
 
@@ -75,7 +75,7 @@ module RethinkDB
 
     def each(&block) # :nodoc:
       raise RqlRuntimeError, "Can only iterate over a cursor once." if @run
-      return self.enum_for(:each) if !block
+      return enum_for(:each) if !block
       @run = true
       while true
         @results.each(&block)
@@ -154,7 +154,7 @@ module RethinkDB
       @token_cnt = 0
       @token_cnt_mutex = Mutex.new
 
-      self.connect()
+      connect()
     end
     attr_reader :host, :port, :default_db, :conn_id
 
@@ -178,8 +178,8 @@ module RethinkDB
       opts[:noreply] ? nil : wait(token, nil)
     end
     def run(msg, opts, &b)
-      reconnect(:noreply_wait => false) if @auto_reconnect && !self.is_open()
-      raise RqlRuntimeError, "Connection is closed." if !self.is_open()
+      reconnect(:noreply_wait => false) if @auto_reconnect && !is_open()
+      raise RqlRuntimeError, "Connection is closed." if !is_open()
 
       global_optargs = {}
       all_opts = @default_opts.merge(opts)
@@ -259,7 +259,7 @@ module RethinkDB
           end
           @waiters.delete(token)
         }
-        raise RqlRuntimeError, "Connection is closed." if res.nil? && !self.is_open()
+        raise RqlRuntimeError, "Connection is closed." if res.nil? && !is_open()
         raise RqlDriverError, "Internal driver error, no response found." if res.nil?
         return res
       rescue @abort_module::Abort => e
@@ -278,8 +278,8 @@ module RethinkDB
     def inspect
       db = @default_opts[:db] || RQL.new.db('test')
       properties = "(#{@host}:#{@port}) (Default DB: #{db.inspect})"
-      state = self.is_open() ? "(open)" : "(closed)"
-      "#<RethinkDB::Connection:#{self.object_id} #{properties} #{state}>"
+      state = is_open() ? "(open)" : "(closed)"
+      "#<RethinkDB::Connection:#{object_id} #{properties} #{state}>"
     end
 
     @@last = nil
@@ -293,8 +293,8 @@ module RethinkDB
     # enumerables on the client.
     def reconnect(opts={})
       raise ArgumentError, "Argument to reconnect must be a hash." if opts.class != Hash
-      self.close(opts)
-      self.connect()
+      close(opts)
+      connect()
     end
 
     def connect()
@@ -321,7 +321,7 @@ module RethinkDB
       end
       opts[:noreply_wait] = true if !opts.keys.include?(:noreply_wait)
 
-      self.noreply_wait() if opts[:noreply_wait] && self.is_open()
+      noreply_wait() if opts[:noreply_wait] && is_open()
       if @listener
         @listener.terminate
         @listener.join
@@ -339,7 +339,7 @@ module RethinkDB
     end
 
     def noreply_wait
-      raise RqlRuntimeError, "Connection is closed." if !self.is_open()
+      raise RqlRuntimeError, "Connection is closed." if !is_open()
       q = [Query::QueryType::NOREPLY_WAIT]
       res = run_internal(q, {noreply: false}, new_token)
       if res['t'] != Response::ResponseType::WAIT_COMPLETE


### PR DESCRIPTION
`self` is only required when calling a self write accessor [link](https://github.com/bbatsov/ruby-style-guide#no-self-unless-required)