### PR TITLE
check arity before calling passed in functions

### DIFF
--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -57,10 +57,11 @@ scoped_ptr_t<val_t> reql_func_t::call(env_t *env,
         // way (thanks to entropy).  TODO: This is bad.
         rcheck(arg_names.size() == args.size() || arg_names.size() == 0,
                base_exc_t::LOGIC,
-               strprintf("Expected %zd argument%s but found %zu.",
+               strprintf("Expected function with %zu argument%s but found function with %zu argument%s.",
+                         args.size(),
+                         (args.size() == 1 ? "" : "s"),
                          arg_names.size(),
-                         (arg_names.size() == 1 ? "" : "s"),
-                         args.size()));
+                         (arg_names.size() == 1 ? "" : "s")));
 
         var_scope_t new_scope = arg_names.size() == 0
             ? captured_scope

--- a/test/rql_test/src/control.yaml
+++ b/test/rql_test/src/control.yaml
@@ -28,12 +28,12 @@ tests:
     - py: "r.do(1, 2, lambda x: x)"
       js: r.do(1, 2, function(x) { return x; })
       rb: r.do(1, 2) {|x| x}
-      ot: err("ReqlQueryLogicError", 'Expected 1 argument but found 2.', [1])
+      ot: err("ReqlQueryLogicError", 'Expected function with 2 arguments but found function with 1 argument.', [1])
 
     - py: "r.do(1, 2, 3, lambda x, y: x + y)"
       js: r.do(1, 2, 3, function(x, y) { return x.add(y); })
       rb: r.do(1, 2, 3) {|x, y| x + y}
-      ot: err("ReqlQueryLogicError", 'Expected 2 arguments but found 3.', [1])
+      ot: err("ReqlQueryLogicError", 'Expected function with 3 arguments but found function with 2 arguments.', [1])
 
     - cd: "r.do(1)"
       ot: 1
@@ -69,12 +69,12 @@ tests:
     - py: "r.expr(0).do(lambda a,b: a + b)"
       js: r(0).do(function(a,b) { return a.add(b); })
       rb: r(0).do{ |a, b| a + b }
-      ot: err("ReqlQueryLogicError", 'Expected 2 arguments but found 1.', [1])
+      ot: err("ReqlQueryLogicError", 'Expected function with 1 argument but found function with 2 arguments.', [1])
 
     - py: "r.do(1, 2, lambda a: a)"
       js: r.do(1,2, function(a) { return a; })
       rb: r.do(1, 2) { |a| a }
-      ot: err("ReqlQueryLogicError", 'Expected 1 argument but found 2.', [1])
+      ot: err("ReqlQueryLogicError", 'Expected function with 2 arguments but found function with 1 argument.', [1])
 
     - cd: r.expr(5).do(r.row)
       rb: r(5).do{ |row| row }


### PR DESCRIPTION
#4189

check arity before calling passed in functions for `reduce`, `filter`, `concat_map`, `group`, `avg`, `min`, and `max`