### PR TITLE
Drivers: expose client port and address

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1074,6 +1074,9 @@ class TcpConnection extends Connection
         # just set the `@open` flag to `false`
         @rawSocket.on 'timeout', => @open = false; @emit 'timeout'
 
+    clientPort: -> @rawSocket.localPort
+    clientAddress: -> @rawSocket.localAddress
+
     # #### TcpConnection close method
     #
     # This is a public method for closing the current connection. It

--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -524,10 +524,10 @@ class Connection(object):
         self._next_token = 0
 
     def client_port(self):
-        self._instance._socket.client_port()
+        return self._instance._socket.client_port()
 
     def client_address(self):
-        self._instance._socket.client_address()
+        return self._instance._socket.client_address()
 
     def reconnect(self, noreply_wait=True, timeout=None):
         if timeout is None:

--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -317,11 +317,19 @@ class SocketWrapper(object):
                 raise ReqlDriverError("Server dropped connection with message: \"%s\"" %
                                       (message, ))
 
+    def client_port(self):
+        if self.is_open():
+            return self._socket.getsockname()[1]
+
+    def client_address(self):
+        if self.is_open():
+            return self._socket.getsockname()[0]
+
     def is_open(self):
         return self._socket is not None
 
     def close(self):
-        if self._socket is not None:
+        if self.is_open():
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
                 self._socket.close()
@@ -514,6 +522,12 @@ class Connection(object):
         self._child_kwargs = kwargs
         self._instance = None
         self._next_token = 0
+
+    def client_port(self):
+        self._instance._socket.client_port()
+
+    def client_address(self):
+        self._instance._socket.client_address()
 
     def reconnect(self, noreply_wait=True, timeout=None):
         if timeout is None:

--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -317,14 +317,6 @@ class SocketWrapper(object):
                 raise ReqlDriverError("Server dropped connection with message: \"%s\"" %
                                       (message, ))
 
-    def client_port(self):
-        if self.is_open():
-            return self._socket.getsockname()[1]
-
-    def client_address(self):
-        if self.is_open():
-            return self._socket.getsockname()[0]
-
     def is_open(self):
         return self._socket is not None
 
@@ -418,6 +410,14 @@ class ConnectionInstance(object):
         self._header_in_progress = None
         self._socket = None
         self._closing = False
+
+    def client_port(self):
+        if self.is_open():
+            return self._socket._socket.getsockname()[1]
+
+    def client_address(self):
+        if self.is_open():
+            return self._socket._socket.getsockname()[0]
 
     def connect(self, timeout):
         self._socket = SocketWrapper(self, timeout)
@@ -524,10 +524,12 @@ class Connection(object):
         self._next_token = 0
 
     def client_port(self):
-        return self._instance._socket.client_port()
+        if self.is_open():
+            return self._instance.client_port()
 
     def client_address(self):
-        return self._instance._socket.client_address()
+        if self.is_open():
+            return self._instance.client_address()
 
     def reconnect(self, noreply_wait=True, timeout=None):
         if timeout is None:

--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -129,6 +129,14 @@ class ConnectionInstance(object):
         if self._io_loop is None:
             self._io_loop = asyncio.get_event_loop()
 
+    def client_port(self):
+        if self.is_open():
+            return self._streamwriter.get_extra_info('socketname')[1]
+
+    def client_address(self):
+        if self.is_open():
+            return self._streamwriter.get_extra_info('socketname')[0]
+
     @asyncio.coroutine
     def connect(self, timeout):
         try:

--- a/drivers/python/rethinkdb/net_tornado.py
+++ b/drivers/python/rethinkdb/net_tornado.py
@@ -100,6 +100,14 @@ class ConnectionInstance(object):
         else:
             self._stream = iostream.IOStream(self._socket, io_loop=self._io_loop)
 
+    def client_port(self):
+        if self.is_open():
+            return self._socket.getsockname()[1]
+
+    def client_address(self):
+        if self.is_open():
+            return self._socket.getsockname()[0]
+
     @gen.coroutine
     def connect(self, timeout):
         deadline = None if timeout is None else self._io_loop.time() + timeout

