### PR TITLE
JS Driver: allow `r.js` to accept a function

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -1197,7 +1197,10 @@ rethinkdb.expr = varar 1, 2, (val, nestingDepth=20) ->
     else
         new DatumTerm val
 
-rethinkdb.js = aropt (jssrc, opts) -> new JavaScript opts, jssrc
+rethinkdb.js = aropt (jssrc, opts) ->
+    if typeof jssrc is 'function'
+        jssrc = "(#{jssrc.toString()})"
+    new JavaScript opts, jssrc
 
 rethinkdb.http = aropt (url, opts) -> new Http opts, url
 

--- a/test/rql_test/src/control.yaml
+++ b/test/rql_test/src/control.yaml
@@ -140,6 +140,10 @@ tests:
     - cd: r.expr('foo').do(r.js('(function(x) { return x + "bar"; })'))
       ot: "'foobar'"
 
+    # should accept function argument in JS driver
+    - js: r.expr('foo').do(r.js(function(x) { return x + "bar"; }))
+      ot: "'foobar'"
+
     # js timeout optarg shouldn't be triggered
     - py: r.js('1 + 2', timeout=1.2)
       js: r.js('1 + 2', {timeout:1.2})


### PR DESCRIPTION
Fixes #4260.