### PR TITLE
Fix reference to options in TLS constructor (SSL)

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -912,9 +912,11 @@ class TcpConnection extends Connection
         # using the net module and store it in the `@rawSocket`
         # attribute.
         if @ssl
-            @rawSocket = tls.connect options
+          @ssl.host = @host
+          @ssl.port = @port
+          @rawSocket = tls.connect @ssl
         else
-            @rawSocket = net.connect @port, @host
+          @rawSocket = net.connect @port, @host
 
         # We disable [Nagle's
         # algorithm](http://en.wikipedia.org/wiki/Nagle%27s_algorithm)


### PR DESCRIPTION
JS Driver 2.1.0 shipped with broken SSL functionality.

This fix corrects the missing variable and pre-populates TLS config options with the host and port from the rethinkdb host object.

Usage:

```javascript
var r = require( 'rethinkdb' );
r.connect({
    host: 'aws-eu-west-1-portal.1.dblayer.com',
    port: 10999,
    authKey: 'XXXdYXnhUKUCXOG1ejodIHypwd9JTQOwO1CgmHSCXXX',
    ssl: {
      ca: [ fs.readFileSync(__dirname+'/part_to_public_key.crt') ]
    }
  }, function(err, conn) {
    if(err) throw err;
    console.log('connected');
  });
```