### PR TITLE
Date precision loss in Java driver

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Util.java
@@ -77,7 +77,7 @@ public class Util {
 
         if (val instanceof Date) {
             TimeZone tz = TimeZone.getTimeZone("UTC");
-            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ");
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
             df.setTimeZone(tz);
             return Iso8601.fromString(df.format((Date) val));
         }

--- a/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
@@ -99,7 +99,7 @@ public class Converter {
             Double epoch_time = (Double) obj.get("epoch_time");
             String timezone = (String) obj.get("timezone");
             Calendar calendar = Calendar.getInstance();
-            calendar.setTimeInMillis(epoch_time.longValue() * 1000);
+            calendar.setTimeInMillis((long) (epoch_time * 1000));
             calendar.setTimeZone(TimeZone.getTimeZone(timezone));
             return calendar.getTime();
         } catch (Exception ex) {

--- a/drivers/java/src/test/java/RethinkDBTest.java
+++ b/drivers/java/src/test/java/RethinkDBTest.java
@@ -4,16 +4,15 @@ import com.rethinkdb.gen.exc.ReqlQueryLogicError;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.net.Connection;
 import junit.framework.Assert;
-
-import static org.junit.Assert.assertEquals;
-
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
 
 public class RethinkDBTest{
 
@@ -114,6 +113,13 @@ public class RethinkDBTest{
 
         Long nmb10 = r.expr("0xa").coerceTo("NUMBER").run(conn);
         Assert.assertEquals(nmb10.longValue(), 10L);
+    }
+
+    @Test
+    public void testDate() {
+        Date date = new Date();
+        Date result = r.expr(date).run(conn);
+        Assert.assertEquals(date.getTime(), result.getTime());
     }
 
     @Test


### PR DESCRIPTION
Upstream implementation of Date-to-ReqlAst conversion causes a precision loss: seconds and milliseconds are gone. The conversion of value returned from database also causes milliseconds to be lost, because the double value is truncated before it's multiplied by 1000.

Fixed both issues and added a test.