### PR TITLE
Add mention of arrayLimit option and indexing to error message

### DIFF
--- a/src/rdb_protocol/error.hpp
+++ b/src/rdb_protocol/error.hpp
@@ -119,13 +119,13 @@ private:
 #define rcheck_array_size_datum(arr, limit, type) do {                  \
         auto _limit = (limit);                                          \
         rcheck_datum((arr).size() <= _limit.array_size_limit(), (type),  \
-                     strprintf("Array over size limit `%zu`.",          \
+                     strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",          \
                                _limit.array_size_limit()).c_str());     \
     } while (0)
 #define rcheck_array_size(arr, limit, type) do {                        \
         auto _limit = (limit);                                          \
         rcheck((arr).size() <= _limit.array_size_limit(), type,          \
-               strprintf("Array over size limit `%zu`.",                \
+               strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",                \
                          _limit.array_size_limit()).c_str());           \
     } while (0)
 #define rcheck(pred, type, msg) rcheck_target(this, pred, type, msg)

--- a/src/rdb_protocol/error.hpp
+++ b/src/rdb_protocol/error.hpp
@@ -119,13 +119,17 @@ private:
 #define rcheck_array_size_datum(arr, limit, type) do {                  \
         auto _limit = (limit);                                          \
         rcheck_datum((arr).size() <= _limit.array_size_limit(), (type),  \
-                     strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",          \
+                     strprintf("Array over size limit `%zu`. \
+                                To change the number of allowed elements, \
+                                modify the 'arrayLimit' option, or use an index.", \
                                _limit.array_size_limit()).c_str());     \
     } while (0)
 #define rcheck_array_size(arr, limit, type) do {                        \
         auto _limit = (limit);                                          \
         rcheck((arr).size() <= _limit.array_size_limit(), type,          \
-               strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",                \
+               strprintf("Array over size limit `%zu`. \
+                          To change the number of allowed elements, \
+                          modify the 'arrayLimit' option, or use an index.", \
                          _limit.array_size_limit()).c_str());           \
     } while (0)
 #define rcheck(pred, type, msg) rcheck_target(this, pred, type, msg)

--- a/src/rdb_protocol/error.hpp
+++ b/src/rdb_protocol/error.hpp
@@ -119,13 +119,13 @@ private:
 #define rcheck_array_size_datum(arr, limit, type) do {                  \
         auto _limit = (limit);                                          \
         rcheck_datum((arr).size() <= _limit.array_size_limit(), (type),  \
-                     strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",          \
+                     strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",          \
                                _limit.array_size_limit()).c_str());     \
     } while (0)
 #define rcheck_array_size(arr, limit, type) do {                        \
         auto _limit = (limit);                                          \
         rcheck((arr).size() <= _limit.array_size_limit(), type,          \
-               strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",                \
+               strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",                \
                          _limit.array_size_limit()).c_str());           \
     } while (0)
 #define rcheck(pred, type, msg) rcheck_target(this, pred, type, msg)

--- a/src/rdb_protocol/shards.cc
+++ b/src/rdb_protocol/shards.cc
@@ -331,7 +331,7 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the arrayLimit option, or use an index.",
+                    strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the arrayLimit option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
             lst1->reserve(lst1->size() + lst2->size());
@@ -361,7 +361,7 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",
+                    strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
 

--- a/src/rdb_protocol/shards.cc
+++ b/src/rdb_protocol/shards.cc
@@ -331,7 +331,7 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`.",
+                    strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the arrayLimit option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
             lst1->reserve(lst1->size() + lst2->size());
@@ -361,7 +361,7 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`.",
+                    strprintf("Array over size limit `%zu`. To change the number of allowed documents, modify the 'arrayLimit' option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
 

--- a/src/rdb_protocol/shards.cc
+++ b/src/rdb_protocol/shards.cc
@@ -331,7 +331,9 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the arrayLimit option, or use an index.",
+                    strprintf("Array over size limit `%zu`. \
+                              To change the number of allowed elements, \
+                              modify the arrayLimit option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
             lst1->reserve(lst1->size() + lst2->size());
@@ -361,7 +363,9 @@ private:
             } else {
                 rcheck_toplevel(
                     size <= env->limits().array_size_limit(), base_exc_t::GENERIC,
-                    strprintf("Array over size limit `%zu`. To change the number of allowed elements, modify the 'arrayLimit' option, or use an index.",
+                    strprintf("Array over size limit `%zu`. \
+                              To change the number of allowed elements, \
+                              modify the 'arrayLimit' option, or use an index.",
                               env->limits().array_size_limit()).c_str());
             }
 


### PR DESCRIPTION
Minimal fix to issue #3061 , Just added a message mentioning arrayLimit option and using an index. 