--- a/drivers/python/rethinkdb/net_twisted.py
+++ b/drivers/python/rethinkdb/net_twisted.py
@@ -238,6 +238,14 @@ class ConnectionInstance(object):
         if start_reactor:
             reactor.run()
 
+    def client_port(self):
+        if self.is_open():
+            return self._connection.transport.getHost().port
+
+    def client_address(self):
+        if self.is_open():
+            return self._connection.transport.getHost().host
+
     def _handleResponse(self, token, data):
         try:
             cursor = self._cursor_cache.get(token)

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -482,6 +482,13 @@ module RethinkDB
     end
     attr_reader :host, :port, :default_db, :conn_id
 
+    def client_port
+      is_open() ? @socket.addr[1] : nil
+    end
+    def client_address
+      is_open() ? @socket.addr[0] : nil
+    end
+
     def new_token
       @token_cnt_mutex.synchronize{@token_cnt += 1}
     end

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -486,7 +486,7 @@ module RethinkDB
       is_open() ? @socket.addr[1] : nil
     end
     def client_address
-      is_open() ? @socket.addr[0] : nil
+      is_open() ? @socket.addr[3] : nil
     end
 
     def new_token

--- a/test/rql_test/connections/asyncio_connection.py
+++ b/test/rql_test/connections/asyncio_connection.py
@@ -260,6 +260,19 @@ class TestNoConnection(TestCaseCompatible):
 
 class TestConnection(TestWithConnection):
     @asyncio.coroutine
+    def test_client_port_and_address(self):
+        c = yield from r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        self.assertIsNotNone(c.client_port())
+        self.assertIsNotNone(c.client_address())
+
+        yield from c.close()
+
+        self.assertIsNone(c.client_port())
+        self.assertIsNone(c.client_address())
+
+    @asyncio.coroutine
     def test_connect_close_reconnect(self):
         c = yield from r.connect(host=sharedServerHost,
                             port=sharedServerDriverPort)

--- a/test/rql_test/connections/client_info.rb
+++ b/test/rql_test/connections/client_info.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+# -- import the rethinkdb driver
+
+require_relative '../importRethinkDB.rb'
+
+# --
+
+$port = (ARGV[0] || ENV['RDB_DRIVER_PORT'] || raise('driver port not supplied')).to_i
+
+def expect_eq(left, right, message=nil)
+  if left != right
+    if message.nil?
+      raise RuntimeError, "Actual value #{left} not equal to expected value #{right}."
+    else
+      raise RuntimeError, "Actual value #{left} not equal to expected value #{right}: #{message}"
+    end
+  end
+end
+
+def expect_ne(left, right, message=nil)
+  if left == right
+    if message.nil?
+      raise RuntimeError, "Value #{left} unexpected."
+    else
+      raise RuntimeError, message
+    end
+  end
+end
+
+def test_client_port_and_address(conn)
+  expect_ne(conn.client_port, nil)
+  expect_ne(conn.client_address, nil)
+
+  conn.close()
+
+  expect_eq(conn.client_port, nil)
+  expect_eq(conn.client_address, nil)
+end
+
+$tests = {
+  :test_client_port_and_address => method(:test_client_port_and_address)
+}
+
+$tests.each do |name, m|
+  timeout(10) {
+    puts "Running test #{name}"
+    c = r.connect(:host => 'localhost', :port => $port)
+    m.call(c)
+    puts " - PASS"
+  }
+end

--- a/test/rql_test/connections/client_info.rb.test
+++ b/test/rql_test/connections/client_info.rb.test
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import os, sys, subprocess
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, "common"))
+import utils
+
+# -- start rethinkdb server if necessary
+
+server = None
+host = None
+port = None
+
+if not ('RDB_SERVER_HOST' in os.environ or 'RDB_DRIVER_PORT' in os.environ):
+    import driver
+
+    serverExe = sys.argv[1] if len(sys.argv) > 1 else utils.find_rethinkdb_executable()
+    server = driver.Process(executable_path=serverExe)
+
+    # expose the server info for the subprocess
+
+    os.environ['RDB_DRIVER_PORT'] = port = str(server.driver_port)
+    os.environ['RDB_SERVER_HOST'] = host = server.host
+else:
+    host = os.environ.get('RDB_SERVER_HOST', 'localhost')
+    port = int(os.environ.get('RDB_DRIVER_PORT', 28015))
+
+# -- run test
+
+command = [os.environ.get('INTERPRETER_PATH', 'ruby'), os.path.join(os.path.dirname(__file__), 'client_info.rb')]
+sys.exit(subprocess.call(command, stderr=subprocess.STDOUT))

