### PR TITLE
Use Integer.BYTES and Long.BYTES instead of hardcoding size

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/ast/Query.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/Query.java
@@ -63,7 +63,7 @@ public class Query {
         }
         String queryJson = queryArr.toJSONString();
         byte[] queryBytes = queryJson.getBytes(StandardCharsets.UTF_8);
-        ByteBuffer bb = Util.leByteBuffer(8 + 4 + queryBytes.length)
+        ByteBuffer bb = Util.leByteBuffer(Long.BYTES + Integer.BYTES + queryBytes.length)
             .putLong(token)
             .putInt(queryBytes.length)
             .put(queryBytes);

--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -33,7 +33,7 @@ public class Connection<C extends ConnectionInstance> {
     private Connection(Builder<C> builder) {
         dbname = builder.dbname;
         String authKey = builder.authKey.orElse("");
-        handshake = Util.leByteBuffer(4 + 4 + authKey.length() + 4)
+        handshake = Util.leByteBuffer(Integer.BYTES + Integer.BYTES + authKey.length() + Integer.BYTES)
                 .putInt(Version.V0_4.value)
                 .putInt(authKey.length())
                 .put(authKey.getBytes())


### PR DESCRIPTION
Using Integer.BYTES and Long.BYTES makes the intent of the byte handling code clearer, and less error prone if there are future changes to these sections.

cc @deontologician 