### PR TITLE
Java Driver: Change map collector to bypass HashMap.merge()

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
@@ -53,10 +53,14 @@ public class Converter {
                 return convertPseudo(mapobj, fmt);
             }
             return mapobj.entrySet().stream()
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            entry -> convertPseudotypes(entry.getValue(), fmt)
-                    ));
+                    .collect(
+                            HashMap::new,
+                            (map, entry) -> map.put(
+                                    entry.getKey(),
+                                    convertPseudotypes(entry.getValue(), fmt)
+                            ),
+                            HashMap::putAll
+                    );
         } else {
             return obj;
         }


### PR DESCRIPTION
I decided to try the Java driver, but the build failed it's testing! Tests produced many of these null pointer exceptions:

```
java.lang.NullPointerException
	at java.util.HashMap.merge(HashMap.java:1216)
	at java.util.stream.Collectors.lambda$toMap$230(Collectors.java:1320)
	at java.util.stream.Collectors$$Lambda$28/1254557951.accept(Unknown Source)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1683)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:512)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:502)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at com.rethinkdb.net.Converter.convertPseudotypes(Converter.java:58)
	at com.rethinkdb.net.Converter.lambda$convertPseudotypes$14(Converter.java:49)
```

If you look at the source of [OpenJDK 8's `HashMap.merge()`](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/java/util/HashMap.java#1216), you can see it explicitly doesn't allow null values!? This is odd, since `HashMap` supports null values.

To fix it, I just changed the collector to not use `Collectors.toMap()` which is what eventually calls `HashMap.merge()`. I normally would be a good code contributor and add a test as well, but I'm not sure how to test a tools specific issue...