### PR TITLE
Fixes #4037

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -327,7 +327,7 @@ class RDBVal extends TermBase
             new IndexCreate opts, @, name, funcWrap(defun_or_opts)
         else if defun_or_opts?
             # FIXME?
-            if (Object::toString.call(defun_or_opts) is '[object Object]') and not (defun_or_opts instanceof Function) and not (defun_or_opts instanceof TermBase)
+            if (Object::toString.call(defun_or_opts) is '[object Object]') and not (typeof defun_or_opts is 'function') and not (defun_or_opts instanceof TermBase)
                 new IndexCreate defun_or_opts, @, name
             else
                 new IndexCreate {}, @, name, funcWrap(defun_or_opts)
@@ -1185,7 +1185,7 @@ rethinkdb.expr = varar 1, 2, (val, nestingDepth=20) ->
 
     else if val instanceof TermBase
         val
-    else if val instanceof Function
+    else if typeof val is 'function'
         new Func {}, val
     else if val instanceof Date
         new ISO8601 {}, val.toISOString()

--- a/drivers/javascript/util.coffee
+++ b/drivers/javascript/util.coffee
@@ -101,10 +101,10 @@ convertPseudotype = (obj, opts) ->
             obj
 
 recursivelyConvertPseudotype = (obj, opts) ->
-    if obj instanceof Array
+    if Array.isArray obj
         for value, i in obj
             obj[i] = recursivelyConvertPseudotype(value, opts)
-    else if obj instanceof Object
+    else if obj and typeof obj is 'object'
         for key, value of obj
             obj[key] = recursivelyConvertPseudotype(value, opts)
         obj = convertPseudotype(obj, opts)


### PR DESCRIPTION
In a few spots the JavaScript driver uses `instanceof` to check for array, function, and object types. As `instanceof` looks at the variable's prototype to find the appropriate constructor, this is a problem when checking a variable that was instantiated in a different JavaScript context, such as an iframe, or in this case the Node Webkit window context. See [Differences of JavaScript contexts](https://github.com/nwjs/nw.js/wiki/Differences-of-JavaScript-contexts).

Using `typeof` (or `Array.isArray` for arrays) is robust to cross-context type checking.

This PR changes three `instancesof` type checks to use `typeof` and one to use `Array.isArray`.

I ran the tests like so `/rethinkdb/test/rql_test/test-runner -i js` and they passed.