### PR TITLE
Update proto doc for contains

### DIFF
--- a/src/rdb_protocol/ql2.proto
+++ b/src/rdb_protocol/ql2.proto
@@ -361,7 +361,7 @@ message Term {
         SKIP  = 70; // Sequence, NUMBER -> Sequence
         LIMIT = 71; // Sequence, NUMBER -> Sequence
         OFFSETS_OF = 87; // Sequence, DATUM -> Sequence | Sequence, Function(1) -> Sequence
-        CONTAINS = 93; // Sequence, DATUM -> BOOL | Sequence, Function(1) -> BOOL
+        CONTAINS = 93; // Sequence, (DATUM | Function(1))... -> BOOL
 
         // Stream/Object Ops
         // Get a particular field from an object, or map that over a


### PR DESCRIPTION
While implementing contains for https://github.com/hamiltop/exrethinkdb I found that the behavior of the function to differ from the spec.

1. Multiple predicates are allowed and behave as a logical `AND`
2. A mix of predicates and datum are allowed and behave as a logical `AND`

Number 1 is reflected in the actual docs properly but not reflected in the spec.
Number 2 is in neither the docs nor the comments in the spec.