### PR TITLE
Add information about Twisted requirement

### DIFF
--- a/test/rql_test/README.md
+++ b/test/rql_test/README.md
@@ -25,11 +25,11 @@ make -C ../..
 sudo npm install -g mocha
 ```
 
-You also need `twisted` library for Python, with OpenSSL support. You might get it from your system's repositories or install it using `pip` (make sure you install it for correct Python version):
+You also need `twisted` library for Python, with OpenSSL support. Many systems have these installed, but if not they can be installed using `pip` (make sure you install it for correct Python version):
 
 ```
-pip install twisted
-pip install pyopenssl
+sudo pip install twisted
+sudo pip install pyopenssl
 ```
 
 ### Basic Usage

--- a/test/rql_test/README.md
+++ b/test/rql_test/README.md
@@ -25,6 +25,13 @@ make -C ../..
 sudo npm install -g mocha
 ```
 
+You also need `twisted` library for Python, with OpenSSL support. You might get it from your system's repositories or install it using `pip` (make sure you install it for correct Python version):
+
+```
+pip install twisted
+pip install pyopenssl
+```
+
 ### Basic Usage
 
 `./test-runner` runs all the tests.


### PR DESCRIPTION
Apparently you also need Python's Twisted to run RQL tests (at least it shouted at me running Ruby tests when I did not have it installed). This might be a useful information to add to RQL tests Readme.