### PR TITLE
Support for insert and select operations with POJOs in Java driver

### DIFF
--- a/drivers/java/build.gradle
+++ b/drivers/java/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-parameters"
+}
+
 version = '2.2-b1'
 ext.isReleaseVersion = !version.endsWith("b1")
 group = "com.rethinkdb"

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -83,9 +83,11 @@ public class ReqlAst {
     /**
      * Runs this query via connection {@code conn} with default options and returns an atom result
      * or a sequence result as a cursor. The atom result representing a JSON object is converted
-     * to an object of type {@code Class<P>}. The cursor is a {@code com.rethinkdb.net.Cursor}
-     * which may be iterated to get a sequence of atom results of type {@code Class<P>}
+     * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+     * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+     * of type {@code Class<P>}
      * @param conn The connection to run this query
+     * @param pojoClass The class of POJO to convert to
      * @param <T> The type of result
      * @param <P> The type of POJO to convert to
      * @return The result of this query (either a {@code P or a Cursor<P>}
@@ -97,10 +99,12 @@ public class ReqlAst {
     /**
      * Runs this query via connection {@code conn} with options {@code runOpts} and returns an atom result
      * or a sequence result as a cursor. The atom result representing a JSON object is converted
-     * to an object of type {@code Class<P>}. The cursor is a {@code com.rethinkdb.net.Cursor}
-     * which may be iterated to get a sequence of atom results of type {@code Class<P>}
+     * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+     * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+     * of type {@code Class<P>}
      * @param conn The connection to run this query
      * @param runOpts The options to run this query with
+     * @param pojoClass The class of POJO to convert to
      * @param <T> The type of result
      * @param <P> The type of POJO to convert to
      * @return The result of this query (either a {@code P or a Cursor<P>}

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -9,6 +9,7 @@ import com.rethinkdb.net.ConnectionInstance;
 import org.json.simple.JSONArray;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -67,6 +68,14 @@ public class ReqlAst {
 
     public <T> T run(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
         return Util.toPojo(conn.run(this, new OptArgs()), pojoClass);
+    }
+
+    public <T> List<T> runList(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {
+        return Util.toPojoList(conn.run(this, runOpts), pojoClass);
+    }
+
+    public <T> List<T> runList(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
+        return Util.toPojoList(conn.run(this, new OptArgs()), pojoClass);
     }
 
     public void runNoReply(Connection conn){

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -63,11 +63,11 @@ public class ReqlAst {
     }
 
     public <T> T run(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {
-        return Util.toPojo(conn.run(this, runOpts), pojoClass);
+        return Util.toPojo(pojoClass, conn.run(this, runOpts));
     }
 
     public <T> T run(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
-        return Util.toPojo(conn.run(this, new OptArgs()), pojoClass);
+        return Util.toPojo(pojoClass, conn.run(this, new OptArgs()));
     }
 
     public <T> List<T> runList(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -9,8 +9,8 @@ import com.rethinkdb.net.ConnectionInstance;
 import org.json.simple.JSONArray;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Base class for all reql queries.
@@ -53,29 +53,60 @@ public class ReqlAst {
         return result;
     }
 
-    public <T> T run(Connection<? extends ConnectionInstance> conn,
-                     OptArgs runOpts) {
-        return conn.run(this, runOpts);
-    }
-
+    /**
+     * Runs this query via connection {@code conn} with default options and returns an atom result
+     * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+     * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+     * which may be iterated to get a sequence of atom results
+     * @param conn The connection to run this query
+     * @param <T> The type of result
+     * @return The result of this query
+     */
     public <T> T run(Connection<? extends ConnectionInstance> conn) {
-        return conn.run(this, new OptArgs());
+        return conn.run(this, new OptArgs(), Optional.empty());
     }
 
-    public <T> T run(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {
-        return Util.toPojo(pojoClass, conn.run(this, runOpts));
+    /**
+     * Runs this query via connection {@code conn} with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+     * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+     * which may be iterated to get a sequence of atom results
+     * @param conn The connection to run this query
+     * @param runOpts The options to run this query with
+     * @param <T> The type of result
+     * @return The result of this query
+     */
+    public <T> T run(Connection<? extends ConnectionInstance> conn, OptArgs runOpts) {
+        return conn.run(this, runOpts, Optional.empty());
     }
 
-    public <T> T run(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
-        return Util.toPojo(pojoClass, conn.run(this, new OptArgs()));
+    /**
+     * Runs this query via connection {@code conn} with default options and returns an atom result
+     * or a sequence result as a cursor. The atom result representing a JSON object is converted
+     * to an object of type {@code Class<P>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+     * which may be iterated to get a sequence of atom results of type {@code Class<P>}
+     * @param conn The connection to run this query
+     * @param <T> The type of result
+     * @param <P> The type of POJO to convert to
+     * @return The result of this query (either a {@code P or a Cursor<P>}
+     */
+    public <T, P> T run(Connection<? extends ConnectionInstance> conn, Class<P> pojoClass) {
+        return conn.run(this, new OptArgs(), Optional.of(pojoClass));
     }
 
-    public <T> List<T> runList(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {
-        return Util.toPojoList(conn.run(this, runOpts), pojoClass);
-    }
-
-    public <T> List<T> runList(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
-        return Util.toPojoList(conn.run(this, new OptArgs()), pojoClass);
+    /**
+     * Runs this query via connection {@code conn} with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result representing a JSON object is converted
+     * to an object of type {@code Class<P>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+     * which may be iterated to get a sequence of atom results of type {@code Class<P>}
+     * @param conn The connection to run this query
+     * @param runOpts The options to run this query with
+     * @param <T> The type of result
+     * @param <P> The type of POJO to convert to
+     * @return The result of this query (either a {@code P or a Cursor<P>}
+     */
+    public <T, P> T run(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<P> pojoClass) {
+        return conn.run(this, runOpts, Optional.of(pojoClass));
     }
 
     public void runNoReply(Connection conn){

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -1,16 +1,16 @@
 package com.rethinkdb.ast;
 
+import com.rethinkdb.gen.exc.ReqlDriverError;
+import com.rethinkdb.gen.proto.TermType;
 import com.rethinkdb.model.Arguments;
 import com.rethinkdb.model.OptArgs;
 import com.rethinkdb.net.Connection;
-import com.rethinkdb.gen.proto.TermType;
-import com.rethinkdb.gen.exc.*;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.rethinkdb.net.ConnectionInstance;
 import org.json.simple.JSONArray;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Base class for all reql queries.
  */
@@ -59,6 +59,14 @@ public class ReqlAst {
 
     public <T> T run(Connection<? extends ConnectionInstance> conn) {
         return conn.run(this, new OptArgs());
+    }
+
+    public <T> T run(Connection<? extends ConnectionInstance> conn, OptArgs runOpts, Class<T> pojoClass) {
+        return Util.toPojo(conn.run(this, runOpts), pojoClass);
+    }
+
+    public <T> T run(Connection<? extends ConnectionInstance> conn, Class<T> pojoClass) {
+        return Util.toPojo(conn.run(this, new OptArgs()), pojoClass);
     }
 
     public void runNoReply(Connection conn){

--- a/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
@@ -8,23 +8,18 @@ import com.rethinkdb.model.MapObject;
 import com.rethinkdb.model.ReqlLambda;
 import com.rethinkdb.net.Cursor;
 
-import java.lang.*;
-import java.lang.reflect.*;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.*;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 
@@ -176,6 +171,7 @@ public class Util {
      * either by names and value types. Names of parameters are only available since Java 8
      * and only in case <code>javac</code> is run with <code>-parameters</code> argument.<br>
      * If the POJO's class doesn't satisfy the conditions, a ReqlDriverError is thrown.
+     * @param <T> POJO's type
      * @param pojoClass POJO's class to be instantiated
      * @param map Map to be converted
      * @return Instantiated POJO
@@ -275,6 +271,7 @@ public class Util {
 
     /**
      * Converts a cursor of String-to-Object maps to a list of POJOs using {@link #toPojo(Class, Map) toPojo}.
+     * @param <T> POJO's type
      * @param cursor Cursor to be iterated
      * @param pojoClass POJO's class
      * @return List of POJOs

--- a/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
@@ -6,7 +6,6 @@ import com.rethinkdb.gen.exc.ReqlDriverError;
 import com.rethinkdb.model.Arguments;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.model.ReqlLambda;
-import com.rethinkdb.net.Cursor;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -20,7 +19,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map;
-import java.util.stream.Stream;
 
 
 public class Util {
@@ -160,134 +158,5 @@ public class Util {
         catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
             throw new ReqlDriverError("Can't convert %s to a ReqlAst: %s", pojo, e.getMessage());
         }
-    }
-
-    /**
-     * Converts a String-to-Object map to a POJO using bean introspection.<br>
-     * The POJO's class must be public and satisfy one of the following conditions:<br>
-     * 1. Should have a public parameterless constructor and public setters for all properties
-     * in the map. Properties with no corresponding entries in the map would have default values<br>
-     * 2. Should have a public constructor with parameters matching the contents of the map
-     * either by names and value types. Names of parameters are only available since Java 8
-     * and only in case <code>javac</code> is run with <code>-parameters</code> argument.<br>
-     * If the POJO's class doesn't satisfy the conditions, a ReqlDriverError is thrown.
-     * @param <T> POJO's type
-     * @param pojoClass POJO's class to be instantiated
-     * @param map Map to be converted
-     * @return Instantiated POJO
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> T toPojo(Class pojoClass, Map<String, Object> map) {
-        try {
-            if (map == null) {
-                return null;
-            }
-
-            if (!Modifier.isPublic(pojoClass.getModifiers())) {
-                throw new IllegalAccessException(String.format("%s should be public", pojoClass));
-            }
-
-            Constructor[] allConstructors = pojoClass.getDeclaredConstructors();
-
-            if (getPublicParameterlessConstructors(allConstructors).count() == 1) {
-                return (T) constructViaPublicParameterlessConstructor(pojoClass, map);
-            }
-
-            Constructor[] constructors = getSuitablePublicParametrizedConstructors(allConstructors, map);
-
-            if (constructors.length == 1) {
-                return (T) constructViaPublicParametrizedConstructor(constructors[0], map);
-            }
-
-            throw new IllegalAccessException(String.format(
-                    "%s should have a public parameterless constructor " +
-                    "or a public constructor with %d parameters", pojoClass, map.keySet().size()));
-        } catch (InstantiationException | IllegalAccessException | IntrospectionException | InvocationTargetException e) {
-            throw new ReqlDriverError("Can't convert %s to a POJO: %s", map, e.getMessage());
-        }
-    }
-    
-    private static Stream<Constructor> getPublicParameterlessConstructors(Constructor[] constructors) {
-        return Arrays.stream(constructors).filter(constructor ->
-                Modifier.isPublic(constructor.getModifiers()) &&
-                constructor.getParameterCount() == 0
-        );
-    }
-    
-    @SuppressWarnings("unchecked")
-    private static Object constructViaPublicParameterlessConstructor(Class pojoClass, Map<String, Object> map)
-            throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
-        Object pojo = pojoClass.newInstance();
-        BeanInfo info = Introspector.getBeanInfo(pojoClass);
-
-        for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
-            String propertyName = descriptor.getName();
-
-            if (!map.containsKey(propertyName)) {
-                continue;
-            }
-
-            Method writer = descriptor.getWriteMethod();
-
-            if (writer != null && writer.getDeclaringClass() == pojoClass) {
-                Object value = map.get(propertyName);
-                Class valueClass = writer.getParameterTypes()[0];
-
-                writer.invoke(pojo, value instanceof Map
-                        ? toPojo(valueClass, (Map<String, Object>) value)
-                        : valueClass.cast(value));
-            }
-        }
-        
-        return pojo;
-    }
-
-    private static Constructor[] getSuitablePublicParametrizedConstructors(Constructor[] allConstructors, Map<String, Object> map) {
-        return Arrays.stream(allConstructors).filter(constructor ->
-                Modifier.isPublic(constructor.getModifiers()) &&
-                areParametersMatching(constructor.getParameters(), map)
-        ).toArray(Constructor[]::new);
-    }
-
-    private static boolean areParametersMatching(Parameter[] parameters, Map<String, Object> values) {
-        return Arrays.stream(parameters).allMatch(parameter ->
-                values.containsKey(parameter.getName()) &&
-                values.get(parameter.getName()).getClass() == parameter.getType()
-        );
-    }
-
-    private static Object constructViaPublicParametrizedConstructor(Constructor constructor, Map<String, Object> map)
-            throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
-        Object[] values = Arrays.stream(constructor.getParameters()).map(parameter -> {
-                Object value = map.get(parameter.getName());
-
-                return value instanceof Map
-                        ? toPojo(value.getClass(), (Map<String, Object>) value)
-                        : value;
-        }).toArray();
-
-        return constructor.newInstance(values);
-    }
-
-    /**
-     * Converts a cursor of String-to-Object maps to a list of POJOs using {@link #toPojo(Class, Map) toPojo}.
-     * @param <T> POJO's type
-     * @param cursor Cursor to be iterated
-     * @param pojoClass POJO's class
-     * @return List of POJOs
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> List<T> toPojoList(Cursor cursor, Class<T> pojoClass) {
-        List<T> list = new ArrayList<T>();
-
-        for (Object value : cursor) {
-            if (!(value instanceof Map)) {
-                throw new ReqlDriverError("Can't convert %s to a POJO, should be of Map<String, Object>", value);
-            }
-
-            list.add(toPojo(pojoClass, (Map<String, Object>) value));
-        }
-
-        return list;
     }
 }

--- a/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
@@ -183,6 +183,10 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static <T> T toPojo(Class pojoClass, Map<String, Object> map) {
         try {
+            if (map == null) {
+                return null;
+            }
+
             if (!Modifier.isPublic(pojoClass.getModifiers())) {
                 throw new IllegalAccessException(String.format("%s should be public", pojoClass));
             }
@@ -203,7 +207,6 @@ public class Util {
                     "%s should have a public parameterless constructor " +
                     "or a public constructor with %d parameters", pojoClass, map.keySet().size()));
         } catch (InstantiationException | IllegalAccessException | IntrospectionException | InvocationTargetException e) {
-            e.printStackTrace();
             throw new ReqlDriverError("Can't convert %s to a POJO: %s", map, e.getMessage());
         }
     }

--- a/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
@@ -6,6 +6,7 @@ import com.rethinkdb.gen.exc.ReqlDriverError;
 import com.rethinkdb.model.Arguments;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.model.ReqlLambda;
+import com.rethinkdb.net.Cursor;
 
 import java.lang.*;
 import java.nio.ByteBuffer;
@@ -173,6 +174,7 @@ public class Util {
      * @param pojoClass POJO's class to be instantiated
      * @return Instantiated POJO
      */
+    @SuppressWarnings("unchecked")
     public static <T> T toPojo(Map<String, Object> map, Class<T> pojoClass) {
         try {
             if (!Modifier.isPublic(pojoClass.getModifiers())) {
@@ -214,5 +216,26 @@ public class Util {
             e.printStackTrace();
             throw new ReqlDriverError("Can't convert %s to a POJO: %s", map, e.getMessage());
         }
+    }
+
+    /**
+     * Converts a cursor of String-to-Object maps to a list of POJOs using {@link #toPojo(Map, Class) toPojo}.
+     * @param cursor Cursor to be iterated
+     * @param pojoClass POJO's class
+     * @return List of POJOs
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> toPojoList(Cursor cursor, Class<T> pojoClass) {
+        List<T> list = new ArrayList<T>();
+
+        for (Object value : cursor) {
+            if (!(value instanceof Map)) {
+                throw new ReqlDriverError("Can't convert %s to a POJO, should be of Map<String, Object>", value);
+            }
+
+            list.add(toPojo((Map<String, Object>) value, pojoClass));
+        }
+
+        return list;
     }
 }

--- a/drivers/java/src/main/java/com/rethinkdb/net/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Util.java
@@ -1,8 +1,17 @@
 package com.rethinkdb.net;
 
+import com.rethinkdb.gen.exc.ReqlDriverError;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Stream;
 
 public class Util {
 
@@ -24,4 +33,116 @@ public class Util {
         return new String(buf.array(), StandardCharsets.UTF_8);
     }
 
+    public static <T, P> T convertToPojo(Object value, Optional<Class<P>> pojoClass) {
+        return !pojoClass.isPresent() || !(value instanceof Map)
+                ? (T) value
+                : (T) toPojo(pojoClass.get(), (Map<String, Object>) value);
+    }
+
+    /**
+     * Converts a String-to-Object map to a POJO using bean introspection.<br>
+     * The POJO's class must be public and satisfy one of the following conditions:<br>
+     * 1. Should have a public parameterless constructor and public setters for all properties
+     * in the map. Properties with no corresponding entries in the map would have default values<br>
+     * 2. Should have a public constructor with parameters matching the contents of the map
+     * either by names and value types. Names of parameters are only available since Java 8
+     * and only in case <code>javac</code> is run with <code>-parameters</code> argument.<br>
+     * If the POJO's class doesn't satisfy the conditions, a ReqlDriverError is thrown.
+     * @param <T> POJO's type
+     * @param pojoClass POJO's class to be instantiated
+     * @param map Map to be converted
+     * @return Instantiated POJO
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T toPojo(Class<T> pojoClass, Map<String, Object> map) {
+        try {
+            if (map == null) {
+                return null;
+            }
+
+            if (!Modifier.isPublic(pojoClass.getModifiers())) {
+                throw new IllegalAccessException(String.format("%s should be public", pojoClass));
+            }
+
+            Constructor[] allConstructors = pojoClass.getDeclaredConstructors();
+
+            if (getPublicParameterlessConstructors(allConstructors).count() == 1) {
+                return (T) constructViaPublicParameterlessConstructor(pojoClass, map);
+            }
+
+            Constructor[] constructors = getSuitablePublicParametrizedConstructors(allConstructors, map);
+
+            if (constructors.length == 1) {
+                return (T) constructViaPublicParametrizedConstructor(constructors[0], map);
+            }
+
+            throw new IllegalAccessException(String.format(
+                    "%s should have a public parameterless constructor " +
+                            "or a public constructor with %d parameters", pojoClass, map.keySet().size()));
+        } catch (InstantiationException | IllegalAccessException | IntrospectionException | InvocationTargetException e) {
+            throw new ReqlDriverError("Can't convert %s to a POJO: %s", map, e.getMessage());
+        }
+    }
+
+    private static Stream<Constructor> getPublicParameterlessConstructors(Constructor[] constructors) {
+        return Arrays.stream(constructors).filter(constructor ->
+                Modifier.isPublic(constructor.getModifiers()) &&
+                        constructor.getParameterCount() == 0
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object constructViaPublicParameterlessConstructor(Class pojoClass, Map<String, Object> map)
+            throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+        Object pojo = pojoClass.newInstance();
+        BeanInfo info = Introspector.getBeanInfo(pojoClass);
+
+        for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
+            String propertyName = descriptor.getName();
+
+            if (!map.containsKey(propertyName)) {
+                continue;
+            }
+
+            Method writer = descriptor.getWriteMethod();
+
+            if (writer != null && writer.getDeclaringClass() == pojoClass) {
+                Object value = map.get(propertyName);
+                Class valueClass = writer.getParameterTypes()[0];
+
+                writer.invoke(pojo, value instanceof Map
+                        ? toPojo(valueClass, (Map<String, Object>) value)
+                        : valueClass.cast(value));
+            }
+        }
+
+        return pojo;
+    }
+
+    private static Constructor[] getSuitablePublicParametrizedConstructors(Constructor[] allConstructors, Map<String, Object> map) {
+        return Arrays.stream(allConstructors).filter(constructor ->
+                Modifier.isPublic(constructor.getModifiers()) &&
+                        areParametersMatching(constructor.getParameters(), map)
+        ).toArray(Constructor[]::new);
+    }
+
+    private static boolean areParametersMatching(Parameter[] parameters, Map<String, Object> values) {
+        return Arrays.stream(parameters).allMatch(parameter ->
+                values.containsKey(parameter.getName()) &&
+                        values.get(parameter.getName()).getClass() == parameter.getType()
+        );
+    }
+
+    private static Object constructViaPublicParametrizedConstructor(Constructor constructor, Map<String, Object> map)
+            throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+        Object[] values = Arrays.stream(constructor.getParameters()).map(parameter -> {
+            Object value = map.get(parameter.getName());
+
+            return value instanceof Map
+                    ? toPojo(value.getClass(), (Map<String, Object>) value)
+                    : value;
+        }).toArray();
+
+        return constructor.newInstance(values);
+    }
 }

--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -12,9 +12,10 @@ import java.util.Arrays;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import gen.TestingFramework;
 
 public class RethinkDBTest{
@@ -242,4 +243,19 @@ public class RethinkDBTest{
             r.db("test").tableDrop(tblName).run(conn);
         }
     }
+    }
+
+    @Test
+    public void testTableSelectOfPojo() {
+        TestPojo pojo = new TestPojo("foo", new TestPojoInner(42L, true));
+        Map<String, Object> pojoResult = r.db(dbName).table(tableName).insert(pojo).run(conn);
+        assertEquals(1L, pojoResult.get("inserted"));
+
+        String key = (String) ((List) pojoResult.get("generated_keys")).get(0);
+        TestPojo result = r.db(dbName).table(tableName).get(key).run(conn, TestPojo.class);
+        assertEquals("foo", result.getStringProperty());
+        assertTrue(42L == result.getPojoProperty().getLongProperty());
+        assertEquals(true, result.getPojoProperty().getBooleanProperty());
+    }
 }
+

--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -4,19 +4,18 @@ import com.rethinkdb.gen.exc.ReqlQueryLogicError;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.model.OptArgs;
 import com.rethinkdb.net.Connection;
+import gen.TestingFramework;
 import junit.framework.Assert;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
-import java.util.Arrays;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import gen.TestingFramework;
 
 public class RethinkDBTest{
 
@@ -242,7 +241,6 @@ public class RethinkDBTest{
             r.expr(r.array("optargs", "conn_default")).forEach(r::dbDrop).run(conn);
             r.db("test").tableDrop(tblName).run(conn);
         }
-    }
     }
 
     @Test

--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -253,9 +253,34 @@ public class RethinkDBTest{
 
         String key = (String) ((List) pojoResult.get("generated_keys")).get(0);
         TestPojo result = r.db(dbName).table(tableName).get(key).run(conn, TestPojo.class);
+
         assertEquals("foo", result.getStringProperty());
         assertTrue(42L == result.getPojoProperty().getLongProperty());
         assertEquals(true, result.getPojoProperty().getBooleanProperty());
+    }
+
+    @Test
+    public void testTableSelectOfPojoList() {
+        TestPojo pojoOne = new TestPojo("foo", new TestPojoInner(42L, true));
+        TestPojo pojoTwo = new TestPojo("bar", new TestPojoInner(53L, false));
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(pojoOne).run(conn);
+        Map<String, Object> pojoTwoResult = r.db(dbName).table(tableName).insert(pojoTwo).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+        assertEquals(1L, pojoTwoResult.get("inserted"));
+
+        List<TestPojo> result = r.db(dbName).table(tableName).runList(conn, TestPojo.class);
+        assertEquals(2, result.size());
+
+        TestPojo pojoOneSelected = "foo".equals(result.get(0).getStringProperty()) ? result.get(0) : result.get(1);
+        TestPojo pojoTwoSelected = "bar".equals(result.get(0).getStringProperty()) ? result.get(0) : result.get(1);
+
+        assertEquals("foo", pojoOneSelected.getStringProperty());
+        assertTrue(42L == pojoOneSelected.getPojoProperty().getLongProperty());
+        assertEquals(true, pojoOneSelected.getPojoProperty().getBooleanProperty());
+
+        assertEquals("bar", pojoTwoSelected.getStringProperty());
+        assertTrue(53L == pojoTwoSelected.getPojoProperty().getLongProperty());
+        assertEquals(false, pojoTwoSelected.getPojoProperty().getBooleanProperty());
     }
 }
 

--- a/drivers/java/src/test/java/TestPojo.java
+++ b/drivers/java/src/test/java/TestPojo.java
@@ -1,10 +1,13 @@
+/**
+ * Has both public parameterless constructor and public parametrized constructor
+ */
 public class TestPojo {
     private String stringProperty;
     private TestPojoInner pojoProperty;
 
     public TestPojo() {}
 
-    TestPojo(String stringProperty, TestPojoInner pojoProperty) {
+    public TestPojo(String stringProperty, TestPojoInner pojoProperty) {
         this.stringProperty = stringProperty;
         this.pojoProperty = pojoProperty;
     }

--- a/drivers/java/src/test/java/TestPojo.java
+++ b/drivers/java/src/test/java/TestPojo.java
@@ -1,0 +1,17 @@
+public class TestPojo {
+    private String stringProperty;
+    private TestPojoInner pojoProperty;
+
+    public TestPojo() {}
+
+    TestPojo(String stringProperty, TestPojoInner pojoProperty) {
+        this.stringProperty = stringProperty;
+        this.pojoProperty = pojoProperty;
+    }
+
+    public String getStringProperty() { return this.stringProperty; }
+    public TestPojoInner getPojoProperty() { return this.pojoProperty; }
+
+    public void setStringProperty(String stringProperty) { this.stringProperty = stringProperty; }
+    public void setPojoProperty(TestPojoInner pojoProperty) { this.pojoProperty = pojoProperty; }
+}

--- a/drivers/java/src/test/java/TestPojoInner.java
+++ b/drivers/java/src/test/java/TestPojoInner.java
@@ -1,0 +1,17 @@
+public class TestPojoInner {
+    private Long longProperty;
+    private Boolean booleanProperty;
+
+    public TestPojoInner() {}
+
+    TestPojoInner(Long longProperty, Boolean booleanProperty) {
+        this.longProperty = longProperty;
+        this.booleanProperty = booleanProperty;
+    }
+
+    public Long getLongProperty() { return this.longProperty; }
+    public Boolean getBooleanProperty() { return this.booleanProperty; }
+
+    public void setLongProperty(Long longProperty) { this.longProperty = longProperty; }
+    public void setBooleanProperty(Boolean booleanProperty) { this.booleanProperty = booleanProperty; }
+}

--- a/drivers/java/src/test/java/TestPojoInner.java
+++ b/drivers/java/src/test/java/TestPojoInner.java
@@ -1,10 +1,11 @@
+/**
+ * Has only public parametrized constructor and no public parameterless constructor
+ */
 public class TestPojoInner {
     private Long longProperty;
     private Boolean booleanProperty;
 
-    public TestPojoInner() {}
-
-    TestPojoInner(Long longProperty, Boolean booleanProperty) {
+    public TestPojoInner(Long longProperty, Boolean booleanProperty) {
         this.longProperty = longProperty;
         this.booleanProperty = booleanProperty;
     }


### PR DESCRIPTION
Added support for select and insert operations on Java bean classes, not only on boxed primitive types, lists and maps. You can select one typed object:

```java
Pojo pojo = r.db("db").table("table").get("reql-expr").run(conn, Pojo.class);
```
...or a list of objects:
```java
List<Pojo> pojoList = r.db("db").table("table").get("reql-expr").runList(conn, Pojo.class);
```

Objects are constructed from ```Map<String, Object>``` instances selected from RethinkDB using reflection. Insertion of typed objects employs the same technique:

```java
Pojo pojo = new Pojo("foo", new NestedPojo(42L, true));
r.db("db").table("table").insert(pojo).run(conn);
```

Merging this code to Java driver would be extremely useful for me and, I presume, to the community, because working with maps and primitives is quite painful in Java.

I bet my code removes a portion of that pain :smile: 