### PR TITLE
[ruby] support for ssl encryption and CA verification

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -457,7 +457,7 @@ module RethinkDB
       @auth_key = opts[:auth_key] || ""
       @timeout = opts[:timeout].to_i
       @timeout = 20 if @timeout <= 0
-      @ssl_opts = opts.reject { |k, v| !k.to_s.start_with?('ssl') } if opts.is_a?(Hash)
+      @ssl_opts = opts[:ssl] || {}
 
       @@last = self
       @default_opts = @default_db ? {:db => RQL.new.db(@default_db)} : {}
@@ -670,9 +670,12 @@ module RethinkDB
 
     def create_context(options)
       context = OpenSSL::SSL::SSLContext.new
-      if options[:ssl_verify] || options[:ssl_ca_cert]
-        context.ca_file = options[:ssl_ca_cert]
+      context.ssl_version = :TLSv1_2
+      if options[:ca_certs]
+        context.ca_file = options[:ca_certs]
         context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      else
+        raise 'ssl options provided but missing required "ca_certs" option'
       end
       context
     end

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -652,7 +652,6 @@ module RethinkDB
     def init_socket
       unless @ssl_opts.empty?
         @tcp_socket = base_socket
-        @tcp_socket.connect(::Socket.pack_sockaddr_in(@port, @host))
         context = create_context(@ssl_opts)
         @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
         @socket.sync_close = true
@@ -660,12 +659,11 @@ module RethinkDB
         verify_cert!(@socket, context)
       else
         @socket = base_socket
-        @socket.connect(Socket.pack_sockaddr_in(@port, @host))
       end
     end
 
     def base_socket
-      socket = Socket.new(Socket::PF_INET, Socket::SOCK_STREAM, 0)
+      socket = TCPSocket.open(@host, @port)
       socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       socket
     end


### PR DESCRIPTION
[Addresses Ruby Driver](https://github.com/rethinkdb/rethinkdb/issues/3158)

The following abstracts the socket connection out a bit to allow for creating an SSL connection to a cluster. In order for this to be used, you'd need a proxy (Haproxy, nginx, etc) sitting in front of the RethinkDB cluster performing the SSL verification.

For now, the SSL support is only good for encrypting traffic and verifying the CA certification to prevent MITM attacks. 