### PR TITLE
Properly quote JS object keys in toString()

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -457,7 +457,7 @@ intsp = (seq) ->
     return res
 
 kved = (optargs) ->
-    ['{', intsp([k, ': ', v] for own k,v of optargs), '}']
+    ['{', intsp([JSON.stringify(k), ': ', v] for own k,v of optargs), '}']
 
 intspallargs = (args, optargs) ->
     argrepr = []

--- a/test/rql_test/connections/tostring.mocha
+++ b/test/rql_test/connections/tostring.mocha
@@ -1,0 +1,27 @@
+/////
+// Tests the driver API for toString() method on queries
+/////
+
+var assert = require('assert');
+var path = require('path');
+
+// -- load rethinkdb from the proper location
+
+var r = require(path.resolve(__dirname, '..', 'importRethinkDB.js')).r;
+
+describe('Javascript query toString()', function(){
+
+    var testCases = [
+        'r.table("turtles").filter(r.row("firstName").match("ny$"))',
+        'r.table("posts").orderBy({"index": r.desc("date")})',
+        'r.db("test").table("sometable").insert({"-x-y-z": 2})',
+    ];
+
+    it('works for various queries', function(){
+        testCases.forEach(function(queryString){
+            var query = eval(queryString);
+            assert.equal(eval(queryString).toString(), queryString);
+        });
+    });
+
+});


### PR DESCRIPTION
This addresses part of issue #2372.

Before this change:

  > r.table('turtles', {readMode: 'single'}).toString()
  'r.table("turtles", {readMode: "single"})'

  > r.expr({'-x-y-z': 2}).merge({b: [1,2]}).toString()
  'r({-x-y-z: "b"}).merge({b: [1, 2]})'

After this change:

  > r.table('turtles', {readMode: 'single'}).toString()
  'r.table("turtles", {"readMode": "single"})'

  > r.expr({'-x-y-z': 2}).merge({b: [1,2]}).toString()
  'r({"-x-y-z": "b"}).merge({"b": [1, 2]})'