### PR TITLE
Java: ResponseNotes was never used.

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Response.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Response.java
@@ -48,7 +48,8 @@ class Response {
         if(jsonResp.containsKey("e")){
             res.setErrorType(((Long)jsonResp.get("e")).intValue());
         }
-        return res.setProfile((JSONArray) jsonResp.getOrDefault("p", null))
+        return res.setNotes(responseNotes)
+                .setProfile((JSONArray) jsonResp.getOrDefault("p", null))
                 .setBacktrace((JSONArray) jsonResp.getOrDefault("b", null))
                 .setData((JSONArray) jsonResp.getOrDefault("r", new JSONArray()))
                 .build();


### PR DESCRIPTION
Discovered in `C#/.NET` driver by inspection analyzers. #5390 related. `Cursor.isFeed` would still always be false.