### PR TITLE
Allow for local publishing of both Ivy and Maven repos.

### DIFF
--- a/drivers/java/build.gradle
+++ b/drivers/java/build.gradle
@@ -64,8 +64,8 @@ repositories {
     ivy {
         url "${System.properties['user.home']}/.ivy2/local"
         layout 'pattern', {
-            artifact "[organisation]/[module]/[revision]/[artifact](-[classifier])-[revision](.[ext])"
-            ivy "[organisation]/[module]/[revision]/[artifact](-[classifier])-[revision](.[ext])"
+            artifact "[organisation]/[module]/jars/[artifact](-[classifier])-[revision](.[ext])"
+            ivy "[organisation]/[module]/[artifact](-[classifier])-[revision](.[ext])"
             }
     } 
 }

--- a/drivers/java/build.gradle
+++ b/drivers/java/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'ivy-publish'
 apply plugin: 'signing'
 
 tasks.withType(JavaCompile) {
@@ -57,17 +59,37 @@ test {
 
 buildDir = '../../build/drivers/java/gradle'
 
+
+repositories {
+    ivy {
+        url "${System.properties['user.home']}/.ivy2/local"
+        layout 'pattern', {
+            artifact "[organisation]/[module]/[revision]/[artifact](-[classifier])-[revision](.[ext])"
+            ivy "[organisation]/[module]/[revision]/[artifact](-[classifier])-[revision](.[ext])"
+            }
+    } 
+}
+publishing {
+    publications {
+        ivyJava(IvyPublication) {
+            from components.java
+        }
+    }
+    repositories {
+      add project.repositories.ivy
+    }
+}
 uploadArchives {
   repositories {
     mavenDeployer {
       beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
       repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
       }
 
       snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
       }
 
       pom.project {


### PR DESCRIPTION
While evaluating the new Java driver, I found it easiest to publish to my local repo instead of trying to workaround via a remote snapshots repository. I think this will come in handy for others, especially Scala developers who use SBT and rely on local Ivy repo publication.