### PR TITLE
Add asyncio event loop support

### DIFF
--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -539,7 +539,7 @@ connection_type = DefaultConnection
 def connect(host='localhost', port=28015, db=None, auth_key="", timeout=20, **kwargs):
     global connection_type
     conn = connection_type(host, port, db, auth_key, timeout, **kwargs)
-    return conn.reconnect(timeout)
+    return conn.reconnect(timeout=timeout)
 
 def set_loop_type(library):
     global connection_type

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -1,0 +1,226 @@
+# Copyright 2015 RethinkDB, all rights reserved.
+
+import asyncio
+import socket
+import struct
+
+from . import ql2_pb2 as p
+from .net import decodeUTF, Query, Response, Cursor, maybe_profile, convert_pseudo
+from .net import Connection as ConnectionBase
+from .errors import *
+
+__all__ = ['Connection']
+
+pResponse = p.Response.ResponseType
+pQuery = p.Query.QueryType
+
+@asyncio.coroutine
+def _read_until(streamreader, delimiter):
+    """Naive implementation of reading until a delimiter"""
+    buffer = bytearray()
+    while True:
+        c = yield from streamreader.read(1)
+        if c == b'':
+            break  # EOF
+        buffer.append(c[0])
+        if c == delimiter:
+            break
+    return bytes(buffer)
+
+
+# The asyncio implementation of the Cursor object:
+# The `new_response` Future notifies any waiting coroutines that the can attempt
+# to grab the next result.  In addition, the waiting coroutine will schedule a
+# timeout at the given deadline (if provided), at which point the future will be
+# errored.
+class AsyncioCursor(Cursor):
+    def __init__(self, *args, **kwargs):
+        Cursor.__init__(self, *args, **kwargs)
+        self.new_response = asyncio.Future()
+
+    def _extend(self, res):
+        Cursor._extend(self, res)
+        self.new_response.set_result(True)
+        self.new_response = asyncio.Future()
+
+    # Convenience function so users know when they've hit the end of the cursor
+    # without having to catch an exception
+    @asyncio.coroutine
+    def fetch_next(self, wait=True):
+        timeout = Cursor._wait_to_timeout(wait)
+        while len(self.items) == 0 and self.error is None:
+            self._maybe_fetch_batch()
+            yield from asyncio.wait_for(self.new_response, timeout)
+        # If there is a (non-empty) error to be received, we return True, so the
+        # user will receive it on the next `next` call.
+        return len(self.items) != 0 or not isinstance(self.error, RqlCursorEmpty)
+
+    def _empty_error(self):
+        # We do not have RqlCursorEmpty inherit from StopIteration as that interferes
+        # with Tornado's gen.coroutine and is the equivalent of gen.Return(None).
+        return RqlCursorEmpty(self.query.term)
+
+    @asyncio.coroutine
+    def _get_next(self, timeout):
+        while len(self.items) == 0:
+            self._maybe_fetch_batch()
+            if self.error is not None:
+                raise self.error
+            yield from asyncio.wait_for(self.new_response, timeout)
+        return convert_pseudo(self.items.pop(0), self.query)
+
+    def _maybe_fetch_batch(self):
+        if self.error is None and \
+           len(self.items) <= self.threshold and \
+           self.outstanding_requests == 0:
+            self.outstanding_requests += 1
+            asyncio.async(self.conn._parent._continue(self))
+
+
+class ConnectionInstance(object):
+    _streamreader = None
+    _streamwriter = None
+
+    def __init__(self, parent, io_loop=None):
+        self._parent = parent
+        self._closing = False
+        self._user_queries = { }
+        self._cursor_cache = { }
+        self._ready = asyncio.Future()
+        self._io_loop = io_loop
+        if self._io_loop is None:
+            self._io_loop = asyncio.get_event_loop()
+
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+    @asyncio.coroutine
+    def connect(self, timeout):
+        try:
+            self._socket.connect((self._parent.host, self._parent.port))
+        except Exception as err:
+            raise RqlDriverError('Could not connect to %s:%s. Error: %s' %
+                    (self._parent.host, self._parent.port, str(err)))
+
+        self._streamreader, self._streamwriter = yield from \
+            asyncio.open_connection(sock=self._socket, loop=self._io_loop)
+
+        try:
+            self._streamwriter.write(self._parent.handshake)
+            response = yield from asyncio.wait_for(
+                _read_until(self._streamreader, b'\0'),
+                timeout, loop=self._io_loop,
+            )
+        except Exception as err:
+            raise RqlDriverError(
+                'Connection interrupted during handshake with %s:%s. Error: %s' %
+                    (self._parent.host, self._parent.port, str(err)))
+
+        message = decodeUTF(response[:-1]).split('\n')[0]
+
+        if message != 'SUCCESS':
+            self.close(False, None)
+            raise RqlDriverError('Server dropped connection with message: "%s"' %
+                               message)
+
+        # Start a parallel function to perform reads
+        #  store a reference to it so it doesn't get destroyed
+        self._reader_task = asyncio.async(self._reader(), loop=self._io_loop)
+        return self._parent
+
+    def is_open(self):
+        return not self._closing
+
+    @asyncio.coroutine
+    def close(self, noreply_wait, token, exception=None):
+        self._closing = True
+        if exception is not None:
+            err_message = "Connection is closed (%s)." + str(exception)
+        else:
+            err_message = "Connection is closed."
+
+        # Cursors may remove themselves when errored, so copy a list of them
+        for cursor in list(self._cursor_cache.values()):
+            cursor._error(err_message)
+
+        for query, future in iter(self._user_queries.values()):
+            future.set_exception(RqlDriverError(err_message))
+
+        self._user_queries = { }
+        self._cursor_cache = { }
+
+        if noreply_wait:
+            noreply = Query(pQuery.NOREPLY_WAIT, token, None, None)
+            yield from self.run_query(noreply, False)
+
+        self._streamwriter.close()
+        return None
+
+    @asyncio.coroutine
+    def run_query(self, query, noreply):
+        self._streamwriter.write(query.serialize())
+        if noreply:
+            return None
+
+        response_future = asyncio.Future()
+        self._user_queries[query.token] = (query, response_future)
+        return (yield from response_future)
+
+    # The _reader coroutine runs in parallel, reading responses
+    # off of the socket and forwarding them to the appropriate Future or Cursor.
+    # This is shut down as a consequence of closing the stream, or an error in the
+    # socket/protocol from the server.  Unexpected errors in this coroutine will
+    # close the ConnectionInstance and be passed to any open Futures or Cursors.
+    @asyncio.coroutine
+    def _reader(self):
+        try:
+            while True:
+                buf = yield from self._streamreader.read(12)
+                (token, length,) = struct.unpack("<qL", buf)
+                buf = yield from self._streamreader.read(length)
+                res = Response(token, buf)
+
+                cursor = self._cursor_cache.get(token)
+                if cursor is not None:
+                    cursor._extend(res)
+                elif token in self._user_queries:
+                    # Do not pop the query from the dict until later, so
+                    # we don't lose track of it in case of an exception
+                    query, future = self._user_queries[token]
+                    if res.type == pResponse.SUCCESS_ATOM:
+                        value = convert_pseudo(res.data[0], query)
+                        future.set_result(maybe_profile(value, res))
+                    elif res.type in (pResponse.SUCCESS_SEQUENCE,
+                                      pResponse.SUCCESS_PARTIAL):
+                        cursor = AsyncioCursor(self, query)
+                        self._cursor_cache[token] = cursor
+                        cursor._extend(res)
+                        future.set_result(maybe_profile(cursor, res))
+                    elif res.type == pResponse.WAIT_COMPLETE:
+                        future.set_result(None)
+                    else:
+                        future.set_exception(res.make_error(query))
+                    del self._user_queries[token]
+                elif not self._closing:
+                    raise RqlDriverError("Unexpected response received.")
+        except Exception as ex:
+            if not self._closing:
+                self.close(False, None, ex)
+
+
+class Connection(ConnectionBase):
+    def __init__(self, *args, **kwargs):
+        ConnectionBase.__init__(self, ConnectionInstance, *args, **kwargs)
+
+    @asyncio.coroutine
+    def reconnect(self, noreply_wait=True, timeout=None):
+        # We close before reconnect so reconnect doesn't try to close us
+        # and then fail to return the Future (this is a little awkward).
+        yield from self.close(noreply_wait)
+        return (yield from ConnectionBase.reconnect(self, noreply_wait, timeout))
+
+    @asyncio.coroutine
+    def close(self, *args, **kwargs):
+        if self._instance is None:
+            return None
+        return (yield from ConnectionBase.close(self, *args, **kwargs))

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -66,7 +66,7 @@ class AsyncioCursor(Cursor):
 
     def _empty_error(self):
         # We do not have RqlCursorEmpty inherit from StopIteration as that interferes
