### PR TITLE
Only set __proto__ in TermBase if it exists

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -52,9 +52,12 @@ hasImplicit = (args) ->
 class TermBase
     showRunWarning: true
     constructor: ->
-        self = (ar (field) -> self.bracket(field))
-        self.__proto__ = @.__proto__
-        return self
+        if {}.__proto__ != undefined
+            self = (ar (field) -> self.bracket(field))
+            self.__proto__ = @.__proto__
+            self
+        else
+            @
 
     run: (connection, options, callback) ->
         # Valid syntaxes are


### PR DESCRIPTION
IE 10 doesn't have the `__proto__` property. So for JS interpreters without `__proto__` we skip the `__proto__` magic (thereby disabling the `foo('bracket')` syntax in ReQL).

Fixes #162
Fix suggested by @mikemintz