### PR TITLE
feat(raft_leader): display raft leader for table in table_status

### DIFF
--- a/src/clustering/administration/tables/calculate_status.cc
+++ b/src/clustering/administration/tables/calculate_status.cc
@@ -79,6 +79,9 @@ void get_table_status(
     status_out->total_loss = false;
     status_out->config = config;
 
+    /* Determine raft leader for this table */
+    table_meta_client->get_raft_leader(table_id, interruptor, &status_out->raft_leader);
+
     /* Send the status query to every server for the table. */
     bool all_replicas_ready;
     try {

--- a/src/clustering/administration/tables/calculate_status.hpp
+++ b/src/clustering/administration/tables/calculate_status.hpp
@@ -57,6 +57,7 @@ public:
     table_config_and_shards_t config;
     std::map<server_id_t, range_map_t<key_range_t::right_bound_t,
         table_shard_status_t> > server_shards;
+    boost::optional<server_id_t> raft_leader;
     std::set<server_id_t> disconnected;
     server_name_map_t server_names;
 };

--- a/src/clustering/administration/tables/table_status.cc
+++ b/src/clustering/administration/tables/table_status.cc
@@ -88,6 +88,18 @@ ql::datum_t convert_shard_status_to_datum(
     return std::move(shard_builder).to_datum();
 }
 
+ql::datum_t convert_raft_leader_to_datum(
+        const table_status_t &status,
+        admin_identifier_format_t identifier_format) {
+    if (static_cast<bool>(status.raft_leader)) {
+      return convert_name_or_uuid_to_datum(
+          status.server_names.get(*status.raft_leader),
+          *status.raft_leader, identifier_format);
+    }
+
+    return ql::datum_t::null();
+}
+
 ql::datum_t convert_table_status_to_datum(
         const table_status_t &status,
         admin_identifier_format_t identifier_format) {
@@ -116,6 +128,10 @@ ql::datum_t convert_table_status_to_datum(
         }
         builder.overwrite("shards", std::move(shards_builder).to_datum());
     }
+
+    // add raft leader information
+    builder.overwrite("raft_leader",
+      convert_raft_leader_to_datum(status, identifier_format));
 
     ql::datum_object_builder_t status_builder;
     status_builder.overwrite("ready_for_outdated_reads", ql::datum_t::boolean(

--- a/src/clustering/table_manager/table_meta_client.cc
+++ b/src/clustering/table_manager/table_meta_client.cc
@@ -230,6 +230,23 @@ void table_meta_client_t::get_shard_status(
     }
 }
 
+void table_meta_client_t::get_raft_leader(
+        const namespace_id_t &table_id,
+        signal_t *interruptor_on_caller,
+        boost::optional<server_id_t> *raft_leader_out)
+        THROWS_ONLY(interrupted_exc_t, no_such_table_exc_t, failed_table_op_exc_t) {
+    cross_thread_signal_t interruptor(interruptor_on_caller, home_thread());
+    on_thread_t thread_switcher(home_thread());
+
+    table_manager_directory->read_all(
+      [&](const std::pair<peer_id_t, namespace_id_t> &key,
+          const table_manager_bcard_t *bcard) {
+          if (key.second == table_id && static_cast<bool>(bcard->leader)) {
+            *raft_leader_out = boost::make_optional(bcard->server_id);
+          }
+      });
+}
+
 void table_meta_client_t::get_debug_status(
         const namespace_id_t &table_id,
         all_replicas_ready_mode_t all_replicas_ready_mode,

--- a/src/clustering/table_manager/table_meta_client.hpp
+++ b/src/clustering/table_manager/table_meta_client.hpp
@@ -147,6 +147,14 @@ public:
         bool *all_replicas_ready_out)
         THROWS_ONLY(interrupted_exc_t, no_such_table_exc_t, failed_table_op_exc_t);
 
+    /* `get_raft_leader()` fetches raft leader from the table directory.
+    This is for displaying raft information in `rethinkdb.table_status`. */
+    void get_raft_leader(
+        const namespace_id_t &table_id,
+        signal_t *interruptor,
+        boost::optional<server_id_t> *raft_leader_out)
+        THROWS_ONLY(interrupted_exc_t, no_such_table_exc_t, failed_table_op_exc_t);
+
     /* `get_debug_status()` fetches all status information from all servers. This is for
     displaying in `rethinkdb._debug_table_status`. */
     void get_debug_status(


### PR DESCRIPTION
This adds support for tracking the raft leader for each table and
displaying that information per-table in the table_status
artificial table.

relates to issue https://github.com/rethinkdb/rethinkdb/issues/4902

I know there probably is a lot to review here, as I'm clearly not very familiar with your code base. Off the top of my head I have the following comments/concerns:

  * The serialized form of `table_status_response_t` has changed, making it incompatible with older versions of the database. I had considered packing this information into `table_raft_state_t` but wasn't sure if that would even make a difference, so it would be helpful if someone could advise here (I tacked it on to the end of the serialization in case order mattered here).

  * The location of the data itself is just set as `raft_leader` on the top level of the `table_status` documents, this is easily changeable and I think it's just a matter of consensus on your side of where it belongs (`raft_leader` or `raft.leader` etc)

  * Currently the raft_leader information piggybacks a request for `want_raft_state` which may be misleading, but let's me get away with not having to change the request format.

  * The way I'm currently getting the server name seems a bit unorthodox, there are comments in your code describing its flakey nature in production

  * In order to determine if a table is a raft leader I'm statically casting the `leader` member of a table manager, and before that process I use the leader rw locker. In other parts of the codebase where you something similar you allow for the possibility of it already being locked (sort of looks like a try_lock) due to leadership changes - this might be trouble if I don't do it here


Anyway, I'm sure there's more but it's a start.