-        # with Tornado's gen.coroutine and is the equivalent of gen.Return(None).
+        # with mechanisms to return from a coroutine.
         return RqlCursorEmpty(self.query.term)
 
     @asyncio.coroutine

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -211,9 +211,9 @@ class ConnectionInstance(object):
     def _reader(self):
         try:
             while True:
-                buf = yield from self._streamreader.read(12)
+                buf = yield from self._streamreader.readexactly(12)
                 (token, length,) = struct.unpack("<qL", buf)
-                buf = yield from self._streamreader.read(length)
+                buf = yield from self._streamreader.readexactly(length)
                 res = Response(token, buf)
 
                 cursor = self._cursor_cache.get(token)
@@ -241,7 +241,7 @@ class ConnectionInstance(object):
                     raise RqlDriverError("Unexpected response received.")
         except Exception as ex:
             if not self._closing:
-                self.close(False, None, ex)
+                yield from self.close(False, None, ex)
 
 
 class Connection(ConnectionBase):

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -84,6 +84,7 @@ class AsyncioCursor(Cursor):
            len(self.items) <= self.threshold and \
            self.outstanding_requests == 0:
             self.outstanding_requests += 1
+            asyncio.async(self.conn._parent._continue(self))
 
 
 class ConnectionInstance(object):

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -165,7 +165,7 @@ class ConnectionInstance(object):
         return self._parent
 
     def is_open(self):
-        return not self._closing
+        return not (self._closing or self._streamreader.at_eof())
 
     @asyncio.coroutine
     def close(self, noreply_wait, token, exception=None):

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -85,7 +85,7 @@ class AsyncioCursor(Cursor):
         while len(self.items) == 0 and self.error is None:
             self._maybe_fetch_batch()
             with translate_timeout_errors():
-                yield from waiter(self.new_response)
+                yield from waiter(asyncio.shield(self.new_response))
         # If there is a (non-empty) error to be received, we return True, so the
         # user will receive it on the next `next` call.
         return len(self.items) != 0 or not isinstance(self.error, RqlCursorEmpty)
@@ -103,7 +103,7 @@ class AsyncioCursor(Cursor):
             if self.error is not None:
                 raise self.error
             with translate_timeout_errors():
-                yield from waiter(self.new_response)
+                yield from waiter(asyncio.shield(self.new_response))
         return convert_pseudo(self.items.pop(0), self.query)
 
     def _maybe_fetch_batch(self):

