### PR TITLE
Java Driver: Fixes ordering of Funcall Arguments in the AST.

### DIFF
--- a/drivers/java/templates/ast/Funcall.java
+++ b/drivers/java/templates/ast/Funcall.java
@@ -1,0 +1,18 @@
+<%inherit file="../AstSubclass.java" />
+
+<%block name="special_methods">
+    @Override
+    protected Object build()
+    {
+        /*
+          This object should be constructed with arguments first, and the
+          function itself as the last parameter.  This makes it easier for
+          the places where this object is constructed.  The actual wire
+          format is function first, arguments last, so we flip them around
+          when building the AST.
+        */
+        ReqlAst func = args.remove(args.size()-1);
+        args.add(0, func);
+        return super.build();
+    }
+</%block>


### PR DESCRIPTION
For @deontologician ,

After some protocol debugging in the C# driver, it appears the Java driver is also affected. Per the Python source code:

```
class FunCall(RqlQuery):
    tt = pTerm.FUNCALL

    # This object should be constructed with arguments first, and the
    # function itself as the last parameter.  This makes it easier for
    # the places where this object is constructed.  The actual wire
    # format is function first, arguments last, so we flip them around
    # before passing it down to the base class constructor.
    def __init__(self, *args):
        if len(args) == 0:
            raise ReqlDriverError("Expected 1 or more arguments but found 0.")
        args = [func_wrap(args[-1])] + list(args[:-1])
    .....
```

Seems like the actual wire-line format is function first, arguments last, so we flip them around when building the AST.

This PR adds a `Funcall` template that overrides `build()` moving the last argument to the first. It's been about 14 years since I wrote Java, so I hope this is correct. :)

This should also get a few more unit tests to pass.

P.S.: I tried to keep the PR as small as possible so the AST should get regenerated.