### PR TITLE
fix a java compiler error in eclipse.

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Converter.java
@@ -64,7 +64,7 @@ public class Converter {
                                     entry.getKey(),
                                     convertPseudotypes(entry.getValue(), fmt)
                             ),
-                            HashMap::putAll
+                            HashMap<String, Object>::putAll
                     );
         } else {
             return obj;


### PR DESCRIPTION
When loading the java driver in Eclipse IDE 4.5.1 gives an error
```
The type HashMap does not define putAll(Object, Object) that is applicable here	Converter.java	/drivers-java/src/main/java/com/rethinkdb/net	line 67
```

Specifying an explicit  type argument fixes the problem.
