### PR TITLE
Java Driver: Fixing dbCreate() to run

### DIFF
--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -32,7 +32,7 @@ public class RethinkDBTest{
                 .port(31157)
                 .connect();
         try{
-            r.dbCreate(dbName);
+            r.dbCreate(dbName).run(conn);
         }catch(ReqlError e){}
         try {
             r.db(dbName).wait_().run(conn);


### PR DESCRIPTION
Hi @deontologician. Shadowing your progress on your Java driver with my C# driver and I think we need run here. :)

https://github.com/bchavez/RethinkDb.Driver/blob/master/Source/RethinkDb.Driver.Tests/ConnectionTest.cs