### PR TITLE
Remove error log message from normal exit

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -138,13 +138,7 @@ public class Connection {
         exec = Executors.newSingleThreadExecutor();
         exec.submit((Runnable) () -> {
             // pump responses until canceled
-            while (true) {
-                // validate socket is open
-                if (!isOpen()) {
-                    log.error("Response Pump: The socket is not open, exiting.");
-                    break;
-                }
-
+            while (isOpen()) {
                 // read response and send it to whoever is waiting, if anyone
                 try {
                     final Response response = this.socket.orElseThrow(() -> new ReqlDriverError("No socket available.")).read();


### PR DESCRIPTION
Due to the way the .close() method works, this error log is always hit unless there's a termination from an io exception. Also moving the isOpen() check to the loop to be more explicit.