--- a/test/rql_test/connections/connection.mocha
+++ b/test/rql_test/connections/connection.mocha
@@ -230,6 +230,17 @@ describe("JavaScript Callback style", function() {
             r.expr(1).run(reqlConn, givesError("ReqlDriverError", "Connection is closed.", done));
         });
 
+        it("gets clientPort", function(done){
+            assert(reqlConn.clientPort() != null);
+            done();
+        });
+
+
+        it("gets clientAddress", function(done){
+            assert(reqlConn.clientAddress() != null);
+            done();
+        });
+
         describe('noreplyWait', function(){
             it("waits", function(done){
                 var t = Date.now();

--- a/test/rql_test/connections/connection.py
+++ b/test/rql_test/connections/connection.py
@@ -316,6 +316,12 @@ class TestAuthConnection(TestPrivateServer):
         conn.reconnect()
 
 class TestConnection(TestWithConnection):
+    def test_client_port_and_address(self):
+        c = r.connect(host=sharedServerHost, port=sharedServerDriverPort)
+
+        self.assertIsNotNone(c.client_port())
+        self.assertIsNotNone(c.client_address())
+
     def test_connect_close_reconnect(self):
         c = r.connect(host=sharedServerHost, port=sharedServerDriverPort)
         r.expr(1).run(c)

--- a/test/rql_test/connections/connection.py
+++ b/test/rql_test/connections/connection.py
@@ -322,6 +322,11 @@ class TestConnection(TestWithConnection):
         self.assertIsNotNone(c.client_port())
         self.assertIsNotNone(c.client_address())
 
+        c.close()
+
+        self.assertIsNone(c.client_port())
+        self.assertIsNone(c.client_address())
+
     def test_connect_close_reconnect(self):
         c = r.connect(host=sharedServerHost, port=sharedServerDriverPort)
         r.expr(1).run(c)

--- a/test/rql_test/connections/tornado_connection.py
+++ b/test/rql_test/connections/tornado_connection.py
@@ -351,6 +351,19 @@ class TestNoConnection(TestCaseCompatible):
 
 class TestConnection(TestWithConnection):
     @gen.coroutine
+    def test_client_port_and_address(self):
+        c = yield r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        self.assertIsNotNone(c.client_port())
+        self.assertIsNotNone(c.client_address())
+
+        yield c.close()
+
+        self.assertIsNone(c.client_port())
+        self.assertIsNone(c.client_address())
+
+    @gen.coroutine
     def test_connect_close_reconnect(self):
         c = yield r.connect(host=sharedServerHost,
                             port=sharedServerDriverPort)

--- a/test/rql_test/connections/twisted_connection.py
+++ b/test/rql_test/connections/twisted_connection.py
@@ -244,6 +244,19 @@ class TestNoConnection(TestCaseCompatible):
 
 class TestConnection(TestWithConnection):
     @inlineCallbacks
+    def test_client_port_and_address(self):
+        c = yield r.connect(host=sharedServerHost,
+                            port=sharedServerDriverPort)
+
+        self.assertIsNotNone(c.client_port())
+        self.assertIsNotNone(c.client_address())
+
+        yield c.close()
+
+        self.assertIsNone(c.client_port())
+        self.assertIsNone(c.client_address())
+
+    @inlineCallbacks
     def test_connect_close_reconnect(self):
         c = yield r.connect(host=sharedServerHost,
                             port=sharedServerDriverPort)
@@ -944,4 +957,3 @@ if __name__ == '__main__':
     AsyncTestRunner(stream=sys.stdout, verbosity=2).run(suite).\
         addCallback(finishTests)
     reactor.run()
-


### PR DESCRIPTION
Fixes #4620. The original use-case was to filter the `jobs` table to only include jobs initiated by the current client ([see #544 comment](https://github.com/rethinkdb/rethinkdb/issues/544#issuecomment-127435975)).

I will also update the Ruby driver if the API looks ok to everyone.