### PR TITLE
[python] support for ssl encryption and CA verification

### DIFF
--- a/drivers/python/rethinkdb/net_tornado.py
+++ b/drivers/python/rethinkdb/net_tornado.py
@@ -87,15 +87,13 @@ class ConnectionInstance(object):
         self._io_loop = io_loop
         if self._io_loop is None:
             self._io_loop = IOLoop.current()
-        self._use_ssl = parent._use_ssl
-        self._ca_certs = parent._ca_certs
 
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        if _use_ssl:
+        if len(self._parent.ssl) > 0:
             ssl_options = {}
-            if self._ca_certs:
-                ssl_options['ca_certs'] = self._ca_certs
+            if self._parent.ssl["ca_certs"]:
+                ssl_options['ca_certs'] = self._parent.ssl["ca_certs"]
                 ssl_options['cert_reqs'] = 2 # ssl.CERT_REQUIRED
             self._stream = iostream.SSLIOStream(
                 self._socket, ssl_options=ssl_options, io_loop=self._io_loop)


### PR DESCRIPTION
[Addresses Python Driver](https://github.com/rethinkdb/rethinkdb/issues/3158)

The following abstracts the socket connection out a bit to allow for creating an SSL connection to a cluster. In order for this to be used, you'd need a proxy (Haproxy, nginx, etc) sitting in front of the RethinkDB cluster performing the SSL verification.

For now, the SSL support is only good for encrypting traffic and verifying the CA certification to prevent MITM attacks. 

For the implementation, I'm using the additional kwargs to add `ssl` and `ca_certs`.