### PR TITLE
JS Driver: db optarg to `.run()` is ignored if default db is already set on the connection

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -781,10 +781,10 @@ class Connection extends events.EventEmitter
             query.global_optargs[util.fromCamelCase(key)] = r.expr(value).build()
 
         # If the user has specified the `db` on the connection (either
-        # in the constructor, or with the `.use` method, we add that
-        # db to the optargs for the query.
-        if @db?
-            query.global_optargs['db'] = r.db(@db).build()
+        # in the constructor, as an optarg to .run(), or with the `.use` method)
+        # we add that db to the optargs for the query.
+        if opts.db? or @db?
+            query.global_optargs.db = r.db(opts.db or @db).build()
 
         # Next, ensure that the `useOutdated`, `noreply`, and
         # `profile` options (if present) are actual booleans using the


### PR DESCRIPTION
Fixes #4347