### PR TITLE
Fix for 4845

### DIFF
--- a/drivers/java/.gitignore
+++ b/drivers/java/.gitignore
@@ -3,3 +3,4 @@ build/
 .#*
 *.iml
 .idea/
+test-config-override.properties

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -47,10 +47,9 @@ public class ReqlAst {
     }
 
     public static Map<String, Object> buildOptarg(OptArgs opts){
-        return opts.entrySet().stream().collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> entry.getValue().build()
-        ));
+        Map<String, Object> result = new HashMap<>( opts.size() );
+        opts.forEach( (name, arg) -> result.put( name, arg.build() ) );
+        return result;
     }
 
     public <T> T run(Connection<? extends ConnectionInstance> conn,

--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -4,7 +4,7 @@ import com.rethinkdb.gen.exc.ReqlQueryLogicError;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.net.Connection;
 import junit.framework.Assert;
-import junit.framework.TestCase;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.*;
@@ -26,11 +26,8 @@ public class RethinkDBTest{
     public ExpectedException expectedEx = ExpectedException.none();
 
     @BeforeClass
-    public static void oneTimeSetUp() throws TimeoutException {
-        Connection<?> conn = r.connection()
-                .hostname("newton")
-                .port(31157)
-                .connect();
+    public static void oneTimeSetUp() throws Exception {
+        Connection<?> conn = TestingFramework.createConnection();
         try{
             r.dbCreate(dbName).run(conn);
         }catch(ReqlError e){}
@@ -43,11 +40,8 @@ public class RethinkDBTest{
     }
 
     @AfterClass
-    public static void oneTimeTearDown() throws TimeoutException {
-        Connection<?> conn = r.connection()
-                .hostname("newton")
-                .port(31157)
-                .connect();
+    public static void oneTimeTearDown() throws Exception {
+        Connection<?> conn = TestingFramework.createConnection();
         try {
             r.db(dbName).tableDrop(tableName).run(conn);
         }catch(ReqlError e){}
@@ -59,10 +53,7 @@ public class RethinkDBTest{
 
     @Before
     public void setUp() throws Exception {
-        conn = r.connection()
-                .hostname("newton")
-                .port(31157)
-                .connect();
+        conn = TestingFramework.createConnection();
         r.db(dbName).table(tableName).delete().run(conn);
     }
 
@@ -196,7 +187,8 @@ public class RethinkDBTest{
     public void testTableInsert(){
         MapObject foo = new MapObject()
                 .with("hi", "There")
-                .with("yes", 7);
+                .with("yes", 7)
+                .with("no", null );
         Map<String, Object> result = r.db(dbName).table(tableName).insert(foo).run(conn);
         assertEquals(result.get("inserted"), 1L);
     }

--- a/drivers/java/src/test/java/TestingFramework.java
+++ b/drivers/java/src/test/java/TestingFramework.java
@@ -1,0 +1,94 @@
+import com.rethinkdb.RethinkDB;
+import com.rethinkdb.net.Connection;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Very basic testing framework lying miserably in the java's default package.
+ */
+public class TestingFramework {
+
+    private static final String DEFAULT_CONFIG_RESOURCE = "default-config.properties";
+    private static final String OVERRIDE_FILE_NAME = "test-config-override.properties";
+    private static final String HOST_NAME = "hostName";
+    private static final String PORT      = "port";
+
+    /**
+     * Read the test configuration. Put a propertiy file called "test-config-override.properties" in the working
+     * directory of the tests to override default values.
+     * <P>
+     * Example:
+     * <pre>
+     *     hostName=myHost
+     *     port=12345
+     * </pre>
+     * </P>
+     */
+    public static Configuration getConfig() {
+        Properties config = new Properties();
+
+        try ( InputStream is = TestingFramework.class.getResourceAsStream( DEFAULT_CONFIG_RESOURCE ) ) {
+            config.load( is );
+        } catch ( IOException e ) {
+            throw new IllegalStateException( e );
+        }
+
+        // Check the local override file.
+        String workdir = System.getProperty( "user.dir" );
+        File defaultFile = new File( workdir, OVERRIDE_FILE_NAME );
+        if ( defaultFile.exists() ) {
+            try ( InputStream is = new FileInputStream( defaultFile ) ) {
+                config.load( is );
+            } catch ( IOException e ) {
+                throw new IllegalStateException( e );
+            }
+        }
+
+        Configuration result = new Configuration();
+        result.setHostName( config.getProperty( "hostName" ).trim() );
+        result.setPort( Integer.parseInt( config.getProperty( "port" ).trim() ) );
+        return result;
+    }
+
+    /**
+     * @return A new connection from the configuration.
+     */
+    public static Connection createConnection() throws Exception {
+        Configuration config = getConfig();
+
+        return RethinkDB.r.connection()
+                          .hostname( config.getHostName() )
+                          .port( config.getPort() )
+                          .connect();
+    }
+
+    /**
+     * Test framework configuration.
+     */
+    public static class Configuration {
+
+        private String hostName;
+        private int port;
+
+        public String getHostName() {
+            return hostName;
+        }
+
+        public void setHostName( String hostName ) {
+            this.hostName = hostName;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort( int port ) {
+            this.port = port;
+        }
+    }
+
+}

--- a/drivers/java/src/test/resources/default-config.properties
+++ b/drivers/java/src/test/resources/default-config.properties
@@ -1,0 +1,2 @@
+hostName=newton
+port=31157

--- a/drivers/java/test-config-override.properties
+++ b/drivers/java/test-config-override.properties
@@ -1,2 +1,0 @@
-hostName=localhost
-port=28015

--- a/drivers/java/test-config-override.properties
+++ b/drivers/java/test-config-override.properties
@@ -1,0 +1,2 @@
+hostName=localhost
+port=28015


### PR DESCRIPTION
Hi,

here is a fix to the bug 4845 I just entered. I also upgraded the test class to allow "override" of the configuration without having to modify any code.

The idea is to include a file in the root of the java driver called "test-config-override.properties" that can contains the hostName and port parameters. This file is git-ignored so nobody commit it to the repo.

If not defined, those parameters default to "newton" and 31157 which are Josh's parameters, I guess.

Have a nice day !
