### PR TITLE
JS Driver: promise friendly `cursor.eachAsync()`

### DIFF
--- a/drivers/javascript/cursor.coffee
+++ b/drivers/javascript/cursor.coffee
@@ -240,30 +240,11 @@ class IterableResult
         return nextCb()
 
     toArray: varar 0, 1, (cb) ->
-        fn = (cb) =>
-            arr = []
-            eachCb = (err, row) =>
-                if err?
-                    cb err
-                else
-                    arr.push(row)
-
-            onFinish = (err, ar) =>
-                cb null, arr
-
-            @each eachCb, onFinish
-
         if cb? and typeof cb isnt 'function'
             throw new err.ReqlDriverError "First argument to `toArray` must be a function or undefined."
 
-        new Promise( (resolve, reject) =>
-            toArrayCb = (err, result) ->
-                if err?
-                    reject(err)
-                else
-                    resolve(result)
-            fn(toArrayCb)
-        ).nodeify cb
+        results = []
+        return @eachAsync(results.push.bind(results)).return(results).nodeify(cb)
 
     _makeEmitter: ->
         @emitter = new EventEmitter

--- a/drivers/javascript/cursor.coffee
+++ b/drivers/javascript/cursor.coffee
@@ -217,15 +217,12 @@ class IterableResult
         if onFinished? and typeof onFinished isnt 'function'
             throw new err.ReqlDriverError "Optional second argument to each must be a function."
 
-        stopFlag = false
         self = @
         nextCb = (err, data) =>
-            if stopFlag isnt true
-                if err?.message is 'No more rows in the cursor.'
-                    onFinished?()
-                else
-                    stopFlag = cb(err, data) is false
-                    @_next nextCb
+            if err?.message is 'No more rows in the cursor.'
+                onFinished?()
+            else if cb(err, data) isnt false
+                @_next nextCb
             else
                 onFinished?()
         @_next nextCb

--- a/test/rql_test/connections/cursor.mocha
+++ b/test/rql_test/connections/cursor.mocha
@@ -176,6 +176,25 @@ describe('JavaScript Cursor', function() {
             });
         });
 
+        describe('eachAsync', function() {
+            it('iterates over table', function(done) {
+                var i = 0;
+                tableCursor.eachAsync(function(row) {
+                    assert.deepEqual(row, {'id':i});
+                    i++;
+                }).then(function() {
+                    assert.equal(i, numRows);
+                    done();
+                });
+            });
+
+            it('errors when missing argument', function(done) {
+                expectedMsg = 'First argument to eachAsync must be a function.';
+                assert.throws(function() { tableCursor.eachAsync(); }, argErrorTest(expectedMsg));
+                done();
+            });
+        });
+
         describe('close', function(done) {
             it("doesn't error", function(done) {
                 tableCursor.close(function(err) {

--- a/test/rql_test/connections/cursor.mocha
+++ b/test/rql_test/connections/cursor.mocha
@@ -169,6 +169,24 @@ describe('JavaScript Cursor', function() {
                 );
             });
 
+            it('stops iteration over table early', function(done) {
+                var i = 0;
+                tableCursor.each(
+                    function(err, row) {
+                        assert.ifError(err);
+                        assert.deepEqual(row, {'id':i});
+                        if (row.id === 10) {
+                            return false;
+                        }
+                        i++;
+                    },
+                    function() {
+                        assert.equal(i, 10);
+                        done();
+                    }
+                );
+            });
+
             it('errors when missing argument', function(done) {
                 expectedMsg = 'Expected between 1 and 2 arguments but found 0.';
                 assert.throws(function() { tableCursor.each(); }, argErrorTest(expectedMsg));
@@ -184,6 +202,43 @@ describe('JavaScript Cursor', function() {
                     i++;
                 }).then(function() {
                     assert.equal(i, numRows);
+                    done();
+                });
+            });
+
+            it('resolves before continuing iteration', function(done) {
+                var i = 0,
+                    handled = 0;
+
+                function asyncHandler(row) {
+                    return Promise.resolve().then(function () {
+                        assert.equal(handled++, row.id);
+                    })
+                }
+
+                tableCursor.eachAsync(function(row) {
+                    assert.deepEqual(row, {'id':i});
+                    i++;
+                    return asyncHandler(row);
+                })
+                .then(function() {
+                    assert.equal(i, numRows);
+                    done();
+                });
+            });
+
+            it('stops iteration over table early', function(done) {
+                var i = 0;
+                tableCursor.eachAsync(function(row) {
+                    assert.deepEqual(row, {'id':i});
+                    if (row.id === 10) {
+                        return Promise.reject(row);
+                    }
+                    i++;
+                })
+                .catch(function(row) {
+                    assert.equal(i, 10);
+                    assert.equal(row.id, 10);
                     done();
                 });
             });


### PR DESCRIPTION
Fixes #4780. Unfortunately, there was no way to implement this as an overload to the existing `cursor.each()` since there's no way to disambiguate the argument style.

Here's some example usage:

```js
cursor.eachAsync(function (row) {
  if (/* some condition */) {
    // if you return a promise, it will be awaited
    // before the cursor continues iteration
    return asyncRowHandler(row.id);
  }
  else {
    // iteration can be stopped early by returning a
    // promise that is later rejected or simply by throw'ing
    return Promise.reject('Stop iteration early.')
  }
})
.then(function () {
  // `cursor.eachAsync()` returns a promise that is resolved
  // once all rows have been read from the cursor
});
```