### PR TITLE
Bumped Java driver development version to 2.2-beta-3-SNAPSHOT.

### DIFF
--- a/drivers/java/build.gradle
+++ b/drivers/java/build.gradle
@@ -8,7 +8,7 @@ tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
 }
 
-version = '2.2-beta-2-SNAPSHOT'
+version = '2.2-beta-3-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("-SNAPSHOT")
 group = "com.rethinkdb"
 archivesBaseName = "rethinkdb-driver"


### PR DESCRIPTION
@deontologician with the release of `beta-2`, we should bump to `beta-3-SNAPSHOT`, right?