### PR TITLE
Implement a custom encoder to match the decode route.

### DIFF
--- a/drivers/python/rethinkdb/net_asyncio.py
+++ b/drivers/python/rethinkdb/net_asyncio.py
@@ -198,7 +198,7 @@ class ConnectionInstance(object):
 
     @asyncio.coroutine
     def run_query(self, query, noreply):
-        self._streamwriter.write(query.serialize())
+        self._streamwriter.write(query.serialize(self._parent._get_json_encoder()))
         if noreply:
             return None
 

--- a/drivers/python/rethinkdb/net_tornado.py
+++ b/drivers/python/rethinkdb/net_tornado.py
@@ -174,7 +174,7 @@ class ConnectionInstance(object):
 
     @gen.coroutine
     def run_query(self, query, noreply):
-        yield self._stream.write(query.serialize())
+        yield self._stream.write(query.serialize(self._parent._get_json_encoder()))
         if noreply:
             raise gen.Return(None)
 

--- a/drivers/python/rethinkdb/net_twisted.py
+++ b/drivers/python/rethinkdb/net_twisted.py
@@ -334,7 +334,7 @@ class ConnectionInstance(object):
         if not noreply:
             self._user_queries[query.token] = (query, response_defer)
         # Send the query
-        self._connection.transport.write(query.serialize())
+        self._connection.transport.write(query.serialize(self._parent._get_json_encoder()))
 
         if noreply:
             returnValue(None)


### PR DESCRIPTION
This makes the query encoding recurse one fewer times like the response improvement.