### PR TITLE
`Object#timeout` is depreciated, updated to use `Timeout#timeout`

### DIFF
--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -812,7 +812,7 @@ module RethinkDB
     def start_listener
       class << @socket
         def maybe_timeout(sec=nil, &b)
-          sec ? timeout(sec, &b) : b.call
+          sec ? Timeout::timeout(sec, &b) : b.call
         end
         def read_exn(len, timeout_sec=nil)
           maybe_timeout(timeout_sec) {


### PR DESCRIPTION
Ran across this earlier with the Ruby driver:

`Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.`

`#start_listener` in `net.rb` was making a call to `Object#timeout` which is [depreciated](http://ruby-doc.org/stdlib-2.1.0/libdoc/timeout/rdoc/Object.html). Per the depreciation notice, I switched the call over to `Timeout.timeout` and checked it once more to verify it was OK.

Here's my Rails Console output before and after this patch:

```
irb(main):001:0> User.create(:name => 'Nico')
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/josh/.rbenv/versions/2.3.0-preview2/lib/ruby/gems/2.3.0/gems/rethinkdb-2.2.0.1/lib/net.rb:815:in `maybe_timeout': Object#timeout is deprecated, use Timeout.timeout instead.
Connected to rethinkdb://localhost:28015/nb_app_development
[   5.1ms] r.table("users").insert( {"name" => "Nico", "id" => "2ndkD3nENWfezK", "created_at" => r.expr(2015-12-22 01:41:06 +0000), "updated_at" => r.expr(2015-12-22 01:41:06 +0000)})
=> #<User id: "2ndkD3nENWfezK", created_at: 2015-12-21 20:41:06 -0500, updated_at: 2015-12-21 20:41:06 -0500, name: "Nico">
```

```
irb(main):002:0> User.create(:name => 'Josh')
[   1.3ms] r.table("users").insert( {"name" => "Josh", "id" => "2ndmgh7UwCE5Te", "created_at" => r.expr(2015-12-22 01:44:57 +0000), "updated_at" => r.expr(2015-12-22 01:44:57 +0000)})
=> #<User id: "2ndmgh7UwCE5Te", created_at: 2015-12-21 20:44:57 -0500, updated_at: 2015-12-21 20:44:57 -0500, name: "Josh">
```