### PR TITLE
Avoid certain issues when using EventMachine and fibers

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -715,7 +715,7 @@ module RethinkDB
       @mon.synchronize {
         @opts.clear
         @data.clear
-        @waiters.each {|k,v|
+        @waiters.dup.each {|k,v|
           case v
           when QueryHandle
             v.handle_close
@@ -755,7 +755,7 @@ module RethinkDB
 
     def remove_em_waiters
       @mon.synchronize {
-        @waiters.each {|k,v|
+        @waiters.dup.each {|k,v|
           if v.is_a? QueryHandle
             v.handle_close
             @waiters.delete(k)


### PR DESCRIPTION
This avoid this error:

```
  RuntimeError: can't add a new key into hash during iteration
     # lib/net.rb:480:in `block in register_query'
     # lib/net.rb:476:in `register_query'
     # lib/net.rb:515:in `run'
     # lib/net.rb:341:in `em_run'
```