### PR TITLE
Use liressl

### DIFF
--- a/configure
+++ b/configure
@@ -24,7 +24,7 @@ init () {
     must_fetch_list='bluebird v8'
     please_fetch_list="handlebars gtest re2 $must_fetch_list"
 
-    optional_libs="gtest termcap boost_system ssl"
+    optional_libs="gtest termcap boost_system libressl"
     required_libs="protobuf v8 re2 z crypto curl"
     other_libs="unwind tcmalloc jemalloc"
     all_libs="$required_libs $optional_libs $other_libs"
@@ -1128,8 +1128,8 @@ lib_pkg_name () {
         tcmalloc) echo gperftools ;;
         z) echo zlib ;;
         boost_system) echo boost ;;
-        crypto) echo openssl ;;
-        ssl) echo openssl ;;
+        crypto) echo libressl ;;
+        ssl) echo libressl ;;
         *) echo "$1" ;;
     esac
 }

--- a/mk/support/pkg/libressl.sh
+++ b/mk/support/pkg/libressl.sh
@@ -1,0 +1,21 @@
+
+version=2.3.1
+
+src_url=http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$version.tar.gz
+
+pkg_configure () {
+    if [[ "$CROSS_COMPILING" = 1 ]]; then
+        configure_flags="--host=$($CXX -dumpmachine)"
+    fi
+    in_dir "$build_dir" ./configure --prefix="$(niceabspath "$install_dir")" ${configure_flags:-}"$@"
+}
+
+pkg_link-flags () {
+    local lib="$install_dir/lib/lib$(lc $1).a"
+    if [[ ! -e "$lib" ]]; then
+        echo "pkg.sh: error: static library was not built: $lib" >&2
+        exit 1
+    fi
+
+    echo "$lib"
+}


### PR DESCRIPTION
Hi,

  I was having trouble getting rethinkdb to compile under OSX El Capitan with XCode 7.1. It could not find the openssl headers so I thought I'd have a go at making things work with libressl instead of openssl. It seems to compile now, however I can't be sure that the SSL stuff is working as I've not yet been able to find how to get things to use it.

Daniel