### PR TITLE
Support specifying a custom nesting depth to rethinkdb import

### DIFF
--- a/drivers/python/rethinkdb/_import.py
+++ b/drivers/python/rethinkdb/_import.py
@@ -16,7 +16,7 @@ PY3 = sys.version > '3'
 #json parameters
 json_read_chunk_size = 32 * 1024
 json_max_buffer_size = 128 * 1024 * 1024
-max_nesting_depth = 20
+max_nesting_depth = 100
 try:
     import cPickle as pickle
 except ImportError:


### PR DESCRIPTION
This is needed when you want to export and import some documents deeper than the default nesting depth limit of 20.