### PR TITLE
Only set __proto__ in TermBase if it exists (attempt 2)

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -52,9 +52,12 @@ hasImplicit = (args) ->
 class TermBase
     showRunWarning: true
     constructor: ->
-        self = (ar (field) -> self.bracket(field))
-        self.__proto__ = @.__proto__
-        return self
+        if {}.__proto__ != undefined
+            self = (ar (field) -> self.bracket(field))
+            self.__proto__ = @.__proto__
+            return self
+        else
+            @
 
     run: (connection, options, callback) ->
         # Valid syntaxes are


### PR DESCRIPTION
This is a rewrite of PR https://github.com/rethinkdb/rethinkdb/pull/4534 to resolve issue https://github.com/rethinkdb/rethinkdb/issues/162 (IE10 support in the JS driver).

The only difference is replacing `self` with `return self`. I'm not familiar with CoffeeScript, but it's now closer to the original code. The tests that were failing before are now passing for me.