--- a/test/rql_test/connections/asyncio_connection.py
+++ b/test/rql_test/connections/asyncio_connection.py
@@ -1,0 +1,956 @@
+#!/usr/bin/env python
+##
+# Tests the driver API for making connections and excercizes the
+# networking code
+###
+
+from __future__ import print_function
+
+import datetime
+import os
+import random
+import re
+import sys
+import tempfile
+import time
+import traceback
+import unittest
+import socket
+import asyncio
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                os.pardir, os.pardir, "common"))
+import driver
+import utils
+
+try:
+    xrange
+except NameError:
+    xrange = range
+
+# -- import the rethinkdb driver
+
+r = utils.import_python_driver()
+
+# -- use asyncio subdriver
+
+r.set_loop_type("asyncio")
+
+# -- get settings
+
+DEFAULT_DRIVER_PORT = 28015
+
+rethinkdb_exe = (sys.argv[1]
+                 if len(sys.argv) > 1
+                 else utils.find_rethinkdb_executable())
+use_default_port = bool(int(sys.argv[2])) if len(sys.argv) > 2 else 0
+
+# -- shared server
+
+sharedServer = None
+sharedServerOutput = None
+sharedServerHost = None
+sharedServerDriverPort = None
+if 'RDB_DRIVER_PORT' in os.environ:
+    sharedServerDriverPort = int(os.environ['RDB_DRIVER_PORT'])
+    if 'RDB_SERVER_HOST' in os.environ:
+        sharedServerHost = os.environ['RDB_SERVER_HOST']
+    else:
+        sharedServerHost = 'localhost'
+
+
+@asyncio.coroutine
+def checkSharedServer():
+    if sharedServerDriverPort is not None:
+        conn = yield from r.connect(host=sharedServerHost,
+                               port=sharedServerDriverPort)
+        if 'test' not in (yield from r.db_list().run(conn)):
+            yield from r.db_create('test').run(conn)
+
+
+@asyncio.coroutine
+def closeSharedServer():
+    global sharedServer, sharedServerOutput, sharedServerHost, \
+        sharedServerDriverPort
+
+    if sharedServer is not None:
+        try:
+            sharedServer.close()
+        except Exception as e:
+            sys.stderr.write('Got error while shutting down server: %s'
+                             % str(e))
+    sharedServer = None
+    sharedServerOutput = None
+    sharedServerHost = None
+    sharedServerDriverPort = None
+
+
+def just_do(coroutine, *args, **kwargs):
+    asyncio.get_event_loop().run_until_complete(coroutine(*args, **kwargs))
+
+
+# == Test Base Classes
+
+class TestCaseCompatible(unittest.TestCase):
+    # @asyncio.coroutine
+    # def asyncAssertRaisesRegexp(self, exception, regexp, generator):
+    #     try:
+    #         yield from generator
+    #     except Exception as e:
+    #         self.assertTrue(isinstance(e, exception),
+    #                         '%s expected to raise %s but '
+    #                         'instead raised %s: %s\n%s'
+    #                         % (repr(generator), repr(exception),
+    #                            e.__class__.__name__, str(e),
+    #                            traceback.format_exc()))
+    #         self.assertTrue(re.search(regexp, str(e)),
+    #                         '%s did not raise the expected '
+    #                         'message "%s", but rather: %s'
+    #                         % (repr(generator), str(regexp), str(e)))
+    #     else:
+    #         self.fail('%s failed to raise a %s'
+    #                   % (repr(generator), repr(exception)))
+    #
+    # @asyncio.coroutine
+    # def asyncAssertRaises(self, exception, generator):
+    #     try:
+    #         yield from generator
+    #     except Exception as e:
+    #         self.assertTrue(isinstance(e, exception),
+    #                         '%s expected to raise %s but '
+    #                         'instead raised %s: %s\n%s'
+    #                         % (repr(generator), repr(exception),
+    #                            e.__class__.__name__, str(e),
+    #                            traceback.format_exc()))
+    #     else:
+    #         self.fail('%s failed to raise a %s'
+    #                   % (repr(generator), repr(exception)))
+
+    # can't use standard TestCase run here because async.
+    def run(self, result=None):
+        return just_do(self.arun, result)
+
+    @asyncio.coroutine
+    def setUp(self):
+        return None
+
+    @asyncio.coroutine
+    def tearDown(self):
+        return None
+
+    @asyncio.coroutine
+    def arun(self, result=None):
+        if result is None:
+            result = self.defaultTestResult()
+        result.startTest(self)
+        testMethod = getattr(self, self._testMethodName)
+
+        try:
+            try:
+                yield from self.setUp()
+            except KeyboardInterrupt:
+                raise
+            except:
+                result.addError(self, sys.exc_info())
+                return
+
+            ok = False
+            try:
+                yield from testMethod()
+                ok = True
+            except self.failureException:
+                result.addFailure(self, sys.exc_info())
+            except KeyboardInterrupt:
+                raise
+            except:
+                result.addError(self, sys.exc_info())
+
+            try:
+                yield from self.tearDown()
+            except KeyboardInterrupt:
+                raise
+            except:
+                result.addError(self, sys.exc_info())
+                ok = False
+            if ok:
+                result.addSuccess(self)
+        finally:
+            result.stopTest(self)
+
+
+class TestWithConnection(TestCaseCompatible):
+    port = None
+    server = None
+    serverOutput = None
+    ioloop = None
+
+    @asyncio.coroutine
+    def setUp(self):
+        global sharedServer, sharedServerOutput, sharedServerHost, \
+            sharedServerDriverPort
+
+        if sharedServer is not None:
+            try:
+                yield from sharedServer.check()
+            except Exception:
+                # ToDo: figure out how to blame the last test
+                yield from closeSharedServer()
+
+        if sharedServerDriverPort is None:
+            sharedServerOutput = tempfile.NamedTemporaryFile('w+')
+            sharedServer = driver.Process(executable_path=rethinkdb_exe,
+                                          console_output=sharedServerOutput,
+                                          wait_until_ready=True)
+            sharedServerHost = sharedServer.host
+            sharedServerDriverPort = sharedServer.driver_port
+
+        # - insure we are ready
+
+        yield from checkSharedServer()
+
+    @asyncio.coroutine
+    def tearDown(self):
+        global sharedServer, sharedServerOutput, sharedServerHost, \
+            sharedServerDriverPort
+
+        if sharedServerDriverPort is not None:
+            try:
+                yield from checkSharedServer()
+            except Exception:
+                yield from closeSharedServer()
+                raise  # ToDo: figure out how to best give the server log
+
+# == Test Classes
+
+
+class TestNoConnection(TestCaseCompatible):
+    # No servers started yet so this should fail
+    @asyncio.coroutine
+    def test_connect(self):
+        if not use_default_port:
+            return None  # skipTest will not raise in this environment
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                                           "Could not connect to localhost:%d."
+                                           % DEFAULT_DRIVER_PORT):
+            yield from r.connect()
+
+    @asyncio.coroutine
+    def test_connect_port(self):
+        port = utils.get_avalible_port()
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                                           "Could not connect to localhost:%d."
+                                           % port):
+            yield from r.connect(port=port)
+
+    @asyncio.coroutine
+    def test_connect_host(self):
+        if not use_default_port:
+            return None  # skipTest will not raise in this environment
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                                           "Could not connect to 0.0.0.0:%d."
+                                           % DEFAULT_DRIVER_PORT):
+            yield from r.connect(host="0.0.0.0")
+
+    @asyncio.coroutine
+    def test_connect_timeout(self):
+        # Test that we get a ReQL error if we connect to a
+        # non-responsive port
+        useSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        useSocket.bind(('localhost', 0))
+        useSocket.listen(0)
+
+        host, port = useSocket.getsockname()
+
+        try:
+            with self.assertRaisesRegexp(r.RqlDriverError,
+                                               "Connection interrupted during"
+                                               " handshake with %s:%d. "
+                                               "Error: Operation timed out."
+                                               % (host, port)):
+                yield from r.connect(host=host, port=port, timeout=2)
+        finally:
+            useSocket.close()
+
+    @asyncio.coroutine
+    def test_empty_run(self):
+        # Test the error message when we pass nothing to run and
+        # didn't call `repl`
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                                "RqlQuery.run must be given"
+                                " a connection to run on."):
+             r.expr(1).run()
+
+    @asyncio.coroutine
+    def test_auth_key(self):
+        # Test that everything still doesn't work even with an auth key
+        if not use_default_port:
+            return None  # skipTest will not raise in this environment
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                                           'Could not connect to 0.0.0.0:%d."'
+                                           % DEFAULT_DRIVER_PORT):
+            yield from r.connect(host="0.0.0.0", port=DEFAULT_DRIVER_PORT,
+                                 auth_key="hunter2")
+
+
+class TestConnection(TestWithConnection):
+    @asyncio.coroutine
+    def test_connect_close_reconnect(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        yield from r.expr(1).run(c)
+        yield from c.close()
+        yield from c.close()
+        yield from c.reconnect()
+        yield from r.expr(1).run(c)
+
+    @asyncio.coroutine
+    def test_connect_close_expr(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        yield from r.expr(1).run(c)
+        yield from c.close()
+        with self.assertRaisesRegexp(r.RqlDriverError, "Connection is closed."):
+            yield from r.expr(1).run(c)
+
+    @asyncio.coroutine
+    def test_noreply_wait_waits(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        t = time.time()
+        yield from r.js('while(true);', timeout=0.5).run(c, noreply=True)
+        yield from c.noreply_wait()
+        duration = time.time() - t
+        self.assertGreaterEqual(duration, 0.5)
+
+    @asyncio.coroutine
+    def test_close_waits_by_default(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        t = time.time()
+        yield from r.js('while(true);', timeout=0.5).run(c, noreply=True)
+        yield from c.close()
+        duration = time.time() - t
+        self.assertGreaterEqual(duration, 0.5)
+
+    @asyncio.coroutine
+    def test_reconnect_waits_by_default(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        t = time.time()
+        yield from r.js('while(true);', timeout=0.5).run(c, noreply=True)
+        yield from c.reconnect()
+        duration = time.time() - t
+        self.assertGreaterEqual(duration, 0.5)
+
+    @asyncio.coroutine
+    def test_close_does_not_wait_if_requested(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        t = time.time()
+        yield from r.js('while(true);', timeout=0.5).run(c, noreply=True)
+        yield from c.close(noreply_wait=False)
+        duration = time.time() - t
+        self.assertLess(duration, 0.5)
+
+    @asyncio.coroutine
+    def test_reconnect_does_not_wait_if_requested(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        t = time.time()
+        yield from r.js('while(true);', timeout=0.5).run(c, noreply=True)
+        yield from c.reconnect(noreply_wait=False)
+        duration = time.time() - t
+        self.assertLess(duration, 0.5)
+
+    @asyncio.coroutine
+    def test_db(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        if 't1' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('t1').run(c)
+        yield from r.db('test').table_create('t1').run(c)
+
+        if 'db2' in (yield from r.db_list().run(c)):
+            yield from r.db_drop('db2').run(c)
+        yield from r.db_create('db2').run(c)
+
+        if 't2' in (yield from r.db('db2').table_list().run(c)):
+            yield from r.db('db2').table_drop('t2').run(c)
+        yield from r.db('db2').table_create('t2').run(c)
+
+        # Default db should be 'test' so this will work
+        yield from r.table('t1').run(c)
+
+        # Use a new database
+        c.use('db2')
+        yield from r.table('t2').run(c)
+        with self.assertRaisesRegexp(r.RqlRuntimeError,
+                                           "Table `db2.t1` does not exist."):
+            yield from r.table('t1').run(c)
+
+        c.use('test')
+        yield from r.table('t1').run(c)
+        with self.assertRaisesRegexp(r.RqlRuntimeError,
+                                           "Table `test.t2` does not exist."):
+            yield from r.table('t2').run(c)
+
+        yield from c.close()
+
+        # Test setting the db in connect
+        c = yield from r.connect(db='db2', host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        yield from r.table('t2').run(c)
+
+        with self.assertRaisesRegexp(r.RqlRuntimeError,
+                                           "Table `db2.t1` does not exist."):
+            yield from r.table('t1').run(c)
+
+        yield from c.close()
+
+        # Test setting the db as a `run` option
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        yield from r.table('t2').run(c, db='db2')
+
+    @asyncio.coroutine
+    def test_use_outdated(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        if 't1' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('t1').run(c)
+        yield from r.db('test').table_create('t1').run(c)
+
+        # Use outdated is an option that can be passed to db.table or `run`
+        # We're just testing here if the server actually accepts the option.
+
+        yield from r.table('t1', use_outdated=True).run(c)
+        yield from r.table('t1').run(c, use_outdated=True)
+
+    @asyncio.coroutine
+    def test_repl(self):
+        # Calling .repl() should set this connection as global state
+        # to be used when `run` is not otherwise passed a connection.
+        c = (yield from r.connect(host=sharedServerHost,
+                             port=sharedServerDriverPort)).repl()
+
+        yield from r.expr(1).run()
+
+        c.repl()                # is idempotent
+
+        yield from r.expr(1).run()
+
+        yield from c.close()
+
+        with self.assertRaisesRegexp(r.RqlDriverError, "Connection is closed."):
+            yield from r.expr(1).run()
+
+    @asyncio.coroutine
+    def test_port_conversion(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=str(sharedServerDriverPort))
+        yield from r.expr(1).run(c)
+        yield from c.close()
+
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                               "Could not convert port abc to an integer."):
+            yield from r.connect(port='abc', host=sharedServerHost)
+
+
+class TestShutdown(TestWithConnection):
+    @asyncio.coroutine
+    def setUp(self):
+        if sharedServer is None:
+            # we need to be able to kill the server, so can't use one
+            # from outside
+            yield from closeSharedServer()
+        yield from super(TestShutdown, self).setUp()
+
+    @asyncio.coroutine
+    def test_shutdown(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+        yield from r.expr(1).run(c)
+
+        yield from closeSharedServer()
+        yield from asyncio.sleep(0.2)
+
+        with self.assertRaisesRegexp(r.RqlDriverError,
+                               "Connection is closed."):
+            yield from r.expr(1).run(c)
+
+
+# Another non-connection connection test. It's to test that get_intersecting()
+# batching works properly.
+class TestGetIntersectingBatching(TestWithConnection):
+    @asyncio.coroutine
+    def runTest(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        if 't1' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('t1').run(c)
+        yield from r.db('test').table_create('t1').run(c)
+        t1 = r.db('test').table('t1')
+
+        yield from t1.index_create('geo', geo=True).run(c)
+        yield from t1.index_wait('geo').run(c)
+
+        batch_size = 3
+        point_count = 500
+        poly_count = 500
+        get_tries = 10
+
+        # Insert a couple of random points, so we get a well
+        # distributed range of secondary keys. Also insert a couple of
+        # large-ish polygons, so we can test filtering of duplicates
+        # on the server.
+        rseed = random.getrandbits(64)
+        random.seed(rseed)
+        print("Random seed: " + str(rseed), end=' ')
+        sys.stdout.flush()
+
+        points = []
+        for i in xrange(0, point_count):
+            points.append({'geo': r.point(random.uniform(-180.0, 180.0),
+                                          random.uniform(-90.0, 90.0))})
+        polygons = []
+        for i in xrange(0, poly_count):
+            # A fairly big circle, so it will cover a large range in
+            # the secondary index
+            polygons.append({'geo': r.circle([random.uniform(-180.0, 180.0),
+                                              random.uniform(-90.0, 90.0)],
+                                             1000000)})
+        yield from t1.insert(points).run(c)
+        yield from t1.insert(polygons).run(c)
+
+        # Check that the results are actually lazy at least some of
+        # the time While the test is randomized, chances are extremely
+        # high to get a lazy result at least once.
+        seen_lazy = False
+
+        for i in xrange(0, get_tries):
+            query_circle = r.circle([random.uniform(-180.0, 180.0),
+                                     random.uniform(-90.0, 90.0)], 8000000)
+            reference = yield from t1.filter(r.row['geo'].intersects(query_circle))\
+                                .coerce_to("ARRAY").run(c)
+            cursor = yield from t1.get_intersecting(query_circle, index='geo')\
+                             .run(c, max_batch_rows=batch_size)
+            if cursor.error is None:
+                seen_lazy = True
+
+            while len(reference) > 0:
+                row = yield from cursor.next()
+                self.assertEqual(reference.count(row), 1)
+                reference.remove(row)
+            with self.assertRaises(r.RqlCursorEmpty):
+                yield from cursor.next()
+
+        self.assertTrue(seen_lazy)
+
+        yield from r.db('test').table_drop('t1').run(c)
+
+
+class TestBatching(TestWithConnection):
+    @asyncio.coroutine
+    def runTest(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        # Test the cursor API when there is exactly mod batch size
+        # elements in the result stream
+        if 't1' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('t1').run(c)
+        yield from r.db('test').table_create('t1').run(c)
+        t1 = r.table('t1')
+
+        batch_size = 3
+        count = 500
+
+        ids = set(xrange(0, count))
+
+        yield from t1.insert([{'id': i} for i in ids]).run(c)
+        cursor = yield from t1.run(c, max_batch_rows=batch_size)
+
+        for i in xrange(0, count - 1):
+            row = yield from cursor.next()
+            self.assertTrue(row['id'] in ids)
+            ids.remove(row['id'])
+
+        self.assertEqual((yield from cursor.next())['id'], ids.pop())
+        with self.assertRaises(r.RqlCursorEmpty):
+            yield from cursor.next()
+        yield from r.db('test').table_drop('t1').run(c)
+
+
+class TestGroupWithTimeKey(TestWithConnection):
+    @asyncio.coroutine
+    def runTest(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        if 'times' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('times').run(c)
+        yield from r.db('test').table_create('times').run(c)
+
+        time1 = 1375115782.24
+        rt1 = r.epoch_time(time1).in_timezone('+00:00')
+        dt1 = datetime.datetime.fromtimestamp(time1, r.ast.RqlTzinfo('+00:00'))
+        time2 = 1375147296.68
+        rt2 = r.epoch_time(time2).in_timezone('+00:00')
+        dt2 = datetime.datetime.fromtimestamp(time2, r.ast.RqlTzinfo('+00:00'))
+
+        res = yield from r.table('times').insert({'id': 0, 'time': rt1}).run(c)
+        self.assertEqual(res['inserted'], 1)
+        res = yield from r.table('times').insert({'id': 1, 'time': rt2}).run(c)
+        self.assertEqual(res['inserted'], 1)
+
+        expected_row1 = {'id': 0, 'time': dt1}
+        expected_row2 = {'id': 1, 'time': dt2}
+
+        groups = yield from r.table('times').group('time').coerce_to('array').run(c)
+        self.assertEqual(groups, {dt1: [expected_row1],
+                                  dt2: [expected_row2]})
+
+
+class TestSuccessAtomFeed(TestWithConnection):
+    @asyncio.coroutine
+    def runTest(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        from rethinkdb import ql2_pb2 as p
+
+        if 'success_atom_feed' in (yield from r.db('test').table_list().run(c)):
+            yield from r.db('test').table_drop('success_atom_feed').run(c)
+        yield from r.db('test').table_create('success_atom_feed').run(c)
+        t1 = r.db('test').table('success_atom_feed')
+
+        res = yield from t1.insert({'id': 0, 'a': 16}).run(c)
+        self.assertEqual(res['inserted'], 1)
+        res = yield from t1.insert({'id': 1, 'a': 31}).run(c)
+        self.assertEqual(res['inserted'], 1)
+
+        yield from t1.index_create('a', lambda x: x['a']).run(c)
+        yield from t1.index_wait('a').run(c)
+
+        changes = yield from t1.get(0).changes().run(c)
+        self.assertTrue(changes.error is None)
+        self.assertEqual(len(changes.items), 1)
+
+class TestCursor(TestWithConnection):
+    @asyncio.coroutine
+    def setUp(self):
+        yield from TestWithConnection.setUp(self)
+        self.conn = yield from r.connect(host=sharedServerHost,
+                                    port=sharedServerDriverPort)
+
+    @asyncio.coroutine
+    def tearDown(self):
+        yield from TestWithConnection.tearDown(self)
+        yield from self.conn.close()
+        self.conn = None
+
+    @asyncio.coroutine
+    def test_type(self):
+        cursor = yield from r.range().run(self.conn)
+        self.assertTrue(isinstance(cursor, r.Cursor))
+
+    @asyncio.coroutine
+    def test_cursor_after_connection_close(self):
+        cursor = yield from r.range().run(self.conn)
+        yield from self.conn.close()
+
+        @asyncio.coroutine
+        def read_cursor(cursor):
+            while (yield from cursor.fetch_next()):
+                yield from cursor.next()
+                cursor.close()
+
+        with self.assertRaisesRegexp(r.RqlRuntimeError, "Connection is closed."):
+             yield from read_cursor(cursor)
+
+    @asyncio.coroutine
+    def test_cursor_after_cursor_close(self):
+        cursor = yield from r.range().run(self.conn)
+        cursor.close()
+        count = 0
+        while (yield from cursor.fetch_next()):
+            yield from cursor.next()
+            count += 1
+        self.assertNotEqual(count, 0, "Did not get any cursor results")
+
+    @asyncio.coroutine
+    def test_cursor_close_in_each(self):
+        cursor = yield from r.range().run(self.conn)
+        count = 0
+
+        while (yield from cursor.fetch_next()):
+            yield from cursor.next()
+            count += 1
+            if count == 2:
+                cursor.close()
+
+        self.assertTrue(count >= 2, "Did not get enough cursor results")
+
+    @asyncio.coroutine
+    def test_cursor_success(self):
+        range_size = 10000
+        cursor = yield from r.range().limit(range_size).run(self.conn)
+        count = 0
+        while (yield from cursor.fetch_next()):
+            yield from cursor.next()
+            count += 1
+        self.assertEqual(count, range_size,
+             "Expected %d results on the cursor, but got %d" % (range_size, count))
+
+    @asyncio.coroutine
+    def test_cursor_double_each(self):
+        range_size = 10000
+        cursor = yield from r.range().limit(range_size).run(self.conn)
+        count = 0
+
+        while (yield from cursor.fetch_next()):
+            yield from cursor.next()
+            count += 1
+        self.assertEqual(count, range_size,
+             "Expected %d results on the cursor, but got %d" % (range_size, count))
+
+        while (yield from cursor.fetch_next()):
+            yield from cursor.next()
+            count += 1
+        self.assertEqual(count, range_size,
+             "Expected no results on the second iteration of the cursor, but got %d" % (count - range_size))
+
+    # Used in wait tests
+    num_cursors=3
+
+    @asyncio.coroutine
+    def do_wait_test(self, wait_time):
+        cursors = [ ]
+        cursor_counts = [ ]
+        cursor_timeouts = [ ]
+        for i in xrange(self.num_cursors):
+            cur = yield from r.range().map(r.js("(function (row) {" +
+                                                "end = new Date(new Date().getTime() + 2);" +
+                                                "while (new Date() < end) { }" +
+                                                "return row;" +
+                                           "})")).run(self.conn, max_batch_rows=2)
+            cursors.append(cur)
+            cursor_counts.append(0)
+            cursor_timeouts.append(0)
+
+        @asyncio.coroutine
+        def get_next(cursor_index):
+            try:
+                if wait_time is None: # Special case to use the default
+                    yield from cursors[cursor_index].next()
+                else:
+                    yield from cursors[cursor_index].next(wait=wait_time)
+                cursor_counts[cursor_index] += 1
+            except r.RqlTimeoutError:
+                cursor_timeouts[cursor_index] += 1
+
+        # We need to get ahead of pre-fetching for this to get the error we want
+        while sum(cursor_counts) < 4000:
+            for cursor_index in xrange(self.num_cursors):
+                for read_count in xrange(random.randint(0, 10)):
+                    yield from get_next(cursor_index)
+
+        [cursor.close() for cursor in cursors]
+
+        return (sum(cursor_counts), sum(cursor_timeouts))
+
+    # @asyncio.coroutine
+    # def test_false_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(False)
+    #     self.assertNotEqual(timeouts, 0,
+    #         "Did not get timeouts using zero (false) wait.")
+    #
+    # @asyncio.coroutine
+    # def test_zero_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(0)
+    #     self.assertNotEqual(timeouts, 0,
+    #         "Did not get timeouts using zero wait.")
+    #
+    # @asyncio.coroutine
+    # def test_short_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(0.0001)
+    #     self.assertNotEqual(timeouts, 0,
+    #         "Did not get timeouts using short (100 microsecond) wait.")
+    #
+    # @asyncio.coroutine
+    # def test_long_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(10)
+    #     self.assertEqual(timeouts, 0,
+    #         "Got timeouts using long (10 second) wait.")
+    #
+    # @asyncio.coroutine
+    # def test_infinite_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(True)
+    #     self.assertEqual(timeouts, 0,
+    #         "Got timeouts using infinite wait.")
+    #
+    # @asyncio.coroutine
+    # def test_default_wait(self):
+    #     reads, timeouts = yield from self.do_wait_test(None)
+    #     self.assertEqual(timeouts, 0,
+    #         "Got timeouts using default (infinite) wait.")
+
+    # This test relies on the internals of the TornadoCursor implementation
+    # @asyncio.coroutine
+    # def test_rate_limit(self):
+    #     # Get the first batch
+    #     cursor = yield from r.range().run(self.conn)
+    #     cursor_initial_size = len(cursor.items)
+    #
+    #     # Wait for the second (pre-fetched) batch to arrive
+    #     yield from cursor.new_response
+    #     cursor_new_size = len(cursor.items)
+    #
+    #     self.assertLess(cursor_initial_size, cursor_new_size)
+    #
+    #     # Wait and observe that no third batch arrives
+    #     yield from self.asyncAssertRaises(asyncio.TimeoutError,
+    #         asyncio.wait_for(cursor.new_response, 2)
+    #     )
+    #     self.assertEqual(cursor_new_size, len(cursor.items))
+
+    # Test that an error on a cursor (such as from closing the connection)
+    # properly wakes up waiters immediately
+    @asyncio.coroutine
+    def test_cursor_error(self):
+        cursor = yield from r.range() \
+            .map(lambda row:
+                r.branch(row <= 5000, # High enough for multiple batches
+                         row,
+                         r.js('while(true){ }'))) \
+            .run(self.conn)
+
+        @asyncio.coroutine
+        def read_cursor(cursor, hanging):
+            try:
+                while True:
+                    yield from cursor.next(wait=1)
+            except r.RqlTimeoutError:
+                pass
+            hanging.set_result(True)
+            yield from cursor.next()
+
+        @asyncio.coroutine
+        def read_wrapper(cursor, done, hanging):
+            try:
+                with self.assertRaisesRegexp(r.RqlRuntimeError,
+                                             'Connection is closed.'):
+                    yield from read_cursor(cursor, hanging)
+                done.set_result(None)
+            except Exception as ex:
+                if not cursor_hanging.done():
+                    cursor_hanging.set_exception(ex)
+                done.set_exception(ex)
+
+        cursor_hanging = asyncio.Future()
+        done = asyncio.Future()
+        asyncio.async(read_wrapper(cursor, done, cursor_hanging))
+
+        # Wait for the cursor to hit the hang point before we close and cause an error
+        yield from cursor_hanging
+        yield from self.conn.close()
+        yield from done
+
+class TestChangefeeds(TestWithConnection):
+    @asyncio.coroutine
+    def setUp(self):
+        yield from TestWithConnection.setUp(self)
+        self.conn = yield from r.connect(host=sharedServerHost,
+                                    port=sharedServerDriverPort)
+        if 'a' in (yield from r.db('test').table_list().run(self.conn)):
+            yield from r.db('test').table_drop('a').run(self.conn)
+        yield from r.db('test').table_create('a').run(self.conn)
+        if 'b' in (yield from r.db('test').table_list().run(self.conn)):
+            yield from r.db('test').table_drop('b').run(self.conn)
+        yield from r.db('test').table_create('b').run(self.conn)
+
+    @asyncio.coroutine
+    def tearDown(self):
+        yield from r.db('test').table_drop('b').run(self.conn)
+        yield from r.db('test').table_drop('a').run(self.conn)
+        yield from TestWithConnection.tearDown(self)
+        yield from self.conn.close()
+        self.conn = None
+
+    @asyncio.coroutine
+    def table_a_even_writer(self):
+        for i in range(10):
+            yield from r.db('test').table("a").insert({"id": i * 2}).run(self.conn)
+
+    @asyncio.coroutine
+    def table_a_odd_writer(self):
+        for i in range(10):
+            yield from r.db('test').table("a").insert({"id": i * 2 + 1}).run(self.conn)
+
+    @asyncio.coroutine
+    def table_b_writer(self):
+        for i in range(10):
+            yield from r.db('test').table("b").insert({"id": i}).run(self.conn)
+
+    @asyncio.coroutine
+    def cfeed_noticer(self, table, ready, done, needed_values):
+        feed = yield from r.db('test').table(table).changes(squash=False).run(self.conn)
+        try:
+            ready.set_result(None)
+            while len(needed_values) != 0 and (yield from feed.fetch_next()):
+                item = yield from feed.next()
+                self.assertIsNone(item['old_val'])
+                self.assertIn(item['new_val']['id'], needed_values)
+                needed_values.remove(item['new_val']['id'])
+            done.set_result(None)
+        except Exception as ex:
+            done.set_exception(ex)
+
+    @asyncio.coroutine
+    def test_multiple_changefeeds(self):
+        loop = asyncio.get_event_loop()
+        feeds_ready = { }
+        feeds_done = { }
+        needed_values = { 'a': set(range(20)), 'b': set(range(10)) }
+        for n in ('a', 'b'):
+            feeds_ready[n] = asyncio.Future()
+            feeds_done[n] = asyncio.Future()
+            loop.add_callback(self.cfeed_noticer, n, feeds_ready[n], feeds_done[n], needed_values[n])
+
+        yield from list(feeds_ready.values())
+        yield from [self.table_a_even_writer(),
+               self.table_a_odd_writer(),
+               self.table_b_writer()]
+        yield from list(feeds_done.values())
+        self.assertTrue(all([len(x) == 0 for x in needed_values.values()]))
+
+if __name__ == '__main__':
+    print("Running asyncio connection tests")
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    suite.addTest(loader.loadTestsFromTestCase(TestCursor))
+    suite.addTest(loader.loadTestsFromTestCase(TestChangefeeds))
+    suite.addTest(loader.loadTestsFromTestCase(TestNoConnection))
+    suite.addTest(loader.loadTestsFromTestCase(TestConnection))
+    suite.addTest(TestBatching())
+    suite.addTest(TestGetIntersectingBatching())
+    suite.addTest(TestGroupWithTimeKey())
+    suite.addTest(TestSuccessAtomFeed())
+    suite.addTest(loader.loadTestsFromTestCase(TestShutdown))
+
+    res = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
+
+    serverClosedCleanly = True
+    try:
+        if sharedServer is not None:
+            sharedServer.check_and_stop()
+    except Exception as e:
+        serverClosedCleanly = False
+        sys.stderr.write('The server did not close cleanly after testing: %s'
+                         % str(e))
+
+    if not res.wasSuccessful() or not serverClosedCleanly:
+        sys.exit(1)

--- a/test/rql_test/connections/asyncio_connection.py
+++ b/test/rql_test/connections/asyncio_connection.py
@@ -728,60 +728,59 @@ class TestCursor(TestWithConnection):
 
         return (sum(cursor_counts), sum(cursor_timeouts))
 
-    # @asyncio.coroutine
-    # def test_false_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(False)
-    #     self.assertNotEqual(timeouts, 0,
-    #         "Did not get timeouts using zero (false) wait.")
-    #
-    # @asyncio.coroutine
-    # def test_zero_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(0)
-    #     self.assertNotEqual(timeouts, 0,
-    #         "Did not get timeouts using zero wait.")
-    #
-    # @asyncio.coroutine
-    # def test_short_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(0.0001)
-    #     self.assertNotEqual(timeouts, 0,
-    #         "Did not get timeouts using short (100 microsecond) wait.")
-    #
-    # @asyncio.coroutine
-    # def test_long_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(10)
-    #     self.assertEqual(timeouts, 0,
-    #         "Got timeouts using long (10 second) wait.")
-    #
-    # @asyncio.coroutine
-    # def test_infinite_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(True)
-    #     self.assertEqual(timeouts, 0,
-    #         "Got timeouts using infinite wait.")
-    #
-    # @asyncio.coroutine
-    # def test_default_wait(self):
-    #     reads, timeouts = yield from self.do_wait_test(None)
-    #     self.assertEqual(timeouts, 0,
-    #         "Got timeouts using default (infinite) wait.")
+    @asyncio.coroutine
+    def test_false_wait(self):
+        reads, timeouts = yield from self.do_wait_test(False)
+        self.assertNotEqual(timeouts, 0,
+            "Did not get timeouts using zero (false) wait.")
+
+    @asyncio.coroutine
+    def test_zero_wait(self):
+        reads, timeouts = yield from self.do_wait_test(0)
+        self.assertNotEqual(timeouts, 0,
+            "Did not get timeouts using zero wait.")
+
+    @asyncio.coroutine
+    def test_short_wait(self):
+        reads, timeouts = yield from self.do_wait_test(0.0001)
+        self.assertNotEqual(timeouts, 0,
+            "Did not get timeouts using short (100 microsecond) wait.")
+
+    @asyncio.coroutine
+    def test_long_wait(self):
+        reads, timeouts = yield from self.do_wait_test(10)
+        self.assertEqual(timeouts, 0,
+            "Got timeouts using long (10 second) wait.")
+
+    @asyncio.coroutine
+    def test_infinite_wait(self):
+        reads, timeouts = yield from self.do_wait_test(True)
+        self.assertEqual(timeouts, 0,
+            "Got timeouts using infinite wait.")
+
+    @asyncio.coroutine
+    def test_default_wait(self):
+        reads, timeouts = yield from self.do_wait_test(None)
+        self.assertEqual(timeouts, 0,
+            "Got timeouts using default (infinite) wait.")
 
     # This test relies on the internals of the TornadoCursor implementation
-    # @asyncio.coroutine
-    # def test_rate_limit(self):
-    #     # Get the first batch
-    #     cursor = yield from r.range().run(self.conn)
-    #     cursor_initial_size = len(cursor.items)
-    #
-    #     # Wait for the second (pre-fetched) batch to arrive
-    #     yield from cursor.new_response
-    #     cursor_new_size = len(cursor.items)
-    #
-    #     self.assertLess(cursor_initial_size, cursor_new_size)
-    #
-    #     # Wait and observe that no third batch arrives
-    #     yield from self.asyncAssertRaises(asyncio.TimeoutError,
-    #         asyncio.wait_for(cursor.new_response, 2)
-    #     )
-    #     self.assertEqual(cursor_new_size, len(cursor.items))
+    @asyncio.coroutine
+    def test_rate_limit(self):
+        # Get the first batch
+        cursor = yield from r.range().run(self.conn)
+        cursor_initial_size = len(cursor.items)
+
+        # Wait for the second (pre-fetched) batch to arrive
+        yield from cursor.new_response
+        cursor_new_size = len(cursor.items)
+
+        self.assertLess(cursor_initial_size, cursor_new_size)
+
+        # Wait and observe that no third batch arrives
+        with self.assertRaises(asyncio.TimeoutError):
+            yield from asyncio.wait_for(asyncio.shield(cursor.new_response), 2)
+        self.assertEqual(cursor_new_size, len(cursor.items))
 
     # Test that an error on a cursor (such as from closing the connection)
     # properly wakes up waiters immediately

--- a/test/rql_test/connections/asyncio_connection.py
+++ b/test/rql_test/connections/asyncio_connection.py
@@ -92,40 +92,6 @@ def just_do(coroutine, *args, **kwargs):
 # == Test Base Classes
 
 class TestCaseCompatible(unittest.TestCase):
-    # @asyncio.coroutine
-    # def asyncAssertRaisesRegexp(self, exception, regexp, generator):
-    #     try:
-    #         yield from generator
-    #     except Exception as e:
-    #         self.assertTrue(isinstance(e, exception),
-    #                         '%s expected to raise %s but '
-    #                         'instead raised %s: %s\n%s'
-    #                         % (repr(generator), repr(exception),
-    #                            e.__class__.__name__, str(e),
-    #                            traceback.format_exc()))
-    #         self.assertTrue(re.search(regexp, str(e)),
-    #                         '%s did not raise the expected '
-    #                         'message "%s", but rather: %s'
-    #                         % (repr(generator), str(regexp), str(e)))
-    #     else:
-    #         self.fail('%s failed to raise a %s'
-    #                   % (repr(generator), repr(exception)))
-    #
-    # @asyncio.coroutine
-    # def asyncAssertRaises(self, exception, generator):
-    #     try:
-    #         yield from generator
-    #     except Exception as e:
-    #         self.assertTrue(isinstance(e, exception),
-    #                         '%s expected to raise %s but '
-    #                         'instead raised %s: %s\n%s'
-    #                         % (repr(generator), repr(exception),
-    #                            e.__class__.__name__, str(e),
-    #                            traceback.format_exc()))
-    #     else:
-    #         self.fail('%s failed to raise a %s'
-    #                   % (repr(generator), repr(exception)))
-
     # can't use standard TestCase run here because async.
     def run(self, result=None):
         return just_do(self.arun, result)

--- a/test/rql_test/connections/asyncio_connection.py.test
+++ b/test/rql_test/connections/asyncio_connection.py.test
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import os, sys, subprocess
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, "common"))
+
+if not os.path.isdir('run'):
+    os.makedirs('run')
+
+sys.exit(subprocess.call([os.environ.get('INTERPRETER_PATH', 'python'), os.path.join(os.path.dirname(__file__), 'asyncio_connection.py')]))


### PR DESCRIPTION
This probably needs quite a bit of work, but it's working for a basic example, and I wanted to communicate early. @techdragon talked me into working on this at the PyCon sprints.

Asyncio is part of the standard library in Python 3.4. It's a rather similar API to tornado, so I copied and pasted the net_tornado code that's already in rethinkdb and modified it until it works. The syntax is only valid on Python 3, but the module shouldn't be imported until you do `r.set_loop_type('asyncio')`, so that shouldn't be a problem.

Here's the asyncio version of the tornado example from your [async drivers blog post](http://www.rethinkdb.com/blog/async-drivers/) (BTW, that example is missing a colon on the `while` line):

```python
import asyncio
import rethinkdb as r

r.set_loop_type("asyncio")

@asyncio.coroutine
def print_changes():
    conn = yield from r.connect(host="localhost", port=28015)
    feed = yield from r.table("tv_shows").changes().run(conn)
    while (yield from feed.fetch_next()):
        change = yield from feed.next()
        print(change)

loop = asyncio.get_event_loop()
loop.run_until_complete(print_changes())
```