### PR TITLE
remove redundant code

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -15,8 +15,6 @@ int main(int argc, char *argv[]) {
     setrlimit(RLIMIT_CORE, &core_limit);
 #endif
 
-    startup_shutdown_t startup_shutdown;
-
     std::set<std::string> subcommands_that_look_like_flags;
     subcommands_that_look_like_flags.insert("--version");
     subcommands_that_look_like_flags.insert("-v");

--- a/src/serializer/buf_ptr.hpp
+++ b/src/serializer/buf_ptr.hpp
@@ -21,7 +21,6 @@ public:
         : block_size_(movee.block_size_),
           ser_buffer_(std::move(movee.ser_buffer_)) {
         movee.block_size_ = block_size_t::undefined();
-        movee.ser_buffer_.reset();
     }
 
     buf_ptr_t(block_size_t size,


### PR DESCRIPTION
scoped_malloc_t ser_buf_ already support move semantic