### PR TITLE
Fix Java driver bug where multiple reads overwrite the buffer.

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/SocketWrapper.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/SocketWrapper.java
@@ -143,7 +143,7 @@ public class SocketWrapper {
                 Long timeout = Math.max(0L, deadline.get() - System.currentTimeMillis());
                 socket.setSoTimeout(timeout.intValue());
             }
-            bytesRead += readStream.read(buf);
+            bytesRead += readStream.read(buf, bytesRead, bufsize-bytesRead);
         } catch (SocketTimeoutException ste) {
             throw new TimeoutException("Read timed out." + ste.getMessage());
         } catch (IOException ex) {


### PR DESCRIPTION
The driver currently only works if the socket is able to read everything in one call.