### PR TITLE
Ignore whitespace in database delete confirmation

### DIFF
--- a/admin/static/coffee/modals.coffee
+++ b/admin/static/coffee/modals.coffee
@@ -92,7 +92,7 @@ class DeleteDatabaseModal extends ui_modals.AbstractModal
 
 
     on_submit: =>
-        if @$('.verification_name').val() isnt @database_to_delete.get('name')
+        if $.trim(@$('.verification_name').val()) isnt @database_to_delete.get('name')
             if @$('.mismatch_container').css('display') is 'none'
                 @$('.mismatch_container').slideDown('fast')
             else


### PR DESCRIPTION
Hi, I've recently found myself deleting some databases manually via the web interface and was annoyed that whitespace around the database name wasn't ignored. This PR fixes that.
Feel free to close if you think this is unnecessary. Btw, thanks for the amazing work so far!