### PR TITLE
Don't print an error if the socket is closed.

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -198,7 +198,7 @@ public class Connection {
 
             // close the socket
             socket.ifPresent(SocketWrapper::close);
-            if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+            if (exec != null && !exec.awaitTermination(60, TimeUnit.SECONDS)) {
                 log.error("Executor did not terminate");
             }
         }

--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -194,6 +194,9 @@ public class Connection {
             // terminate response pump
             if (exec != null && !exec.isShutdown()) {
                 exec.shutdown();
+                if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+                    log.error("Executor did not terminate");
+                }
             }
 
             // close the socket

--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -194,13 +194,13 @@ public class Connection {
             // terminate response pump
             if (exec != null && !exec.isShutdown()) {
                 exec.shutdown();
-                if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
-                    log.error("Executor did not terminate");
-                }
             }
 
             // close the socket
             socket.ifPresent(SocketWrapper::close);
+            if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+                log.error("Executor did not terminate");
+            }
         }
 
     }

--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -137,14 +137,8 @@ public class Connection {
         // start response pump
         exec = Executors.newSingleThreadExecutor();
         exec.submit((Runnable) () -> {
-            // pump responses until canceled
-            while (true) {
-                // validate socket is open
-                if (!isOpen()) {
-                    log.error("Response Pump: The socket is not open, exiting.");
-                    break;
-                }
-
+            // pump responses until canceled or the connection is closed
+            while (isOpen()) {
                 // read response and send it to whoever is waiting, if anyone
                 try {
                     final Response response = this.socket.orElseThrow(() -> new ReqlDriverError("No socket available.")).read();


### PR DESCRIPTION
This can happen as part of a normal conn.close() call.

@deontologician @pires