### PR TITLE
Fixes #5233 | Replace NULL by nullptr

### DIFF
--- a/src/arch/address.cc
+++ b/src/arch/address.cc
@@ -107,7 +107,7 @@ void hostname_to_ips_internal(const std::string &host,
     int errno_res;
     struct addrinfo *addrs;
     std::function<void ()> fn =
-        std::bind(do_getaddrinfo, host.c_str(), static_cast<const char*>(NULL),
+        std::bind(do_getaddrinfo, host.c_str(), static_cast<const char*>(nullptr),
                   &hint, &addrs, &res, &errno_res);
     thread_pool_t::run_in_blocker_pool(fn);
 
@@ -183,10 +183,10 @@ std::set<ip_address_t> get_local_ips(const std::set<ip_address_t> &filter,
                   "getifaddrs() failed, could not determine local network interfaces");
 
     for (auto *current_addr = addrs;
-         current_addr != NULL;
+         current_addr != nullptr;
          current_addr = current_addr->ifa_next) {
         struct sockaddr *addr_data = current_addr->ifa_addr;
-        if (addr_data == NULL) {
+        if (addr_data == nullptr) {
             continue;
         } else if (addr_data->sa_family == AF_INET || addr_data->sa_family == AF_INET6) {
             all_ips.insert(ip_address_t(addr_data));

--- a/src/arch/barrier.cc
+++ b/src/arch/barrier.cc
@@ -4,9 +4,9 @@ thread_barrier_t::thread_barrier_t(int num_workers)
     : num_workers_(num_workers), num_waiters_(0) {
     guarantee(num_workers > 0);
 
-    int res = pthread_mutex_init(&mutex_, NULL);
+    int res = pthread_mutex_init(&mutex_, nullptr);
     guarantee_xerr(res == 0, res, "could not initialize barrier mutex");
-    res = pthread_cond_init(&cond_, NULL);
+    res = pthread_cond_init(&cond_, nullptr);
     guarantee_xerr(res == 0, res, "could not initialize barrier condition variable");
 }
 

--- a/src/arch/io/blocker_pool.cc
+++ b/src/arch/io/blocker_pool.cc
@@ -35,7 +35,7 @@ void* blocker_pool_t::event_loop(void *arg) {
         int res = sigfillset(&sigmask);
         guarantee_err(res == 0, "Could not get a full sigmask");
 
-        res = pthread_sigmask(SIG_SETMASK, &sigmask, NULL);
+        res = pthread_sigmask(SIG_SETMASK, &sigmask, nullptr);
         guarantee_xerr(res == 0, res, "Could not block signal");
     }
 #endif
@@ -50,7 +50,7 @@ void* blocker_pool_t::event_loop(void *arg) {
 
         if (parent->shutting_down) {
             // or_lock's destructor gets called, so everything is OK.
-            return NULL;
+            return nullptr;
 
         } else {
 
@@ -132,7 +132,7 @@ blocker_pool_t::~blocker_pool_t() {
 
     /* Wait for stuff to actually shut down */
     for (size_t i = 0; i < threads.size(); ++i) {
-        int res = pthread_join(threads[i], NULL);
+        int res = pthread_join(threads[i], nullptr);
         guarantee_xerr(res == 0, res, "Could not join blocker-pool thread.");
     }
 }

--- a/src/arch/io/concurrency.hpp
+++ b/src/arch/io/concurrency.hpp
@@ -11,7 +11,7 @@ class system_mutex_t {
     friend class system_cond_t;
 public:
     system_mutex_t() {
-        int res = pthread_mutex_init(&m, NULL);
+        int res = pthread_mutex_init(&m, nullptr);
         guarantee_xerr(res == 0, res, "Could not initialize pthread mutex.");
     }
     ~system_mutex_t() {
@@ -29,7 +29,7 @@ public:
             guarantee(parent);
             int res = pthread_mutex_unlock(&parent->m);
             guarantee_xerr(res == 0, res, "Could not release pthread mutex.");
-            parent = NULL;
+            parent = nullptr;
         }
         ~lock_t() {
             if (parent) unlock();
@@ -42,7 +42,7 @@ class system_cond_t {
     pthread_cond_t c;
 public:
     system_cond_t() {
-        int res = pthread_cond_init(&c, NULL);
+        int res = pthread_cond_init(&c, nullptr);
         guarantee_xerr(res == 0, res, "Could not initialize pthread cond.");
     }
     ~system_cond_t() {

--- a/src/arch/io/disk.cc
+++ b/src/arch/io/disk.cc
@@ -293,7 +293,7 @@ void linux_file_t::write_async(int64_t offset, size_t length, const void *buf,
 void linux_file_t::writev_async(int64_t offset, size_t length,
                                 scoped_array_t<iovec> &&bufs,
                                 file_account_t *account, linux_iocallback_t *callback) {
-    rassert(diskmgr != NULL,
+    rassert(diskmgr != nullptr,
             "No diskmgr has been constructed (are we running without an event queue?)");
     verify_aligned_file_access(file_size, offset, length, bufs);
 
@@ -433,7 +433,7 @@ file_open_result_t open_file(const char *path, const int mode, io_backender_t *b
     // TODO WINDOWS: is all this sharing necessary? According to issue #5165, it doesn't even work
     DWORD share_mode = FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE;
 
-    fd.reset(CreateFile(path, access_mode, share_mode, NULL, create_mode, FILE_ATTRIBUTE_NORMAL, NULL));
+    fd.reset(CreateFile(path, access_mode, share_mode, nullptr, create_mode, FILE_ATTRIBUTE_NORMAL, nullptr));
     if (fd.get() == INVALID_FD) {
         logERR("CreateFile failed: %s: %s", path, winerr_string(GetLastError()).c_str());
         return file_open_result_t(file_open_result_t::ERROR, EIO);
@@ -617,7 +617,7 @@ MUST_USE int fsync_parent_directory(const char *path) {
 #else
     char absolute_path[PATH_MAX];
     char *abs_res = realpath(path, absolute_path);
-    guarantee_err(abs_res != NULL, "Failed to determine absolute path for '%s'", path);
+    guarantee_err(abs_res != nullptr, "Failed to determine absolute path for '%s'", path);
     char *parent_path = dirname(absolute_path); // Note: modifies absolute_path
 
     // Get a file descriptor on the parent directory

--- a/src/arch/io/disk/pool.hpp
+++ b/src/arch/io/disk/pool.hpp
@@ -44,7 +44,7 @@ struct pool_diskmgr_action_t
         type = ACTION_RESIZE;
         wrap_in_datasyncs = _wrap_in_datasyncs;
         fd = _fd;
-        buf_and_count.iov_base = NULL;
+        buf_and_count.iov_base = nullptr;
         buf_and_count.iov_len = 0;
         offset = _new_size;
     }
@@ -57,7 +57,7 @@ struct pool_diskmgr_action_t
         wrap_in_datasyncs = false;
         fd = _fd;
         iovecs = std::move(_bufs);
-        buf_and_count.iov_base = NULL;
+        buf_and_count.iov_base = nullptr;
         buf_and_count.iov_len = _count;
         offset = _offset;
     }
@@ -77,7 +77,7 @@ struct pool_diskmgr_action_t
     bool get_is_read() const { return type == ACTION_READ; }
     fd_t get_fd() const { return fd; }
     void get_bufs(iovec **iovecs_out, size_t *iovecs_len_out) {
-        if (buf_and_count.iov_base != NULL) {
+        if (buf_and_count.iov_base != nullptr) {
             *iovecs_out = &buf_and_count;
             *iovecs_len_out = 1;
         } else {

--- a/src/arch/io/event_watcher.cc
+++ b/src/arch/io/event_watcher.cc
@@ -10,9 +10,9 @@
 
 linux_event_watcher_t::linux_event_watcher_t(fd_t f, linux_event_callback_t *eh) :
     fd(f), error_handler(eh),
-    in_watcher(NULL), out_watcher(NULL),
+    in_watcher(nullptr), out_watcher(nullptr),
 #ifdef __linux
-    rdhup_watcher(NULL),
+    rdhup_watcher(nullptr),
 #endif
     watching_for_errors(true),
     old_mask(0),
@@ -49,13 +49,13 @@ linux_event_watcher_t::watch_t::watch_t(linux_event_watcher_t *p, int e) :
 
 linux_event_watcher_t::watch_t::~watch_t() {
     rassert(*parent->get_watch_slot(event) == this);
-    *parent->get_watch_slot(event) = NULL;
+    *parent->get_watch_slot(event) = nullptr;
     parent->remask();
 }
 
 bool linux_event_watcher_t::is_watching(int event) {
     assert_thread();
-    return *get_watch_slot(event) == NULL;
+    return *get_watch_slot(event) == nullptr;
 }
 
 linux_event_watcher_t::watch_t **linux_event_watcher_t::get_watch_slot(int event) {
@@ -126,13 +126,13 @@ void linux_event_watcher_t::on_event(int event) {
     // wakeups.  (They'll just get EAGAIN.)
 
     if ((event & poll_event_in) || (event & error_mask)) {
-        if (in_watcher != NULL && !in_watcher->is_pulsed()) {
+        if (in_watcher != nullptr && !in_watcher->is_pulsed()) {
             in_watcher->pulse();
         }
     }
 
     if ((event & poll_event_out) || (event & error_mask)) {
-        if (out_watcher != NULL && !out_watcher->is_pulsed()) {
+        if (out_watcher != nullptr && !out_watcher->is_pulsed()) {
             out_watcher->pulse();
         }
     }

--- a/src/arch/io/network.cc
+++ b/src/arch/io/network.cc
@@ -99,7 +99,7 @@ linux_tcp_conn_t::linux_tcp_conn_t(const ip_address_t &peer,
                                    int port,
                                    signal_t *interruptor,
                                    int local_port) THROWS_ONLY(connect_failed_exc_t, interrupted_exc_t) :
-        write_perfmon(NULL),
+        write_perfmon(nullptr),
         sock(create_socket_wrapper(peer.get_address_family())),
         event_watcher(new linux_event_watcher_t(sock.get(), this)),
         read_in_progress(false), write_in_progress(false),
@@ -152,7 +152,7 @@ linux_tcp_conn_t::linux_tcp_conn_t(const ip_address_t &peer,
 }
 
 linux_tcp_conn_t::linux_tcp_conn_t(fd_t s) :
-        write_perfmon(NULL),
+        write_perfmon(nullptr),
         sock(s),
         event_watcher(new linux_event_watcher_t(sock.get(), this)),
         read_in_progress(false), write_in_progress(false),
@@ -382,18 +382,18 @@ linux_tcp_conn_t::write_handler_t::write_handler_t(linux_tcp_conn_t *_parent) :
 { }
 
 void linux_tcp_conn_t::write_handler_t::coro_pool_callback(write_queue_op_t *operation, UNUSED signal_t *interruptor) {
-    if (operation->buffer != NULL) {
+    if (operation->buffer != nullptr) {
         parent->perform_write(operation->buffer, operation->size);
-        if (operation->dealloc != NULL) {
+        if (operation->dealloc != nullptr) {
             parent->release_write_buffer(operation->dealloc);
             parent->write_queue_limiter.unlock(operation->size);
         }
     }
 
-    if (operation->cond != NULL) {
+    if (operation->cond != nullptr) {
         operation->cond->pulse();
     }
-    if (operation->dealloc != NULL) {
+    if (operation->dealloc != nullptr) {
         parent->release_write_queue_op(operation);
     }
 }
@@ -408,7 +408,7 @@ void linux_tcp_conn_t::internal_flush_write_buffer() {
     op->buffer = current_write_buffer->buffer;
     op->size = current_write_buffer->size;
     op->dealloc = current_write_buffer.release();
-    op->cond = NULL;
+    op->cond = nullptr;
     op->keepalive = auto_drainer_t::lock_t(drainer.get());
     current_write_buffer.init(get_write_buffer());
 
@@ -497,7 +497,7 @@ void linux_tcp_conn_t::write(const void *buf, size_t size, signal_t *closer) THR
     /* Enqueue the write so it will happen eventually */
     op.buffer = buf;
     op.size = size;
-    op.dealloc = NULL;
+    op.dealloc = nullptr;
     op.cond = &to_signal_when_done;
     write_queue.push(&op);
 
@@ -568,8 +568,8 @@ void linux_tcp_conn_t::flush_buffer(signal_t *closer) THROWS_ONLY(tcp_conn_write
     pulsed. */
     write_queue_op_t op;
     cond_t to_signal_when_done;
-    op.buffer = NULL;
-    op.dealloc = NULL;
+    op.buffer = nullptr;
+    op.dealloc = nullptr;
     op.cond = &to_signal_when_done;
     write_queue.push(&op);
     to_signal_when_done.wait();
@@ -955,7 +955,7 @@ void linux_nonthrowing_tcp_listener_t::accept_loop(auto_drainer_t::lock_t lock) 
     fd_t active_fd = socks[0].get();
 
     while(!lock.get_drain_signal()->is_pulsed()) {
-        fd_t new_sock = accept(active_fd, NULL, NULL);
+        fd_t new_sock = accept(active_fd, nullptr, nullptr);
 
         if (new_sock != INVALID_FD) {
             coro_t::spawn_now_dangerously(std::bind(&linux_nonthrowing_tcp_listener_t::handle, this, new_sock));
@@ -1086,12 +1086,12 @@ signal_t *linux_repeated_nonthrowing_tcp_listener_t::get_bound_signal() {
 std::vector<std::string> get_ips() {
     std::vector<std::string> ret;
 
-    struct ifaddrs *if_addrs = NULL;
+    struct ifaddrs *if_addrs = nullptr;
     int addr_res = getifaddrs(&if_addrs);
     guarantee_err(addr_res == 0, "getifaddrs failed, could not determine local ip addresses");
 
-    for (ifaddrs *p = if_addrs; p != NULL; p = p->ifa_next) {
-        if (p->ifa_addr == NULL) {
+    for (ifaddrs *p = if_addrs; p != nullptr; p = p->ifa_next) {
+        if (p->ifa_addr == nullptr) {
             continue;
         } else if (p->ifa_addr->sa_family == AF_INET) {
             if (!(p->ifa_flags & IFF_LOOPBACK)) {
@@ -1102,7 +1102,7 @@ std::vector<std::string> get_ips() {
                 char buf[buflength + 1] = { 0 };
                 const char *res = inet_ntop(AF_INET, &in_addr->sin_addr, buf, buflength);
 
-                guarantee_err(res != NULL, "inet_ntop failed");
+                guarantee_err(res != nullptr, "inet_ntop failed");
 
                 ret.push_back(std::string(buf));
             }
@@ -1115,7 +1115,7 @@ std::vector<std::string> get_ips() {
                 memset(buf.data(), 0, buf.size());
                 const char *res = inet_ntop(AF_INET6, &in6_addr->sin6_addr, buf.data(), buflength);
 
-                guarantee_err(res != NULL, "inet_ntop failed on an ipv6 address");
+                guarantee_err(res != nullptr, "inet_ntop failed on an ipv6 address");
 
                 ret.push_back(std::string(buf.data()));
             }

--- a/src/arch/io/timer/timer_kqueue_provider.cc
+++ b/src/arch/io/timer/timer_kqueue_provider.cc
@@ -26,7 +26,7 @@ timer_kqueue_provider_t::timer_kqueue_provider_t(linux_event_queue_t *queue)
 timer_kqueue_provider_t::~timer_kqueue_provider_t() {
     queue_->forget_resource(kq_fd_, this);
 
-    guarantee(callback_ == NULL);
+    guarantee(callback_ == nullptr);
     const int res = close(kq_fd_);
     guarantee_err(res == 0, "Could not close the kqueue timer.");
 }
@@ -42,7 +42,7 @@ void timer_kqueue_provider_t::schedule_oneshot(const int64_t next_time_in_nanos,
     struct timespec timeout;
     timeout.tv_sec = 0;
     timeout.tv_nsec = 0;
-    const int res = kevent64(kq_fd_, &event, 1, NULL, 0, 0, &timeout);
+    const int res = kevent64(kq_fd_, &event, 1, nullptr, 0, 0, &timeout);
     guarantee_err(res != -1, "kevent64 failed when making timer");
 
     callback_ = cb;
@@ -55,10 +55,10 @@ void timer_kqueue_provider_t::unschedule_oneshot() {
     struct timespec timeout;
     timeout.tv_sec = 0;
     timeout.tv_nsec = 0;
-    const int res = kevent64(kq_fd_, &event, 1, NULL, 0, 0, &timeout);
+    const int res = kevent64(kq_fd_, &event, 1, nullptr, 0, 0, &timeout);
     guarantee_err(res != -1, "kevent64 failed when deleting timer");
 
-    callback_ = NULL;
+    callback_ = nullptr;
 }
 
 void debug_print(printf_buffer_t *buf, const struct kevent64_s& event) {
@@ -94,7 +94,7 @@ void timer_kqueue_provider_t::on_event(int eventmask) {
     while (!got_short_res) {
         int res;
         do {
-            res = kevent64(kq_fd_, NULL, 0, events, num_events, 0, &timeout);
+            res = kevent64(kq_fd_, nullptr, 0, events, num_events, 0, &timeout);
         } while (res == -1 && get_errno() == EINTR);
 
         guarantee_err(res != -1, "kevent64 failed when reading timer");
@@ -112,10 +112,10 @@ void timer_kqueue_provider_t::on_event(int eventmask) {
         }
     }
 
-    if (expiration_count > 0 && callback_ != NULL) {
+    if (expiration_count > 0 && callback_ != nullptr) {
         // Make the callback be NULL before we call it, so that a new callback can be set.
         timer_provider_callback_t *local_cb = callback_;
-        callback_ = NULL;
+        callback_ = nullptr;
         local_cb->on_oneshot();
     }
 }

--- a/src/arch/io/timer/timer_signal_provider.cc
+++ b/src/arch/io/timer/timer_signal_provider.cc
@@ -23,8 +23,8 @@ void timer_signal_provider_signal_handler(UNUSED int signum, siginfo_t *siginfo,
     timer_signal_provider_t *provider = static_cast<timer_signal_provider_t *>(siginfo->si_value.sival_ptr);
 
     timer_provider_callback_t *local_cb = provider->callback;
-    if (local_cb != NULL) {
-        provider->callback = NULL;
+    if (local_cb != nullptr) {
+        provider->callback = nullptr;
         local_cb->on_oneshot();
     }
 }
@@ -35,7 +35,7 @@ timer_signal_provider_t::timer_signal_provider_t(UNUSED linux_event_queue_t *que
     struct sigaction sa = make_sa_sigaction(SA_SIGINFO, &timer_signal_provider_signal_handler);
 
     // Register the signal.
-    int res = sigaction(TIMER_NOTIFY_SIGNAL, &sa, NULL);
+    int res = sigaction(TIMER_NOTIFY_SIGNAL, &sa, nullptr);
     guarantee_err(res == 0, "timer signal provider could not register the signal handler");
 
     // Initialize the event structure
@@ -52,7 +52,7 @@ timer_signal_provider_t::timer_signal_provider_t(UNUSED linux_event_queue_t *que
 }
 
 timer_signal_provider_t::~timer_signal_provider_t() {
-    guarantee(callback == NULL);
+    guarantee(callback == nullptr);
 
     int res = timer_delete(timerid);
     guarantee_err(res == 0, "timer_delete failed");
@@ -61,7 +61,7 @@ timer_signal_provider_t::~timer_signal_provider_t() {
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = SIG_DFL;
 
-    res = sigaction(TIMER_NOTIFY_SIGNAL, &sa, NULL);
+    res = sigaction(TIMER_NOTIFY_SIGNAL, &sa, nullptr);
     guarantee_err(res == 0, "timer signal provider could not unregister the signal handler");
 }
 
@@ -80,14 +80,14 @@ void timer_signal_provider_t::schedule_oneshot(int64_t next_time_in_nanos, timer
     spec.it_interval.tv_sec = 0;
     spec.it_interval.tv_nsec = 0;
 
-    const int res = timer_settime(timerid, 0, &spec, NULL);
+    const int res = timer_settime(timerid, 0, &spec, nullptr);
     guarantee_err(res == 0, "Could not arm the timer");
 
     callback = cb;
 }
 
 void timer_signal_provider_t::unschedule_oneshot() {
-    callback = NULL;
+    callback = nullptr;
 
     struct itimerspec spec;
     spec.it_interval.tv_sec = 0;
@@ -95,7 +95,7 @@ void timer_signal_provider_t::unschedule_oneshot() {
     spec.it_value.tv_sec = 0;
     spec.it_value.tv_nsec = 0;
 
-    const int res = timer_settime(timerid, 0, &spec, NULL);
+    const int res = timer_settime(timerid, 0, &spec, nullptr);
     guarantee_err(res == 0, "Could not disarm the timer.");
 }
 

--- a/src/arch/io/timer/timerfd_provider.cc
+++ b/src/arch/io/timer/timerfd_provider.cc
@@ -13,7 +13,7 @@
 #include "time.hpp"
 
 timerfd_provider_t::timerfd_provider_t(linux_event_queue_t *_queue)
-    : queue(_queue), timer_fd(-1), callback(NULL) {
+    : queue(_queue), timer_fd(-1), callback(nullptr) {
     const int fd = timerfd_create(CLOCK_MONOTONIC, 0);
     guarantee_err(fd != -1, "Could not create timer");
 
@@ -29,7 +29,7 @@ timerfd_provider_t::timerfd_provider_t(linux_event_queue_t *_queue)
 timerfd_provider_t::~timerfd_provider_t() {
     queue->forget_resource(timer_fd, this);
 
-    guarantee(callback == NULL);
+    guarantee(callback == nullptr);
     const int res = close(timer_fd);
     guarantee_err(res == 0 || get_errno() == EINTR, "Could not close the timer.");
 }
@@ -48,7 +48,7 @@ void timerfd_provider_t::schedule_oneshot(const int64_t next_time_in_nanos, time
     spec.it_value.tv_sec = wait_nanos / BILLION;
     spec.it_value.tv_nsec = wait_nanos % BILLION;
 
-    const int res = timerfd_settime(timer_fd, 0, &spec, NULL);
+    const int res = timerfd_settime(timer_fd, 0, &spec, nullptr);
     guarantee_err(res == 0, "Could not arm the timer.");
 
     callback = cb;
@@ -61,10 +61,10 @@ void timerfd_provider_t::unschedule_oneshot() {
     spec.it_value.tv_sec = 0;
     spec.it_value.tv_nsec = 0;
 
-    const int res = timerfd_settime(timer_fd, 0, &spec, NULL);
+    const int res = timerfd_settime(timer_fd, 0, &spec, nullptr);
     guarantee_err(res == 0, "Could not disarm the timer.");
 
-    callback = NULL;
+    callback = nullptr;
 }
 
 void timerfd_provider_t::on_event(int events) {
@@ -77,10 +77,10 @@ void timerfd_provider_t::on_event(int events) {
     guarantee_err(res == 0 || get_errno() == EAGAIN, "Could not read timer_fd value");
     if (res == 0 && nexpirations > 0) {
         // The callback could be unscheduled but after the timerfd rang, maybe.  So we check here.
-        if (callback != NULL) {
+        if (callback != nullptr) {
             // Make the callback be NULL before we call it, so that a new callback can be set.
             timer_provider_callback_t *local_cb = callback;
-            callback = NULL;
+            callback = nullptr;
             local_cb->on_oneshot();
         }
     }

--- a/src/arch/os_signal.cc
+++ b/src/arch/os_signal.cc
@@ -13,12 +13,12 @@ os_signal_cond_t::os_signal_cond_t() :
     source_signo(0)
 {
     DEBUG_VAR thread_message_t *old = thread_pool_t::set_interrupt_message(this);
-    rassert(old == NULL);
+    rassert(old == nullptr);
 }
 
 os_signal_cond_t::~os_signal_cond_t() {
     if (!is_pulsed()) {
-        DEBUG_VAR thread_message_t *old = thread_pool_t::set_interrupt_message(NULL);
+        DEBUG_VAR thread_message_t *old = thread_pool_t::set_interrupt_message(nullptr);
         rassert(old == this);
     }
 }

--- a/src/arch/runtime/context_switching.cc
+++ b/src/arch/runtime/context_switching.cc
@@ -34,14 +34,14 @@ performance reasons.
 Our custom context-switching code is derived from GLibC, which is covered by the
 LGPL. */
 
-artificial_stack_context_ref_t::artificial_stack_context_ref_t() : pointer(NULL) { }
+artificial_stack_context_ref_t::artificial_stack_context_ref_t() : pointer(nullptr) { }
 
 artificial_stack_context_ref_t::~artificial_stack_context_ref_t() {
     rassert(is_nil(), "You're leaking a context.");
 }
 
 bool artificial_stack_context_ref_t::is_nil() {
-    return pointer == NULL;
+    return pointer == nullptr;
 }
 
 artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_size)
@@ -132,7 +132,7 @@ artificial_stack_t::~artificial_stack_t() {
 
     /* Set `context.pointer` to nil to avoid tripping an assertion in its
     destructor. */
-    context.pointer = NULL;
+    context.pointer = nullptr;
 
     /* Tell Valgrind the stack is no longer in use */
 #ifdef VALGRIND
@@ -224,10 +224,10 @@ void context_switch(artificial_stack_context_ref_t *current_context_out, artific
     rassert(current_context_out->is_nil(), "that variable already holds a context");
     rassert(!dest_context_in->is_nil(), "cannot switch to nil context");
 
-    /* `lightweight_swapcontext()` won't set `dest_context_in->pointer` to NULL,
+    /* `lightweight_swapcontext()` won't set `dest_context_in->pointer` to nullptr,
     so we have to do that ourselves. */
     void *dest_pointer = dest_context_in->pointer;
-    dest_context_in->pointer = NULL;
+    dest_context_in->pointer = nullptr;
 
     lightweight_swapcontext(&current_context_out->pointer, dest_pointer);
 }
@@ -353,8 +353,8 @@ static system_mutex_t virtual_thread_mutexes[MAX_THREADS];
 
 void context_switch(threaded_context_ref_t *current_context,
                     threaded_context_ref_t *dest_context) {
-    guarantee(current_context != NULL);
-    guarantee(dest_context != NULL);
+    guarantee(current_context != nullptr);
+    guarantee(dest_context != nullptr);
 
     bool is_scheduler = false;
     if (!current_context->lock.has()) {
@@ -391,7 +391,7 @@ void threaded_context_ref_t::wait() {
     cond.wait(&virtual_thread_mutexes[linux_thread_pool_t::get_thread_id()]);
     if (do_shutdown) {
         lock.reset();
-        pthread_exit(NULL);
+        pthread_exit(nullptr);
     }
     if (do_rethread) {
         restore_virtual_thread();
@@ -429,7 +429,7 @@ threaded_stack_t::threaded_stack_t(void (*initial_fun_)(void), size_t stack_size
     }
 
     int result = pthread_create(&thread,
-                                NULL,
+                                nullptr,
                                 threaded_stack_t::internal_run,
                                 reinterpret_cast<void *>(this));
     guarantee_xerr(result == 0, result, "Could not create thread: %i", result);
@@ -475,7 +475,7 @@ threaded_stack_t::~threaded_stack_t() {
     }
 
     // Wait for the thread to shut down
-    int result = pthread_join(thread, NULL);
+    int result = pthread_join(thread, nullptr);
     guarantee_xerr(result == 0, result, "Could not join with thread: %i", result);
 
     // ... and re-acquire the lock, if we are in a coroutine.
@@ -501,7 +501,7 @@ void *threaded_stack_t::internal_run(void *p) {
 
     parent->context.wait();
     parent->initial_fun();
-    return NULL;
+    return nullptr;
 }
 
 bool threaded_stack_t::address_in_stack(const void *addr) const {

--- a/src/arch/runtime/coro_profiler.cc
+++ b/src/arch/runtime/coro_profiler.cc
@@ -44,7 +44,7 @@ coro_profiler_t::~coro_profiler_t() {
 }
 
 void coro_profiler_t::record_sample(size_t levels_to_strip_from_backtrace) {
-    if (coro_t::self() == NULL) return;
+    if (coro_t::self() == nullptr) return;
 
     const ticks_t ticks_on_entry = get_ticks();
 
@@ -145,7 +145,7 @@ coro_profiler_t::coro_execution_point_key_t coro_profiler_t::get_current_executi
         if (i + levels_to_strip_from_backtrace < backtrace_size) {
             trace[i] = stack_frames[i + levels_to_strip_from_backtrace];
         } else {
-            trace[i] = NULL;
+            trace[i] = nullptr;
         }
     }
     delete[] stack_frames;
@@ -326,7 +326,7 @@ void coro_profiler_t::print_to_reql(
 std::string coro_profiler_t::trace_to_array_str(const small_trace_t &trace) {
     std::string trace_array_str = "[";
     for (size_t i = 0; i < CORO_PROFILER_BACKTRACE_DEPTH; ++i) {
-        if (trace[i] == NULL) {
+        if (trace[i] == nullptr) {
             break;
         }
         if (i > 0) {

--- a/src/arch/runtime/coroutines.cc
+++ b/src/arch/runtime/coroutines.cc
@@ -70,8 +70,8 @@ struct coro_globals_t {
 #endif  // NDEBUG
 
     coro_globals_t()
-        : current_coro(NULL)
-        , prev_coro(NULL)
+        : current_coro(nullptr)
+        , prev_coro(nullptr)
 #ifndef NDEBUG
         , coro_count(0)
         , printed_high_coro_count_warning(false)
@@ -298,7 +298,7 @@ void coro_t::notify_now_deprecated() {
     TLS_get_cglobals()->assert_finite_coro_waiting_counter = 0;
 #endif
 
-    if (coro_t::self() != NULL) {
+    if (coro_t::self() != nullptr) {
         PROFILER_CORO_YIELD(1);
     }
     coro_t *prev_prev_coro = TLS_get_cglobals()->prev_coro;
@@ -314,7 +314,7 @@ void coro_t::notify_now_deprecated() {
     rassert(TLS_get_cglobals()->current_coro == this);
     TLS_get_cglobals()->current_coro = TLS_get_cglobals()->prev_coro;
     TLS_get_cglobals()->prev_coro = prev_prev_coro;
-    if (coro_t::self() != NULL) {
+    if (coro_t::self() != nullptr) {
         PROFILER_CORO_RESUME;
     }
 
@@ -391,7 +391,7 @@ bool has_n_bytes_free_stack_space(size_t n) {
 }
 
 bool coroutines_have_been_initialized() {
-    return TLS_get_cglobals() != NULL;
+    return TLS_get_cglobals() != nullptr;
 }
 
 coro_t * coro_t::get_coro() {
@@ -464,7 +464,7 @@ void coro_t::grab_spawn_backtrace() {
     // If we have space left and were called from inside a coroutine,
     // we also append the parent's spawn_backtrace.
     int space_remaining = CROSS_CORO_BACKTRACES_MAX_SIZE - spawn_backtrace_size;
-    if (space_remaining > 0 && self() != NULL) {
+    if (space_remaining > 0 && self() != nullptr) {
         spawn_backtrace_size += self()->copy_spawn_backtrace(spawn_backtrace + spawn_backtrace_size,
                                                              space_remaining);
     }
@@ -477,7 +477,7 @@ int coro_t::copy_spawn_backtrace(void **buffer_out, int size) const {
 int coro_t::copy_spawn_backtrace(void **, int) const {
 #endif
 #ifdef CROSS_CORO_BACKTRACES
-    guarantee(buffer_out != NULL);
+    guarantee(buffer_out != nullptr);
     guarantee(size >= 0);
     int num_frames_to_store = std::min(size, spawn_backtrace_size);
     memcpy(buffer_out,

--- a/src/arch/runtime/coroutines.hpp
+++ b/src/arch/runtime/coroutines.hpp
@@ -186,7 +186,7 @@ private:
 
         // If we were called from a coroutine, the new coroutine inherits our
         // caller's priority.
-        if (self() != NULL) {
+        if (self() != nullptr) {
             coro->set_priority(self()->get_priority());
         } else {
             // Otherwise, just reset to the default.

--- a/src/arch/runtime/event_queue/epoll.cc
+++ b/src/arch/runtime/event_queue/epoll.cc
@@ -99,7 +99,7 @@ void epoll_event_queue_t::run() {
         block_pm_duration event_loop_timer(pm_eventloop_singleton_t::get());
 
         for (int i = 0; i < nevents; i++) {
-            if (events[i].data.ptr == NULL) {
+            if (events[i].data.ptr == nullptr) {
                 // The event was queued for a resource that's
                 // been destroyed, so forget_resource is kindly
                 // notifying us to skip it.
@@ -167,7 +167,7 @@ void epoll_event_queue_t::forget_resource(fd_t resource, linux_event_callback_t 
     epoll_event event;
 
     event.events = EPOLLIN;
-    event.data.ptr = NULL;
+    event.data.ptr = nullptr;
 
     int res = epoll_ctl(epoll_fd, EPOLL_CTL_DEL, resource, &event);
     guarantee_err(res == 0, "Couldn't remove resource from watching");
@@ -177,7 +177,7 @@ void epoll_event_queue_t::forget_resource(fd_t resource, linux_event_callback_t 
     // being asked to forget.
     for (int i = 0; i < nevents; i++) {
         if (events[i].data.ptr == cb) {
-            events[i].data.ptr = NULL;
+            events[i].data.ptr = nullptr;
         }
     }
 

--- a/src/arch/runtime/event_queue/kqueue.cc
+++ b/src/arch/runtime/event_queue/kqueue.cc
@@ -63,13 +63,13 @@ void kqueue_event_queue_t::run() {
     // Now, start the loop
     while (!parent->should_shut_down()) {
         // Grab the events from the kqueue!
-        nevents = call_kevent(kqueue_fd, NULL, 0,
-                              events, MAX_IO_EVENT_PROCESSING_BATCH_SIZE, NULL);
+        nevents = call_kevent(kqueue_fd, nullptr, 0,
+                              events, MAX_IO_EVENT_PROCESSING_BATCH_SIZE, nullptr);
 
         block_pm_duration event_loop_timer(pm_eventloop_singleton_t::get());
 
         for (int i = 0; i < nevents; i++) {
-            if (events[i].udata == NULL) {
+            if (events[i].udata == nullptr) {
                 // The event was queued for a resource that's
                 // been destroyed, so forget_resource is kindly
                 // notifying us to skip it by setting `udata` to NULL.
@@ -92,29 +92,29 @@ kqueue_event_queue_t::~kqueue_event_queue_t() {
 
 void kqueue_event_queue_t::add_filters(fd_t resource, const std::set<int16_t> &filters,
                                        linux_event_callback_t *cb) {
-    rassert(cb != NULL);
+    rassert(cb != nullptr);
 
     for (auto filter : filters) {
         struct kevent ev;
         EV_SET(&ev, static_cast<uintptr_t>(resource), filter, EV_ADD, 0, 0, cb);
-        call_kevent(kqueue_fd, &ev, 1, NULL, 0, NULL);
+        call_kevent(kqueue_fd, &ev, 1, nullptr, 0, nullptr);
     }
 }
 
 void kqueue_event_queue_t::del_filters(fd_t resource, const std::set<int16_t> &filters,
                                        linux_event_callback_t *cb) {
-    rassert(cb != NULL);
+    rassert(cb != nullptr);
 
     for (auto filter : filters) {
         struct kevent ev;
         EV_SET(&ev, static_cast<uintptr_t>(resource), filter, EV_DELETE, 0, 0, cb);
-        call_kevent(kqueue_fd, &ev, 1, NULL, 0, NULL);
+        call_kevent(kqueue_fd, &ev, 1, nullptr, 0, nullptr);
     }
 }
 
 void kqueue_event_queue_t::watch_resource(fd_t resource, int event_mask,
                                           linux_event_callback_t *cb) {
-    rassert(cb != NULL);
+    rassert(cb != nullptr);
 
     // Start watching the events on `resource`
     std::set<int16_t> filters = user_to_kevent_filters(event_mask);
@@ -160,8 +160,8 @@ void kqueue_event_queue_t::adjust_resource(fd_t resource, int event_mask,
         if (events[i].ident == static_cast<uintptr_t>(resource)) {
             if (filters_to_del.count(events[i].filter) > 0) {
                 // No longer watching this event
-                events[i].udata = NULL;
-            } else if (events[i].udata != NULL) {
+                events[i].udata = nullptr;
+            } else if (events[i].udata != nullptr) {
                 // Just update the cb, unless we had previously deleted this one.
                 events[i].udata = cb;
             }
@@ -186,8 +186,8 @@ void kqueue_event_queue_t::forget_resource(fd_t resource, linux_event_callback_t
     // being asked to forget.
     for (int i = 0; i < nevents; i++) {
         if (events[i].ident == static_cast<uintptr_t>(resource)) {
-            rassert(events[i].udata == cb || events[i].udata == NULL);
-            events[i].udata = NULL;
+            rassert(events[i].udata == cb || events[i].udata == nullptr);
+            events[i].udata = nullptr;
         }
     }
 }

--- a/src/arch/runtime/event_queue/poll.cc
+++ b/src/arch/runtime/event_queue/poll.cc
@@ -106,7 +106,7 @@ void poll_event_queue_t::run() {
 #ifndef RDB_TIMER_PROVIDER
 #error "RDB_TIMER_PROVIDER not defined."
 #elif RDB_TIMER_PROVIDER == RDB_TIMER_PROVIDER_SIGNAL
-        res = ppoll(&watched_fds[0], watched_fds.size(), NULL, &sigmask_restricted);
+        res = ppoll(&watched_fds[0], watched_fds.size(), nullptr, &sigmask_restricted);
 #else
         res = poll(&watched_fds[0], watched_fds.size(), -1);
 #endif
@@ -140,9 +140,9 @@ void poll_event_queue_t::run() {
         // kernel starves out signals, so we need to unblock them to
         // let the signal handlers get called, and then block them
         // right back. What a sensible fucking system.
-        res = pthread_sigmask(SIG_SETMASK, &sigmask_restricted, NULL);
+        res = pthread_sigmask(SIG_SETMASK, &sigmask_restricted, nullptr);
         guarantee_xerr(res == 0, res, "Could not unblock signals");
-        res = pthread_sigmask(SIG_SETMASK, &sigmask_full, NULL);
+        res = pthread_sigmask(SIG_SETMASK, &sigmask_full, nullptr);
         guarantee_xerr(res == 0, res, "Could not block signals");
 #endif  // RDB_TIMER_PROVIDER
 

--- a/src/arch/runtime/message_hub.cc
+++ b/src/arch/runtime/message_hub.cc
@@ -150,7 +150,7 @@ void linux_message_hub_t::on_event(int events) {
             std::max(static_cast<size_t>(1), effective_granularity >> priority_exponent);
 
         for (linux_thread_message_t *m = get_priority_msg_list(current_priority).head();
-             m != NULL && to_process_from_priority > 0;
+             m != nullptr && to_process_from_priority > 0;
              m = get_priority_msg_list(current_priority).head()) {
 
             get_priority_msg_list(current_priority).remove(m);

--- a/src/arch/runtime/runtime_utils.cc
+++ b/src/arch/runtime/runtime_utils.cc
@@ -19,31 +19,31 @@ int get_cpu_count() {
 
 callable_action_wrapper_t::callable_action_wrapper_t() :
     action_on_heap(false),
-    action_(NULL)
+    action_(nullptr)
 { }
 
 callable_action_wrapper_t::~callable_action_wrapper_t()
 {
-    if (action_ != NULL) {
+    if (action_ != nullptr) {
         reset();
     }
 }
 
 void callable_action_wrapper_t::reset() {
-    rassert(action_ != NULL);
+    rassert(action_ != nullptr);
 
     if (action_on_heap) {
         delete action_;
-        action_ = NULL;
+        action_ = nullptr;
         action_on_heap = false;
     } else {
         action_->~callable_action_t();
-        action_ = NULL;
+        action_ = nullptr;
     }
 }
 
 void callable_action_wrapper_t::run() {
-    rassert(action_ != NULL);
+    rassert(action_ != nullptr);
     action_->run_action();
 }
 

--- a/src/arch/runtime/thread_pool.cc
+++ b/src/arch/runtime/thread_pool.cc
@@ -54,8 +54,8 @@ linux_thread_pool_t::linux_thread_pool_t(int worker_threads, bool _do_set_affini
 #ifndef NDEBUG
       coroutine_summary(false),
 #endif
-      interrupt_message(NULL),
-      generic_blocker_pool(NULL),
+      interrupt_message(nullptr),
+      generic_blocker_pool(nullptr),
       n_threads(worker_threads + 1),    // we create an extra utility thread
       do_set_affinity(_do_set_affinity)
 {
@@ -64,10 +64,10 @@ linux_thread_pool_t::linux_thread_pool_t(int worker_threads, bool _do_set_affini
 
     int res;
 
-    res = pthread_cond_init(&shutdown_cond, NULL);
+    res = pthread_cond_init(&shutdown_cond, nullptr);
     guarantee_xerr(res == 0, res, "Could not create shutdown cond");
 
-    res = pthread_mutex_init(&shutdown_cond_mutex, NULL);
+    res = pthread_mutex_init(&shutdown_cond_mutex, nullptr);
     guarantee_xerr(res == 0, res, "Could not create shutdown cond mutex");
 }
 
@@ -104,7 +104,7 @@ void *linux_thread_pool_t::start_thread(void *arg) {
         res = sigdelset(&sigmask, SIGBUS);
         guarantee_err(res == 0, "Could not remove SIGBUS from sigmask");
 
-        res = pthread_sigmask(SIG_SETMASK, &sigmask, NULL);
+        res = pthread_sigmask(SIG_SETMASK, &sigmask, nullptr);
         guarantee_xerr(res == 0, res, "Could not block signal");
     }
 #endif
@@ -121,7 +121,7 @@ void *linux_thread_pool_t::start_thread(void *arg) {
         linux_thread_t local_thread(tdata->thread_pool, tdata->current_thread);
         tdata->thread_pool->threads[tdata->current_thread] = &local_thread;
         set_thread(&local_thread);
-        blocker_pool_t *generic_blocker_pool = NULL; // Will only be instantiated by one thread
+        blocker_pool_t *generic_blocker_pool = nullptr; // Will only be instantiated by one thread
 
         /* Install a handler for segmentation faults that just prints a backtrace. If we're
         running under valgrind, we don't install this handler because Valgrind will print the
@@ -133,7 +133,7 @@ void *linux_thread_pool_t::start_thread(void *arg) {
         signal_stack.ss_sp = stack_base.get();
         signal_stack.ss_flags = 0;
         signal_stack.ss_size = SIGNAL_HANDLER_STACK_SIZE;
-        int res = sigaltstack(&signal_stack, NULL);
+        int res = sigaltstack(&signal_stack, nullptr);
         guarantee_err(res == 0, "sigaltstack failed");
 
         {
@@ -141,9 +141,9 @@ void *linux_thread_pool_t::start_thread(void *arg) {
                 SA_SIGINFO | SA_ONSTACK,
                 &linux_thread_pool_t::fatal_signal_handler);
 
-            res = sigaction(SIGSEGV, &sa, NULL);
+            res = sigaction(SIGSEGV, &sa, nullptr);
             guarantee_err(res == 0, "Could not install SEGV signal handler");
-            res = sigaction(SIGBUS, &sa, NULL);
+            res = sigaction(SIGBUS, &sa, nullptr);
             guarantee_err(res == 0, "Could not install BUS signal handler");
         }
 #endif
@@ -151,7 +151,7 @@ void *linux_thread_pool_t::start_thread(void *arg) {
 
         // First thread should initialize generic_blocker_pool before the start barrier
         if (tdata->initial_message) {
-            rassert(tdata->thread_pool->generic_blocker_pool == NULL, "generic_blocker_pool already initialized");
+            rassert(tdata->thread_pool->generic_blocker_pool == nullptr, "generic_blocker_pool already initialized");
             generic_blocker_pool = new blocker_pool_t(GENERIC_BLOCKER_THREAD_COUNT,
                                                       &local_thread.queue);
             tdata->thread_pool->generic_blocker_pool = generic_blocker_pool;
@@ -161,7 +161,7 @@ void *linux_thread_pool_t::start_thread(void *arg) {
         // starting up, then it might try to access an uninitialized part of the
         // unstarted one.
         tdata->barrier->wait();
-        rassert(tdata->thread_pool->generic_blocker_pool != NULL,
+        rassert(tdata->thread_pool->generic_blocker_pool != nullptr,
                 "Thread passed start barrier while generic_blocker_pool uninitialized");
 
         // Prime the pump by calling the initial thread message that was passed to thread_pool::run()
@@ -177,17 +177,17 @@ void *linux_thread_pool_t::start_thread(void *arg) {
         tdata->barrier->wait();
 
         // If this thread created the generic blocker pool, clean it up
-        if (generic_blocker_pool != NULL) {
+        if (generic_blocker_pool != nullptr) {
             delete generic_blocker_pool;
-            tdata->thread_pool->generic_blocker_pool = NULL;
+            tdata->thread_pool->generic_blocker_pool = nullptr;
         }
 
-        tdata->thread_pool->threads[tdata->current_thread] = NULL;
-        set_thread(NULL);
+        tdata->thread_pool->threads[tdata->current_thread] = nullptr;
+        set_thread(nullptr);
     }
 
     delete tdata;
-    return NULL;
+    return nullptr;
 }
 
 #ifndef NDEBUG
@@ -209,9 +209,9 @@ void linux_thread_pool_t::run_thread_pool(linux_thread_message_t *initial_messag
         tdata->thread_pool = this;
         tdata->current_thread = i;
         // The initial message gets sent to the utility thread.
-        tdata->initial_message = is_utility_thread ? initial_message : NULL;
+        tdata->initial_message = is_utility_thread ? initial_message : nullptr;
 
-        int res = pthread_create(&pthreads[i], NULL, &start_thread, tdata);
+        int res = pthread_create(&pthreads[i], nullptr, &start_thread, tdata);
         guarantee_xerr(res == 0, res, "Could not create thread");
 
         // Don't set affinity for the utility thread
@@ -247,10 +247,10 @@ void linux_thread_pool_t::run_thread_pool(linux_thread_message_t *initial_messag
     {
         struct sigaction sa = make_sa_sigaction(SA_SIGINFO, &linux_thread_pool_t::interrupt_handler);
 
-        int res = sigaction(SIGTERM, &sa, NULL);
+        int res = sigaction(SIGTERM, &sa, nullptr);
         guarantee_err(res == 0, "Could not install TERM handler");
 
-        res = sigaction(SIGINT, &sa, NULL);
+        res = sigaction(SIGINT, &sa, nullptr);
         guarantee_err(res == 0, "Could not install INT handler");
     }
 #endif
@@ -273,14 +273,14 @@ void linux_thread_pool_t::run_thread_pool(linux_thread_message_t *initial_messag
     {
         struct sigaction sa = make_sa_handler(0, SIG_IGN);
 
-        res = sigaction(SIGTERM, &sa, NULL);
+        res = sigaction(SIGTERM, &sa, nullptr);
         guarantee_err(res == 0, "Could not remove TERM handler");
 
-        res = sigaction(SIGINT, &sa, NULL);
+        res = sigaction(SIGINT, &sa, nullptr);
         guarantee_err(res == 0, "Could not remove INT handler");
     }
 #endif
-    set_thread_pool(NULL);
+    set_thread_pool(nullptr);
 
 #ifndef NDEBUG
     // Save each thread's coroutine counters before shutting down
@@ -304,7 +304,7 @@ void linux_thread_pool_t::run_thread_pool(linux_thread_message_t *initial_messag
     for (int i = 0; i < n_threads; i++) {
         // Wait for child thread to actually exit
 
-        res = pthread_join(pthreads[i], NULL);
+        res = pthread_join(pthreads[i], nullptr);
         guarantee_xerr(res == 0, res, "Could not join thread");
     }
 
@@ -345,8 +345,8 @@ void linux_thread_pool_t::interrupt_handler(int signo, siginfo_t *siginfo, void 
     to send the same thread message twice until it has been received the first time
     (because of the intrusive list), and we could hypothetically get two SIGINTs
     in quick succession. */
-    os_signal_cond_t *interrupt_signal = self->set_interrupt_message(NULL);
-    if (interrupt_signal != NULL) {
+    os_signal_cond_t *interrupt_signal = self->set_interrupt_message(nullptr);
+    if (interrupt_signal != nullptr) {
         interrupt_signal->source_signo = signo;
         interrupt_signal->source_pid = siginfo->si_pid;
         interrupt_signal->source_uid = siginfo->si_uid;
@@ -411,7 +411,7 @@ linux_thread_t::linux_thread_t(linux_thread_pool_t *parent_pool, int thread_id)
 #endif
 {
     // Initialize the mutex which synchronizes access to the do_shutdown variable
-    int res = pthread_mutex_init(&do_shutdown_mutex, NULL);
+    int res = pthread_mutex_init(&do_shutdown_mutex, nullptr);
     guarantee_xerr(res == 0, res, "could not initialize do_shutdown_mutex");
 
     // Watch an eventfd for shutdown notifications
@@ -422,7 +422,7 @@ linux_thread_t::~linux_thread_t() {
 
 #ifndef NDEBUG
     // Save the coroutine counts before they're deleted, should be ready at shutdown
-    rassert(coroutine_counts_at_shutdown != NULL);
+    rassert(coroutine_counts_at_shutdown != nullptr);
     coroutine_counts_at_shutdown->clear();
     coro_runtime.get_coroutine_counts(coroutine_counts_at_shutdown);
 #endif

--- a/src/arch/runtime/thread_pool.hpp
+++ b/src/arch/runtime/thread_pool.hpp
@@ -141,7 +141,7 @@ struct generic_job_t :
 template <class Callable>
 void linux_thread_pool_t::run_in_blocker_pool(const Callable &fn)
 {
-    if (get_thread_pool() != NULL) {
+    if (get_thread_pool() != nullptr) {
         generic_job_t<Callable> job;
         job.fn = &fn;
         job.suspended = coro_t::self();

--- a/src/arch/spinlock.cc
+++ b/src/arch/spinlock.cc
@@ -4,7 +4,7 @@ spinlock_t::spinlock_t() {
 #if PTHREAD_HAS_SPINLOCK
     int res = pthread_spin_init(&l, PTHREAD_PROCESS_PRIVATE);
 #else
-    int res = pthread_mutex_init(&l, NULL);
+    int res = pthread_mutex_init(&l, nullptr);
 #endif
     guarantee_xerr(res == 0, res, "could not initialize spinlock");
 }

--- a/src/arch/timer.cc
+++ b/src/arch/timer.cc
@@ -9,7 +9,7 @@ class timer_token_t : public intrusive_priority_queue_node_t<timer_token_t> {
     friend class timer_handler_t;
 
 private:
-    timer_token_t() : interval_nanos(-1), next_time_in_nanos(-1), callback(NULL) { }
+    timer_token_t() : interval_nanos(-1), next_time_in_nanos(-1), callback(nullptr) { }
 
     friend bool left_is_higher_priority(const timer_token_t *left, const timer_token_t *right);
 
@@ -84,7 +84,7 @@ timer_token_t *timer_handler_t::add_timer_internal(const int64_t ms, timer_callb
     const timer_token_t *top_entry = token_queue.peek();
     token_queue.push(token);
 
-    if (top_entry == NULL || next_time_in_nanos < top_entry->next_time_in_nanos) {
+    if (top_entry == nullptr || next_time_in_nanos < top_entry->next_time_in_nanos) {
         timer_provider.schedule_oneshot(next_time_in_nanos, this);
     }
 

--- a/src/arch/timing.cc
+++ b/src/arch/timing.cc
@@ -25,19 +25,19 @@ void nap(int64_t ms, const signal_t *interruptor) THROWS_ONLY(interrupted_exc_t)
 
 // signal_timer_t
 
-signal_timer_t::signal_timer_t() : timer(NULL) { }
-signal_timer_t::signal_timer_t(int64_t ms) : timer(NULL) {
+signal_timer_t::signal_timer_t() : timer(nullptr) { }
+signal_timer_t::signal_timer_t(int64_t ms) : timer(nullptr) {
     start(ms);
 }
 
 signal_timer_t::~signal_timer_t() {
-    if (timer != NULL) {
+    if (timer != nullptr) {
         cancel_timer(timer);
     }
 }
 
 void signal_timer_t::start(int64_t ms) {
-    guarantee(timer == NULL);
+    guarantee(timer == nullptr);
     guarantee(!is_pulsed());
     if (ms == 0) {
         pulse();
@@ -48,20 +48,20 @@ void signal_timer_t::start(int64_t ms) {
 }
 
 bool signal_timer_t::cancel() {
-    if (timer != NULL) {
+    if (timer != nullptr) {
         cancel_timer(timer);
-        timer = NULL;
+        timer = nullptr;
         return true;
     }
     return false;
 }
 
 bool signal_timer_t::is_running() const {
-    return is_pulsed() || timer != NULL;
+    return is_pulsed() || timer != nullptr;
 }
 
 void signal_timer_t::on_timer() {
-    timer = NULL;
+    timer = nullptr;
     pulse();
 }
 

--- a/src/arch/windows_stub/pthread.cc
+++ b/src/arch/windows_stub/pthread.cc
@@ -21,7 +21,7 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_
         return reinterpret_cast<DWORD>(res);
     };
     HANDLE handle = CreateThread(nullptr, 0, go, static_cast<void*>(data), 0, nullptr);
-    if (handle == NULL) {
+    if (handle == nullptr) {
         logERR("CreateThread failed: %s", winerr_string(GetLastError()));
         return EINVAL;
     } else {
@@ -45,7 +45,7 @@ int pthread_join(pthread_t other, void** retval) {
 }
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *opts) {
-    rassert(opts == NULL, "this implementation of pthread_mutex_init does not support attributes");
+    rassert(opts == nullptr, "this implementation of pthread_mutex_init does not support attributes");
     InitializeCriticalSection(mutex);
     return 0;
 }

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -46,8 +46,8 @@ static bool parse_backtrace_line(char *line, char **filename, char **function, c
         if (*line != ' ') return false;
         line += 1;
     } else {
-        *function = NULL;
-        *offset = NULL;
+        *function = nullptr;
+        *offset = nullptr;
         char *bracket = strchr(line, '[');
         if (!bracket) return false;
         line = bracket - 1;
@@ -94,7 +94,7 @@ been involved in this. */
 
 std::string demangle_cpp_name(const char *mangled_name) {
     int res;
-    char *name_as_c_str = abi::__cxa_demangle(mangled_name, NULL, 0, &res);
+    char *name_as_c_str = abi::__cxa_demangle(mangled_name, nullptr, nullptr, &res);
     if (res == 0) {
         std::string name_as_std_string(name_as_c_str);
         free(name_as_c_str);
@@ -112,7 +112,7 @@ int set_o_cloexec(int fd) {
     return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
 }
 
-address_to_line_t::addr2line_t::addr2line_t(const char *executable) : input(NULL), output(NULL), bad(false), pid(-1) {
+address_to_line_t::addr2line_t::addr2line_t(const char *executable) : input(nullptr), output(nullptr), bad(false), pid(-1) {
     if (pipe(child_in) || set_o_cloexec(child_in[0]) || set_o_cloexec(child_in[1]) || pipe(child_out) || set_o_cloexec(child_out[0]) || set_o_cloexec(child_out[1])) {
         bad = true;
         return;
@@ -127,7 +127,7 @@ address_to_line_t::addr2line_t::addr2line_t(const char *executable) : input(NULL
         dup2(child_in[0], 0);   // stdin
         dup2(child_out[1], 1);  // stdout
 
-        const char *args[] = {"addr2line", "-s", "-e", executable, NULL};
+        const char *args[] = {"addr2line", "-s", "-e", executable, nullptr};
 
         execvp("addr2line", const_cast<char *const *>(args));
         // A normal `exit` can get stuck here it seems. Maybe some `atexit` handler?
@@ -143,7 +143,7 @@ address_to_line_t::addr2line_t::~addr2line_t() {
         fclose(output);
     }
     if (pid != -1) {
-        waitpid(pid, NULL, 0);
+        waitpid(pid, nullptr, 0);
     }
 }
 
@@ -172,7 +172,7 @@ bool address_to_line_t::run_addr2line(const std::string &executable, const void 
 
     char *result = fgets(line, line_size, proc->output);
 
-    if (result == NULL) {
+    if (result == nullptr) {
         proc->bad = true;
         return false;
     }
@@ -210,7 +210,7 @@ backtrace_t::backtrace_t() {
     int size = rethinkdb_backtrace(stack_frames.data(), max_frames);
 
 #ifdef CROSS_CORO_BACKTRACES
-    if (coro_t::self() != NULL) {
+    if (coro_t::self() != nullptr) {
         int space_remaining = max_frames - size;
         rassert(space_remaining >= 0);
         size += coro_t::self()->copy_spawn_backtrace(stack_frames.data() + size,
@@ -274,20 +274,20 @@ backtrace_frame_t::backtrace_frame_t(const void* _addr) :
 void backtrace_frame_t::initialize_symbols() {
     void *addr_array[1] = {const_cast<void *>(addr)};
     char **symbols = backtrace_symbols(addr_array, 1);
-    if (symbols != NULL) {
+    if (symbols != nullptr) {
         symbols_line = std::string(symbols[0]);
         char *c_filename;
         char *c_function;
         char *c_offset;
         char *c_address;
         if (parse_backtrace_line(symbols[0], &c_filename, &c_function, &c_offset, &c_address)) {
-            if (c_filename != NULL) {
+            if (c_filename != nullptr) {
                 filename = std::string(c_filename);
             }
-            if (c_function != NULL) {
+            if (c_function != nullptr) {
                 function = std::string(c_function);
             }
-            if (c_offset != NULL) {
+            if (c_offset != nullptr) {
                 offset = std::string(c_offset);
             }
         }
@@ -327,7 +327,7 @@ const void *backtrace_frame_t::get_addr() const {
 
 lazy_backtrace_formatter_t::lazy_backtrace_formatter_t() :
     backtrace_t(),
-    timestamp(time(0)),
+    timestamp(time(nullptr)),
     timestr(time2str(timestamp)) {
 }
 

--- a/src/btree/concurrent_traversal.hpp
+++ b/src/btree/concurrent_traversal.hpp
@@ -50,7 +50,7 @@ public:
             concurrent_traversal_fifo_enforcer_signal_t waiter)
             THROWS_ONLY(interrupted_exc_t) = 0;
 
-    virtual profile::trace_t *get_trace() THROWS_NOTHING { return NULL; }
+    virtual profile::trace_t *get_trace() THROWS_NOTHING { return nullptr; }
 
 protected:
     virtual ~concurrent_traversal_callback_t() { }

--- a/src/btree/depth_first_traversal.cc
+++ b/src/btree/depth_first_traversal.cc
@@ -17,8 +17,8 @@ scoped_key_value_t::scoped_key_value_t(scoped_key_value_t &&movee)
     : key_(movee.key_),
       value_(movee.value_),
       buf_(std::move(movee.buf_)) {
-    movee.key_ = NULL;
-    movee.value_ = NULL;
+    movee.key_ = nullptr;
+    movee.value_ = nullptr;
 }
 
 scoped_key_value_t::~scoped_key_value_t() { }

--- a/src/btree/depth_first_traversal.hpp
+++ b/src/btree/depth_first_traversal.hpp
@@ -126,7 +126,7 @@ public:
     resulting key ranges would be contiguous and non-overlapping, and they would together
     cover the full range of the traversal. */
 
-    virtual profile::trace_t *get_trace() THROWS_NOTHING { return NULL; }
+    virtual profile::trace_t *get_trace() THROWS_NOTHING { return nullptr; }
 protected:
     virtual ~depth_first_traversal_callback_t() { }
 };

--- a/src/btree/get_distribution.cc
+++ b/src/btree/get_distribution.cc
@@ -15,7 +15,7 @@ public:
     { }
 
     void read_stat_block(buf_lock_t *stat_block) {
-        guarantee (stat_block != NULL);
+        guarantee (stat_block != nullptr);
         buf_read_t read(stat_block);
         uint32_t sb_size;
         const btree_statblock_t *sb_data =

--- a/src/btree/internal_node.cc
+++ b/src/btree/internal_node.cc
@@ -143,7 +143,7 @@ bool level(block_size_t block_size, internal_node_t *node,
            std::vector<block_id_t> *moved_children_out) {
     validate(block_size, node);
     validate(block_size, sibling);
-    if (moved_children_out != NULL) {
+    if (moved_children_out != nullptr) {
         moved_children_out->reserve(sibling->npairs);
     }
 
@@ -170,7 +170,7 @@ bool level(block_size_t block_size, internal_node_t *node,
             const uint16_t new_offset = impl::insert_pair(node, pair_to_move);
             node->pair_offsets[new_npairs] = new_offset;
             ++new_npairs;
-            if (moved_children_out != NULL) {
+            if (moved_children_out != nullptr) {
                 moved_children_out->push_back(pair_to_move->lnode);
             }
 
@@ -190,7 +190,7 @@ bool level(block_size_t block_size, internal_node_t *node,
 
         keycpy(replacement_key, &pair_for_parent->key);
 
-        if (moved_children_out != NULL) {
+        if (moved_children_out != nullptr) {
             moved_children_out->push_back(pair_for_parent->lnode);
         }
         impl::delete_pair(sibling, sibling->pair_offsets[0]);
@@ -203,7 +203,7 @@ bool level(block_size_t block_size, internal_node_t *node,
         block_id_t first_child = get_pair_by_index(sibling, sibling->npairs-1)->lnode;
         offset = impl::insert_pair(node, first_child, key_from_parent);
         impl::insert_offset(node, offset, 0);
-        if (moved_children_out != NULL) {
+        if (moved_children_out != nullptr) {
             moved_children_out->push_back(first_child);
         }
         impl::delete_pair(sibling, sibling->pair_offsets[sibling->npairs-1]);
@@ -220,7 +220,7 @@ bool level(block_size_t block_size, internal_node_t *node,
 
             offset = impl::insert_pair(node, pair_to_move);
             impl::insert_offset(node, offset, 0);
-            if (moved_children_out != NULL) {
+            if (moved_children_out != nullptr) {
                 moved_children_out->push_back(pair_to_move->lnode);
             }
 

--- a/src/btree/internal_node.hpp
+++ b/src/btree/internal_node.hpp
@@ -67,7 +67,7 @@ class internal_key_comp {
 public:
     enum { faux_offset = 0 };
 
-    explicit internal_key_comp(const internal_node_t *_node) : node(_node), key(NULL)  { }
+    explicit internal_key_comp(const internal_node_t *_node) : node(_node), key(nullptr)  { }
     internal_key_comp(const internal_node_t *_node, const btree_key_t *_key) : node(_node), key(_key)  { }
     bool operator()(const uint16_t offset1, const uint16_t offset2) {
         const btree_key_t *key1 = offset1 == faux_offset ? key : &internal_node::get_pair(node, offset1)->key;

--- a/src/btree/leaf_node.cc
+++ b/src/btree/leaf_node.cc
@@ -114,7 +114,7 @@ const btree_key_t *entry_key(const entry_t *p) {
 
 const void *entry_value(const entry_t *p) {
     if (entry_is_deletion(p)) {
-        return NULL;
+        return nullptr;
     } else {
         return reinterpret_cast<const char *>(p) + entry_key(p)->full_size();
     }
@@ -425,14 +425,14 @@ bool fsck(value_sizer_t *sizer, const btree_key_t *left_exclusive_or_null, const
     const btree_key_t *last = left_exclusive_or_null;
     for (int k = 0; k < node->num_pairs; ++k) {
         const btree_key_t *key = entry_key(get_entry(node, node->pair_offsets[k]));
-        if (failed(last == NULL || btree_key_cmp(last, key) < 0,
+        if (failed(last == nullptr || btree_key_cmp(last, key) < 0,
                    "keys out of order")) {
             return false;
         }
         last = key;
     }
 
-    if (failed(last == NULL || right_inclusive_or_null == NULL
+    if (failed(last == nullptr || right_inclusive_or_null == nullptr
                || btree_key_cmp(last, right_inclusive_or_null) <= 0,
                "keys out of order (with right_inclusive key)")) {
         return false;
@@ -446,7 +446,7 @@ void validate(DEBUG_VAR value_sizer_t *sizer, DEBUG_VAR const leaf_node_t *node)
 #ifndef NDEBUG
     do_nothing_fscker_t fits;
     std::string msg;
-    bool fscked_successfully = fsck(sizer, NULL, NULL, node, &fits, &msg);
+    bool fscked_successfully = fsck(sizer, nullptr, nullptr, node, &fits, &msg);
     rassert(fscked_successfully, "%s", msg.c_str());
 #endif
 }
@@ -928,7 +928,7 @@ void move_elements(value_sizer_t *sizer, leaf_node_t *fro, int beg, int end,
 
     fro->live_size += fro_live_size_adjustment;
 
-    if (moved_values_out != NULL) {
+    if (moved_values_out != nullptr) {
         // Collect value pointers of the moved values
         moved_values_out->clear();
         moved_values_out->reserve(end - beg);
@@ -1034,7 +1034,7 @@ void split(value_sizer_t *sizer, leaf_node_t *node, leaf_node_t *rnode, btree_ke
 
     int node_copysize = end_rcost - num_mandatories * sizeof(uint16_t);
     move_elements(sizer, node, s, node->num_pairs, 0, rnode, node_copysize,
-                  tstamp_back_offset, NULL);
+                  tstamp_back_offset, nullptr);
 
     keycpy(median_out, entry_key(get_entry(node, node->pair_offsets[s - 1])));
 }
@@ -1060,7 +1060,7 @@ void merge(value_sizer_t *sizer, leaf_node_t *left, leaf_node_t *right) {
     }
 
     move_elements(sizer, left, 0, left->num_pairs, 0, right, left_copysize,
-                  tstamp_back_offset, NULL);
+                  tstamp_back_offset, nullptr);
 }
 
 // We move keys out of sibling and into node.
@@ -1712,7 +1712,7 @@ continue_bool_t visit_entries(
 }
 
 iterator::iterator()
-    : node_(NULL), index_(-1) { }
+    : node_(nullptr), index_(-1) { }
 
 iterator::iterator(const leaf_node_t *node, int index)
     : node_(node), index_(index) { }

--- a/src/btree/operations.cc
+++ b/src/btree/operations.cc
@@ -417,12 +417,12 @@ void find_keyvalue_location_for_write(
         // its direct children, we might still want to replace the root, so
         // we can't release the superblock yet.
         if (!last_buf.empty() && keyvalue_location_out->superblock) {
-            if (pass_back_superblock != NULL) {
+            if (pass_back_superblock != nullptr) {
                 pass_back_superblock->pulse(superblock);
-                keyvalue_location_out->superblock = NULL;
+                keyvalue_location_out->superblock = nullptr;
             } else {
                 keyvalue_location_out->superblock->release();
-                keyvalue_location_out->superblock = NULL;
+                keyvalue_location_out->superblock = nullptr;
             }
         }
 

--- a/src/btree/operations.hpp
+++ b/src/btree/operations.hpp
@@ -68,7 +68,7 @@ public:
               &pm_total_keys_read, "total_keys_read",
               &pm_keys_set, "keys_set",
               &pm_total_keys_set, "total_keys_set") {
-        if (parent != NULL) {
+        if (parent != nullptr) {
             rename(parent, identifier);
         }
     }
@@ -100,7 +100,7 @@ public:
 class keyvalue_location_t {
 public:
     keyvalue_location_t()
-        : superblock(NULL), pass_back_superblock(NULL),
+        : superblock(nullptr), pass_back_superblock(nullptr),
           there_originally_was_value(false), stat_block(NULL_BLOCK_ID) { }
 
     ~keyvalue_location_t() {
@@ -203,7 +203,7 @@ void find_keyvalue_location_for_write(
         const value_deleter_t *balancing_detacher,
         keyvalue_location_t *keyvalue_location_out,
         profile::trace_t *trace,
-        promise_t<superblock_t *> *pass_back_superblock = NULL) THROWS_NOTHING;
+        promise_t<superblock_t *> *pass_back_superblock = nullptr) THROWS_NOTHING;
 
 void find_keyvalue_location_for_read(
         value_sizer_t *sizer,

--- a/src/btree/parallel_traversal.cc
+++ b/src/btree/parallel_traversal.cc
@@ -356,7 +356,7 @@ void btree_parallel_traversal(superblock_t *superblock,
                               state.stat_block, access_t::read);
         helper->read_stat_block(&stat_block);
     } else {
-        helper->read_stat_block(NULL);
+        helper->read_stat_block(nullptr);
     }
 
     if (helper->progress) {
@@ -389,7 +389,7 @@ void btree_parallel_traversal(superblock_t *superblock,
     } else {
         state.level_count(0) += 1;
         state.acquisition_waiter_stacks.resize(1);
-        counted_t<ranged_block_ids_t> ids_source(new ranged_block_ids_t(root_id, NULL, NULL, 0));
+        counted_t<ranged_block_ids_t> ids_source(new ranged_block_ids_t(root_id, nullptr, nullptr, 0));
         subtrees_traverse(&state,
                           &superblock_releaser, 1, ids_source);
         state.wait();
@@ -431,8 +431,8 @@ struct do_a_subtree_traversal_fsm_t : public node_ready_callback_t {
             is_leaf = node::is_leaf(node);
         }
 
-        const btree_key_t *left_exclusive_or_null = left_unbounded ? NULL : left_exclusive.btree_key();
-        const btree_key_t *right_inclusive_or_null = right_unbounded ? NULL : right_inclusive.btree_key();
+        const btree_key_t *left_exclusive_or_null = left_unbounded ? nullptr : left_exclusive.btree_key();
+        const btree_key_t *right_inclusive_or_null = right_unbounded ? nullptr : right_inclusive.btree_key();
 
         if (is_leaf) {
             if (state->helper->progress) {

--- a/src/btree/parallel_traversal.hpp
+++ b/src/btree/parallel_traversal.hpp
@@ -111,7 +111,7 @@ class parallel_traversal_progress_t;
 
 struct btree_traversal_helper_t {
     btree_traversal_helper_t()
-        : progress(NULL)
+        : progress(nullptr)
     { }
 
     //Before any of these other functions are called the helper gets a chance

--- a/src/btree/reql_specific.cc
+++ b/src/btree/reql_specific.cc
@@ -227,7 +227,7 @@ void superblock_metainfo_iterator_t::advance(char * p) {
 check_failed:
     pos = next_pos = end;
     key_size = value_size = 0;
-    key_ptr = value_ptr = NULL;
+    key_ptr = value_ptr = nullptr;
 }
 
 void superblock_metainfo_iterator_t::operator++() {

--- a/src/btree/superblock.hpp
+++ b/src/btree/superblock.hpp
@@ -14,7 +14,7 @@ public:
         rassert(refcount >= 0);
         if (refcount == 0) {
             sub_superblock->release();
-            sub_superblock = NULL;
+            sub_superblock = nullptr;
         }
     }
 

--- a/src/buffer_cache/alt.cc
+++ b/src/buffer_cache/alt.cc
@@ -121,15 +121,15 @@ cache_t::matching_snapshot_node_or_null(block_id_t block_id,
     ASSERT_NO_CORO_WAITING;
     auto list_it = snapshot_nodes_by_block_id_.find(block_id);
     if (list_it == snapshot_nodes_by_block_id_.end()) {
-        return NULL;
+        return nullptr;
     }
     intrusive_list_t<alt_snapshot_node_t> *list = &list_it->second;
-    for (alt_snapshot_node_t *p = list->tail(); p != NULL; p = list->prev(p)) {
+    for (alt_snapshot_node_t *p = list->tail(); p != nullptr; p = list->prev(p)) {
         if (p->current_page_acq_->block_version() == block_version) {
             return p;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 void cache_t::add_snapshot_node(block_id_t block_id,
@@ -172,7 +172,7 @@ void cache_t::remove_snapshot_node(block_id_t block_id, alt_snapshot_node_t *nod
             debugf("decring child %p from parent %p (in %p)\n",
                    it->second, pair.second, this);
 #endif
-            if (it->second != NULL) {
+            if (it->second != nullptr) {
                 --it->second->ref_count_;
                 if (it->second->ref_count_ == 0) {
 #if ALT_DEBUG
@@ -196,7 +196,7 @@ txn_t::txn_t(cache_conn_t *cache_conn,
     // need to support other cache_conn_t related features (like read operations
     // magically passing write operations), we'll need to do something fancier with
     // read txns on cache conns.
-    help_construct(0, NULL);
+    help_construct(0, nullptr);
 }
 
 txn_t::txn_t(cache_conn_t *cache_conn,
@@ -270,9 +270,9 @@ alt_snapshot_node_t::~alt_snapshot_node_t() {
 }
 
 buf_lock_t::buf_lock_t()
-    : txn_(NULL),
+    : txn_(nullptr),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) { }
 
 #if ALT_DEBUG
@@ -290,7 +290,7 @@ alt_snapshot_node_t *buf_lock_t::help_make_child(cache_t *cache,
     alt_snapshot_node_t *child
         = cache->matching_snapshot_node_or_null(child_id, acq->block_version());
 
-    if (child != NULL) {
+    if (child != nullptr) {
         acq.reset();
     } else {
         acq->declare_snapshotted();
@@ -345,13 +345,13 @@ void buf_lock_t::create_child_snapshot_attachments(cache_t *cache,
     ASSERT_FINITE_CORO_WAITING;
     // We create at most one child snapshot node.
 
-    alt_snapshot_node_t *child = NULL;
+    alt_snapshot_node_t *child = nullptr;
     auto list_it = cache->snapshot_nodes_by_block_id_.find(parent_id);
     if (list_it == cache->snapshot_nodes_by_block_id_.end()) {
         return;
     }
     for (alt_snapshot_node_t *p = list_it->second.tail();
-         p != NULL;
+         p != nullptr;
          p = list_it->second.prev(p)) {
         auto it = p->children_.find(child_id);
         if (it != p->children_.end()) {
@@ -363,7 +363,7 @@ void buf_lock_t::create_child_snapshot_attachments(cache_t *cache,
             continue;
         }
 
-        if (child == NULL) {
+        if (child == nullptr) {
             child = help_make_child(cache, child_id);
         }
 
@@ -385,7 +385,7 @@ void buf_lock_t::create_empty_child_snapshot_attachments(cache_t *cache,
         return;
     }
     for (alt_snapshot_node_t *p = list_it->second.tail();
-         p != NULL;
+         p != nullptr;
          p = list_it->second.prev(p)) {
         auto it = p->children_.find(child_id);
         if (it != p->children_.end()) {
@@ -398,7 +398,7 @@ void buf_lock_t::create_empty_child_snapshot_attachments(cache_t *cache,
         }
 
         p->children_.insert(std::make_pair(child_id,
-                                           static_cast<alt_snapshot_node_t *>(NULL)));
+                                           static_cast<alt_snapshot_node_t *>(nullptr)));
     }
 }
 
@@ -406,7 +406,7 @@ void buf_lock_t::help_construct(buf_parent_t parent, block_id_t block_id,
                                 access_t access) {
     buf_lock_t::wait_for_parent(parent, access);
     ASSERT_FINITE_CORO_WAITING;
-    if (parent.lock_or_null_ != NULL && parent.lock_or_null_->snapshot_node_ != NULL) {
+    if (parent.lock_or_null_ != nullptr && parent.lock_or_null_->snapshot_node_ != nullptr) {
         rassert(access == access_t::read);
         buf_lock_t *parent_lock = parent.lock_or_null_;
         rassert(!parent_lock->current_page_acq_.has());
@@ -414,14 +414,14 @@ void buf_lock_t::help_construct(buf_parent_t parent, block_id_t block_id,
             = get_or_create_child_snapshot_node(txn_->cache(),
                                                 parent_lock->snapshot_node_,
                                                 block_id);
-        guarantee(snapshot_node_ != NULL,
+        guarantee(snapshot_node_ != nullptr,
                   "Tried to acquire (in cache %p) a deleted block (%" PRIu64
                   " as child of %" PRIu64 ") (with read access).",
                   txn_->cache(),
                   block_id, parent_lock->block_id());
         ++snapshot_node_->ref_count_;
     } else {
-        if (access == access_t::write && parent.lock_or_null_ != NULL) {
+        if (access == access_t::write && parent.lock_or_null_ != nullptr) {
             create_child_snapshot_attachments(txn_->cache(),
                                               parent.lock_or_null_->current_page_acq()->block_version(),
                                               parent.lock_or_null_->block_id(),
@@ -441,7 +441,7 @@ buf_lock_t::buf_lock_t(buf_parent_t parent,
                        access_t access)
     : txn_(parent.txn()),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(parent, block_id, access);
 }
@@ -451,7 +451,7 @@ buf_lock_t::buf_lock_t(buf_lock_t *parent,
                        access_t access)
     : txn_(parent->txn_),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(buf_parent_t(parent), block_id, access);
 }
@@ -475,7 +475,7 @@ void buf_lock_t::help_construct(buf_parent_t parent, block_id_t block_id,
                                                   access_t::write,
                                                   alt::page_create_t::yes));
 
-    if (parent.lock_or_null_ != NULL) {
+    if (parent.lock_or_null_ != nullptr) {
         create_empty_child_snapshot_attachments(txn_->cache(),
                                           parent.lock_or_null_->current_page_acq()->block_version(),
                                           parent.lock_or_null_->block_id(),
@@ -497,7 +497,7 @@ buf_lock_t::buf_lock_t(txn_t *txn,
                        alt_create_t create)
     : txn_(txn),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(buf_parent_t(txn), block_id, create);
 }
@@ -507,7 +507,7 @@ buf_lock_t::buf_lock_t(buf_parent_t parent,
                        alt_create_t create)
     : txn_(parent.txn()),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(parent, block_id, create);
 }
@@ -523,7 +523,7 @@ void buf_lock_t::mark_deleted() {
 }
 
 void buf_lock_t::wait_for_parent(buf_parent_t parent, access_t access) {
-    if (parent.lock_or_null_ != NULL) {
+    if (parent.lock_or_null_ != nullptr) {
         buf_lock_t *lock = parent.lock_or_null_;
         guarantee(is_subordinate(lock->access(), access));
         if (access == access_t::write) {
@@ -554,7 +554,7 @@ void buf_lock_t::help_construct(
                                                   alt_create_t::create,
                                                   block_type));
 
-    if (parent.lock_or_null_ != NULL) {
+    if (parent.lock_or_null_ != nullptr) {
         create_empty_child_snapshot_attachments(txn_->cache(),
                                           parent.lock_or_null_->current_page_acq()->block_version(),
                                           parent.lock_or_null_->block_id(),
@@ -576,7 +576,7 @@ buf_lock_t::buf_lock_t(buf_parent_t parent,
                        block_type_t block_type)
     : txn_(parent.txn()),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(parent, create, block_type);
 }
@@ -586,13 +586,13 @@ buf_lock_t::buf_lock_t(buf_lock_t *parent,
                        block_type_t block_type)
     : txn_(parent->txn_),
       current_page_acq_(),
-      snapshot_node_(NULL),
+      snapshot_node_(nullptr),
       access_ref_count_(0) {
     help_construct(buf_parent_t(parent), create, block_type);
 }
 
 buf_lock_t::~buf_lock_t() {
-    if (txn_ != NULL) {
+    if (txn_ != nullptr) {
         cache()->assert_thread();
 #if ALT_DEBUG
         debugf("%p: buf_lock_t %p destroy %" PRIu64 "\n", cache(), this, block_id());
@@ -600,7 +600,7 @@ buf_lock_t::~buf_lock_t() {
     }
     guarantee(access_ref_count_ == 0);
 
-    if (snapshot_node_ != NULL) {
+    if (snapshot_node_ != nullptr) {
         --snapshot_node_->ref_count_;
         if (snapshot_node_->ref_count_ == 0) {
 #if ALT_DEBUG
@@ -619,9 +619,9 @@ buf_lock_t::buf_lock_t(buf_lock_t &&movee)
       snapshot_node_(movee.snapshot_node_),
       access_ref_count_(0) {
     guarantee(movee.access_ref_count_ == 0);
-    movee.txn_ = NULL;
+    movee.txn_ = nullptr;
     movee.current_page_acq_.reset();
-    movee.snapshot_node_ = NULL;
+    movee.snapshot_node_ = nullptr;
 }
 
 buf_lock_t &buf_lock_t::operator=(buf_lock_t &&movee) {
@@ -658,7 +658,7 @@ void buf_lock_t::snapshot_subdag() {
 #endif
     ASSERT_FINITE_CORO_WAITING;
     guarantee(!empty());
-    if (snapshot_node_ != NULL) {
+    if (snapshot_node_ != nullptr) {
         return;
     }
 
@@ -666,7 +666,7 @@ void buf_lock_t::snapshot_subdag() {
         = cache()->matching_snapshot_node_or_null(block_id(),
                                                   current_page_acq_->block_version());
 
-    if (matching_node != NULL) {
+    if (matching_node != nullptr) {
         snapshot_node_ = matching_node;
         ++matching_node->ref_count_;
     } else {
@@ -687,7 +687,7 @@ void buf_lock_t::snapshot_subdag() {
 current_page_acq_t *buf_lock_t::current_page_acq() const {
     ASSERT_NO_CORO_WAITING;
     guarantee(!empty());
-    if (snapshot_node_ != NULL) {
+    if (snapshot_node_ != nullptr) {
         return snapshot_node_->current_page_acq_.get();
     } else {
         return current_page_acq_.get();
@@ -710,7 +710,7 @@ void buf_lock_t::detach_child(block_id_t child_id) {
 repli_timestamp_t buf_lock_t::get_recency() const {
     guarantee(!empty());
     current_page_acq_t *cpa = current_page_acq();
-    guarantee(cpa != NULL);
+    guarantee(cpa != nullptr);
 
     // Emulate the cpa->recency() waiting behavior.  We only do this waiting here so
     // that we can guarantee(!empty()) after it's pulsed.  (FYI: We and the
@@ -736,7 +736,7 @@ void buf_lock_t::set_recency(repli_timestamp_t recency) {
     // You should never need to set the recency of an aux block. It will be
     // discarded anyway.
     guarantee(!is_aux_block_id(block_id()));
-    rassert(snapshot_node_ == NULL);
+    rassert(snapshot_node_ == nullptr);
 
     // We only wait here so that we can guarantee(!empty()) after it's pulsed.
     current_page_acq_->write_acq_signal()->wait();
@@ -753,7 +753,7 @@ void buf_lock_t::set_recency(repli_timestamp_t recency) {
 page_t *buf_lock_t::get_held_page_for_read() {
     guarantee(!empty());
     current_page_acq_t *cpa = current_page_acq();
-    guarantee(cpa != NULL);
+    guarantee(cpa != nullptr);
     // We only wait here so that we can guarantee(!empty()) after it's pulsed.
     cpa->read_acq_signal()->wait();
 
@@ -764,7 +764,7 @@ page_t *buf_lock_t::get_held_page_for_read() {
 
 page_t *buf_lock_t::get_held_page_for_write() {
     guarantee(!empty());
-    rassert(snapshot_node_ == NULL);
+    rassert(snapshot_node_ == nullptr);
     // We only wait here so that we can guarantee(!empty()) after it's pulsed.
     current_page_acq_->write_acq_signal()->wait();
 

--- a/src/buffer_cache/alt.hpp
+++ b/src/buffer_cache/alt.hpp
@@ -185,7 +185,7 @@ public:
     void swap(buf_lock_t &other);
     void reset_buf_lock();
     bool empty() const {
-        return txn_ == NULL;
+        return txn_ == nullptr;
     }
 
     bool is_snapshotted() const;
@@ -194,7 +194,7 @@ public:
     void detach_child(block_id_t child_id);
 
     block_id_t block_id() const {
-        guarantee(txn_ != NULL);
+        guarantee(txn_ != nullptr);
         return current_page_acq()->block_id();
     }
 
@@ -276,27 +276,27 @@ private:
 
 class buf_parent_t {
 public:
-    buf_parent_t() : txn_(NULL), lock_or_null_(NULL) { }
+    buf_parent_t() : txn_(nullptr), lock_or_null_(nullptr) { }
 
     explicit buf_parent_t(buf_lock_t *lock)
         : txn_(lock->txn()), lock_or_null_(lock) {
-        guarantee(lock != NULL);
+        guarantee(lock != nullptr);
         guarantee(!lock->empty());
     }
 
     explicit buf_parent_t(txn_t *txn)
-        : txn_(txn), lock_or_null_(NULL) {
+        : txn_(txn), lock_or_null_(nullptr) {
         rassert(txn != NULL);
     }
 
     void detach_child(block_id_t child_id) {
-        if (lock_or_null_ != NULL) {
+        if (lock_or_null_ != nullptr) {
             lock_or_null_->detach_child(child_id);
         }
     }
 
     bool empty() const {
-        return txn_ == NULL;
+        return txn_ == nullptr;
     }
 
     txn_t *txn() const {

--- a/src/buffer_cache/cache_account.cc
+++ b/src/buffer_cache/cache_account.cc
@@ -3,12 +3,12 @@
 #include "arch/types.hpp"
 
 cache_account_t::cache_account_t()
-    : thread_(-1), io_account_(NULL) { }
+    : thread_(-1), io_account_(nullptr) { }
 
 cache_account_t::cache_account_t(cache_account_t &&movee)
     : thread_(movee.thread_), io_account_(movee.io_account_) {
     movee.thread_ = threadnum_t(-1);
-    movee.io_account_ = NULL;
+    movee.io_account_ = nullptr;
 }
 
 cache_account_t &cache_account_t::operator=(cache_account_t &&movee) {
@@ -19,8 +19,8 @@ cache_account_t &cache_account_t::operator=(cache_account_t &&movee) {
 }
 
 void cache_account_t::init(threadnum_t thread, file_account_t *io_account) {
-    rassert(io_account_ == NULL);
-    rassert(io_account != NULL);
+    rassert(io_account_ == nullptr);
+    rassert(io_account != nullptr);
     io_account_ = io_account;
     thread_ = thread;
 }
@@ -28,15 +28,15 @@ void cache_account_t::init(threadnum_t thread, file_account_t *io_account) {
 
 cache_account_t::cache_account_t(threadnum_t thread, file_account_t *io_account)
     : thread_(thread), io_account_(io_account) {
-    rassert(io_account != NULL);
+    rassert(io_account != nullptr);
 }
 
 void cache_account_t::reset() {
-    if (io_account_ != NULL) {
+    if (io_account_ != nullptr) {
         threadnum_t local_thread = thread_;
         file_account_t *local_account = io_account_;
         thread_ = threadnum_t(-1);
-        io_account_ = NULL;
+        io_account_ = nullptr;
         {
             on_thread_t th(local_thread);
             delete local_account;

--- a/src/buffer_cache/page.hpp
+++ b/src/buffer_cache/page.hpp
@@ -57,10 +57,10 @@ public:
     uint64_t access_time() const { return access_time_; }
 
     bool is_loading() const {
-        return loader_ != NULL && page_t::loader_is_loading(loader_);
+        return loader_ != nullptr && page_t::loader_is_loading(loader_);
     }
     bool is_deferred_loading() const {
-        return loader_ != NULL && !page_t::loader_is_loading(loader_);
+        return loader_ != nullptr && !page_t::loader_is_loading(loader_);
     }
     bool has_waiters() const { return !waiters_.empty(); }
     bool is_loaded() const { return buf_.has(); }
@@ -166,7 +166,7 @@ inline backindex_bag_index_t *access_backindex(page_t *page) {
 class page_ptr_t {
 public:
     explicit page_ptr_t(page_t *page)
-        : page_(NULL) { init(page); }
+        : page_(nullptr) { init(page); }
     page_ptr_t();
 
     // The page_ptr_t MUST be reset before the destructor is called.
@@ -186,7 +186,7 @@ public:
                                cache_account_t *account);
 
     bool has() const {
-        return page_ != NULL;
+        return page_ != nullptr;
     }
 
 private:

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -21,9 +21,9 @@ cache_conn_t::~cache_conn_t() {
     // that the inner page_txn_t's lifetime would exceed the cache_conn_t's.  So we
     // need to tell the page_txn_t that we don't exist -- we do so by nullating its
     // cache_conn_ pointer (which it's capable of handling).
-    if (newest_txn_ != NULL) {
-        newest_txn_->cache_conn_ = NULL;
-        newest_txn_ = NULL;
+    if (newest_txn_ != nullptr) {
+        newest_txn_->cache_conn_ = nullptr;
+        newest_txn_ = nullptr;
     }
 }
 
@@ -86,10 +86,10 @@ void page_read_ahead_cb_t::offer_read_ahead_buf(
 
 void page_read_ahead_cb_t::destroy_self() {
     serializer_->unregister_read_ahead_cb(this);
-    serializer_ = NULL;
+    serializer_ = nullptr;
 
     page_cache_t *page_cache = page_cache_;
-    page_cache_ = NULL;
+    page_cache_ = nullptr;
 
     do_on_thread(page_cache->home_thread(),
                  std::bind(&page_cache_t::read_ahead_cb_is_destroyed, page_cache));
@@ -103,7 +103,7 @@ void page_cache_t::consider_evicting_current_page(block_id_t block_id) {
     // We can't do anything until read-ahead is done, because it uses the existence
     // of a current_page_t entry to figure out whether the read-ahead page could be
     // out of date.
-    if (read_ahead_cb_ != NULL) {
+    if (read_ahead_cb_ != nullptr) {
         return;
     }
 
@@ -127,7 +127,7 @@ void page_cache_t::add_read_ahead_buf(block_id_t block_id,
 
     // We MUST stop if read_ahead_cb_ is NULL because that means current_page_t's
     // could start being destroyed.
-    if (read_ahead_cb_ == NULL) {
+    if (read_ahead_cb_ == nullptr) {
         return;
     }
 
@@ -150,11 +150,11 @@ void page_cache_t::add_read_ahead_buf(block_id_t block_id,
 void page_cache_t::have_read_ahead_cb_destroyed() {
     assert_thread();
 
-    if (read_ahead_cb_ != NULL) {
-        // By setting read_ahead_cb_ to NULL, we make sure we only tell the read
+    if (read_ahead_cb_ != nullptr) {
+        // By setting read_ahead_cb_ to nullptr, we make sure we only tell the read
         // ahead cb to destroy itself exactly once.
         page_read_ahead_cb_t *cb = read_ahead_cb_;
-        read_ahead_cb_ = NULL;
+        read_ahead_cb_ = nullptr;
 
         do_on_thread(cb->home_thread(),
                      std::bind(&page_read_ahead_cb_t::destroy_self, cb));
@@ -208,7 +208,7 @@ page_cache_t::page_cache_t(serializer_t *serializer,
       serializer_(serializer),
       free_list_(serializer),
       evicter_(),
-      read_ahead_cb_(NULL),
+      read_ahead_cb_(nullptr),
       drainer_(make_scoped<auto_drainer_t>()) {
 
     const bool start_read_ahead = balancer->read_ahead_ok_at_start();
@@ -216,7 +216,7 @@ page_cache_t::page_cache_t(serializer_t *serializer,
         read_ahead_cb_existence_ = drainer_->lock();
     }
 
-    page_read_ahead_cb_t *local_read_ahead_cb = NULL;
+    page_read_ahead_cb_t *local_read_ahead_cb = nullptr;
     {
         on_thread_t thread_switcher(serializer->home_thread());
         if (start_read_ahead) {
@@ -431,27 +431,27 @@ cache_account_t page_cache_t::create_cache_account(int priority) {
 
 
 current_page_acq_t::current_page_acq_t()
-    : page_cache_(NULL), the_txn_(NULL) { }
+    : page_cache_(nullptr), the_txn_(nullptr) { }
 
 current_page_acq_t::current_page_acq_t(page_txn_t *txn,
                                        block_id_t block_id,
                                        access_t access,
                                        page_create_t create)
-    : page_cache_(NULL), the_txn_(NULL) {
+    : page_cache_(nullptr), the_txn_(nullptr) {
     init(txn, block_id, access, create);
 }
 
 current_page_acq_t::current_page_acq_t(page_txn_t *txn,
                                        alt_create_t create,
                                        block_type_t block_type)
-    : page_cache_(NULL), the_txn_(NULL) {
+    : page_cache_(nullptr), the_txn_(nullptr) {
     init(txn, create, block_type);
 }
 
 current_page_acq_t::current_page_acq_t(page_cache_t *page_cache,
                                        block_id_t block_id,
                                        read_access_t read)
-    : page_cache_(NULL), the_txn_(NULL) {
+    : page_cache_(nullptr), the_txn_(nullptr) {
     init(page_cache, block_id, read);
 }
 
@@ -464,9 +464,9 @@ void current_page_acq_t::init(page_txn_t *txn,
         init(txn->page_cache(), block_id, read_access_t::read);
     } else {
         txn->page_cache()->assert_thread();
-        guarantee(page_cache_ == NULL);
+        guarantee(page_cache_ == nullptr);
         page_cache_ = txn->page_cache();
-        the_txn_ = (access == access_t::write ? txn : NULL);
+        the_txn_ = (access == access_t::write ? txn : nullptr);
         access_ = access;
         declared_snapshotted_ = false;
         block_id_ = block_id;
@@ -487,7 +487,7 @@ void current_page_acq_t::init(page_txn_t *txn,
                               alt_create_t,
                               block_type_t block_type) {
     txn->page_cache()->assert_thread();
-    guarantee(page_cache_ == NULL);
+    guarantee(page_cache_ == nullptr);
     page_cache_ = txn->page_cache();
     the_txn_ = txn;
     access_ = access_t::write;
@@ -504,9 +504,9 @@ void current_page_acq_t::init(page_cache_t *page_cache,
                               block_id_t block_id,
                               read_access_t) {
     page_cache->assert_thread();
-    guarantee(page_cache_ == NULL);
+    guarantee(page_cache_ == nullptr);
     page_cache_ = page_cache;
-    the_txn_ = NULL;
+    the_txn_ = nullptr;
     access_ = access_t::read;
     declared_snapshotted_ = false;
     block_id_ = block_id;
@@ -519,13 +519,13 @@ void current_page_acq_t::init(page_cache_t *page_cache,
 
 current_page_acq_t::~current_page_acq_t() {
     assert_thread();
-    // Checking page_cache_ != NULL makes sure this isn't a default-constructed acq.
-    if (page_cache_ != NULL) {
-        if (the_txn_ != NULL) {
+    // Checking page_cache_ != nullptr makes sure this isn't a default-constructed acq.
+    if (page_cache_ != nullptr) {
+        if (the_txn_ != nullptr) {
             guarantee(access_ == access_t::write);
             the_txn_->remove_acquirer(this);
         }
-        rassert(current_page_ != NULL);
+        rassert(current_page_ != nullptr);
         if (in_a_list()) {
             // Note that the current_page_acq can be in the current_page_ acquirer
             // list and still be snapshotted. However it will not have a
@@ -544,7 +544,7 @@ current_page_acq_t::~current_page_acq_t() {
 void current_page_acq_t::declare_readonly() {
     assert_thread();
     access_ = access_t::read;
-    if (current_page_ != NULL) {
+    if (current_page_ != nullptr) {
         current_page_->pulse_pulsables(this);
     }
 }
@@ -556,7 +556,7 @@ void current_page_acq_t::declare_snapshotted() {
     // Allow redeclaration of snapshottedness.
     if (!declared_snapshotted_) {
         declared_snapshotted_ = true;
-        rassert(current_page_ != NULL);
+        rassert(current_page_ != nullptr);
         current_page_->add_keepalive();
         current_page_->pulse_pulsables(this);
     }
@@ -575,18 +575,18 @@ signal_t *current_page_acq_t::write_acq_signal() {
 
 page_t *current_page_acq_t::current_page_for_read(cache_account_t *account) {
     assert_thread();
-    rassert(snapshotted_page_.has() || current_page_ != NULL);
+    rassert(snapshotted_page_.has() || current_page_ != nullptr);
     read_cond_.wait();
     if (snapshotted_page_.has()) {
         return snapshotted_page_.get_page_for_read();
     }
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     return current_page_->the_page_for_read(help(), account);
 }
 
 repli_timestamp_t current_page_acq_t::recency() {
     assert_thread();
-    rassert(snapshotted_page_.has() || current_page_ != NULL);
+    rassert(snapshotted_page_.has() || current_page_ != nullptr);
 
     // We wait for write_cond_ when getting the recency (if we're a write acquirer)
     // so that we can't see the recency change before/after the write_cond_ is
@@ -600,16 +600,16 @@ repli_timestamp_t current_page_acq_t::recency() {
     if (snapshotted_page_.has()) {
         return snapshotted_page_.timestamp();
     }
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     return page_cache_->recency_for_block_id(block_id_);
 }
 
 page_t *current_page_acq_t::current_page_for_write(cache_account_t *account) {
     assert_thread();
     rassert(access_ == access_t::write);
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     write_cond_.wait();
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     dirtied_page_ = true;
     return current_page_->the_page_for_write(help(), account);
 }
@@ -617,9 +617,9 @@ page_t *current_page_acq_t::current_page_for_write(cache_account_t *account) {
 void current_page_acq_t::set_recency(repli_timestamp_t recency) {
     assert_thread();
     rassert(access_ == access_t::write);
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     write_cond_.wait();
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     touched_page_ = true;
     page_cache_->set_recency_for_block_id(block_id_, recency);
 }
@@ -627,9 +627,9 @@ void current_page_acq_t::set_recency(repli_timestamp_t recency) {
 void current_page_acq_t::mark_deleted() {
     assert_thread();
     rassert(access_ == access_t::write);
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     write_cond_.wait();
-    rassert(current_page_ != NULL);
+    rassert(current_page_ != nullptr);
     dirtied_page_ = true;
     current_page_->mark_deleted(help());
     // No need to call consider_evicting_current_page here -- there's a
@@ -675,7 +675,7 @@ void current_page_acq_t::pulse_write_available() {
 current_page_t::current_page_t(block_id_t block_id)
     : block_id_(block_id),
       is_deleted_(false),
-      last_write_acquirer_(NULL),
+      last_write_acquirer_(nullptr),
       num_keepalives_(0) {
     // Increment the block version so that we can distinguish between unassigned
     // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
@@ -689,7 +689,7 @@ current_page_t::current_page_t(block_id_t block_id,
     : block_id_(block_id),
       page_(new page_t(block_id, std::move(buf), page_cache)),
       is_deleted_(false),
-      last_write_acquirer_(NULL),
+      last_write_acquirer_(nullptr),
       num_keepalives_(0) {
     // Increment the block version so that we can distinguish between unassigned
     // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
@@ -704,7 +704,7 @@ current_page_t::current_page_t(block_id_t block_id,
     : block_id_(block_id),
       page_(new page_t(block_id, std::move(buf), token, page_cache)),
       is_deleted_(false),
-      last_write_acquirer_(NULL),
+      last_write_acquirer_(nullptr),
       num_keepalives_(0) {
     // Increment the block version so that we can distinguish between unassigned
     // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
@@ -727,7 +727,7 @@ void current_page_t::reset(page_cache_t *page_cache) {
 
     // KSI: Does last_write_acquirer_ even need to be NULL?  Could we not just inform
     // it of our impending destruction?
-    rassert(last_write_acquirer_ == NULL);
+    rassert(last_write_acquirer_ == nullptr);
 
     page_.reset_page_ptr(page_cache);
     // No need to call consider_evicting_current_page here -- we're already getting
@@ -751,7 +751,7 @@ bool current_page_t::should_be_evicted() const {
     }
 
     // A reason: We still have a connection to last_write_acquirer_.  (Important.)
-    if (last_write_acquirer_ != NULL) {
+    if (last_write_acquirer_ != nullptr) {
         return false;
     }
 
@@ -783,7 +783,7 @@ void current_page_t::add_acquirer(current_page_acq_t *acq) {
         block_version_t v = prev_version.subsequent();
         acq->block_version_ = v;
 
-        rassert(acq->the_txn_ != NULL);
+        rassert(acq->the_txn_ != nullptr);
         page_txn_t *const acq_txn = acq->the_txn_;
 
         last_write_acquirer_version_ = v;
@@ -791,7 +791,7 @@ void current_page_t::add_acquirer(current_page_acq_t *acq) {
         if (last_write_acquirer_ != acq_txn) {
             rassert(!acq_txn->pages_write_acquired_last_.has_element(this));
 
-            if (last_write_acquirer_ != NULL) {
+            if (last_write_acquirer_ != nullptr) {
                 page_txn_t *prec = last_write_acquirer_;
 
                 rassert(prec->pages_write_acquired_last_.has_element(this));
@@ -804,7 +804,7 @@ void current_page_t::add_acquirer(current_page_acq_t *acq) {
             last_write_acquirer_ = acq_txn;
         }
     } else {
-        rassert(acq->the_txn_ == NULL);
+        rassert(acq->the_txn_ == nullptr);
         acq->block_version_ = prev_version;
     }
 
@@ -815,7 +815,7 @@ void current_page_t::add_acquirer(current_page_acq_t *acq) {
 void current_page_t::remove_acquirer(current_page_acq_t *acq) {
     current_page_acq_t *next = acquirers_.next(acq);
     acquirers_.remove(acq);
-    if (next != NULL) {
+    if (next != nullptr) {
         pulse_pulsables(next);
     }
 }
@@ -826,7 +826,7 @@ void current_page_t::pulse_pulsables(current_page_acq_t *const acq) {
     // First, avoid pulsing when there's nothing to pulse.
     {
         current_page_acq_t *prev = acquirers_.prev(acq);
-        if (!(prev == NULL || (prev->access_ == access_t::read
+        if (!(prev == nullptr || (prev->access_ == access_t::read
                                && prev->read_cond_.is_pulsed()))) {
             return;
         }
@@ -839,7 +839,7 @@ void current_page_t::pulse_pulsables(current_page_acq_t *const acq) {
         // so the next node might not have been pulsed for read.  Also we might as
         // well stop if we're at the end of the chain (and have been pulsed).
         current_page_acq_t *next = acquirers_.next(acq);
-        if (next == NULL || next->read_cond_.is_pulsed()) {
+        if (next == nullptr || next->read_cond_.is_pulsed()) {
             return;
         }
     }
@@ -848,7 +848,7 @@ void current_page_t::pulse_pulsables(current_page_acq_t *const acq) {
 
     // It's time to pulse the pulsables.
     current_page_acq_t *cur = acq;
-    while (cur != NULL) {
+    while (cur != nullptr) {
         // We know that the previous node has read access and has been pulsed as
         // readable, so we pulse the current node as readable.
         cur->pulse_read_available();
@@ -874,7 +874,7 @@ void current_page_t::pulse_pulsables(current_page_acq_t *const acq) {
             // Even the first write-acquirer gets read access (there's no need for an
             // "intent" mode).  But subsequent acquirers need to wait, because the
             // write-acquirer might modify the value.
-            if (acquirers_.prev(cur) == NULL) {
+            if (acquirers_.prev(cur) == nullptr) {
                 // (It gets exclusive write access if there's no preceding reader.)
                 guarantee(!is_deleted_);
                 cur->pulse_write_available();
@@ -933,7 +933,7 @@ page_t *current_page_t::the_page_for_read(current_page_help_t help,
 
 page_t *current_page_t::the_page_for_read_or_deleted(current_page_help_t help) {
     if (is_deleted_) {
-        return NULL;
+        return nullptr;
     } else {
         convert_from_serializer_if_necessary(help);
         return page_.get_page_for_read();
@@ -957,12 +957,12 @@ page_txn_t::page_txn_t(page_cache_t *page_cache,
       began_waiting_for_flush_(false),
       spawned_flush_(false),
       mark_(marked_not) {
-    if (cache_conn != NULL) {
+    if (cache_conn != nullptr) {
         page_txn_t *old_newest_txn = cache_conn->newest_txn_;
         cache_conn->newest_txn_ = this;
-        if (old_newest_txn != NULL) {
+        if (old_newest_txn != nullptr) {
             rassert(old_newest_txn->cache_conn_ == cache_conn);
-            old_newest_txn->cache_conn_ = NULL;
+            old_newest_txn->cache_conn_ = nullptr;
             connect_preceder(old_newest_txn);
         }
     }
@@ -1024,7 +1024,7 @@ void page_txn_t::remove_acquirer(current_page_acq_t *acq) {
     // It's not snapshotted because you can't snapshot write acqs.  (We
     // rely on this fact solely because we need to grab the block_id_t
     // and current_page_acq_t currently doesn't know it.)
-    rassert(acq->current_page_ != NULL);
+    rassert(acq->current_page_ != nullptr);
 
     const block_version_t block_version = acq->block_version();
 
@@ -1081,7 +1081,7 @@ page_cache_t::compute_changes(const std::vector<page_txn_t *> &txns) {
             const dirtied_page_t &d = txn->snapshotted_dirtied_pages_[i];
 
             block_change_t change(d.block_version, true,
-                                  d.ptr.has() ? d.ptr.get_page_for_read() : NULL,
+                                  d.ptr.has() ? d.ptr.get_page_for_read() : nullptr,
                                   d.ptr.has() ? d.ptr.timestamp() : repli_timestamp_t::invalid);
 
             auto res = changes.insert(std::make_pair(d.block_id, change));
@@ -1109,7 +1109,7 @@ page_cache_t::compute_changes(const std::vector<page_txn_t *> &txns) {
             auto res = changes.insert(std::make_pair(t.block_id,
                                                      block_change_t(t.block_version,
                                                                     false,
-                                                                    NULL,
+                                                                    nullptr,
                                                                     t.tstamp)));
             if (!res.second) {
                 // The insertion failed.  We need to combine the versions.
@@ -1166,21 +1166,21 @@ void page_cache_t::remove_txn_set_from_graph(page_cache_t *page_cache,
             // All existing acquirers should be read acquirers, since this txn _was_
             // the last write acquirer.
             for (current_page_acq_t *acq = current_page->acquirers_.head();
-                 acq != NULL;
+                 acq != nullptr;
                  acq = current_page->acquirers_.next(acq)) {
                 rassert(acq->access() == access_t::read);
             }
 #endif
 
             txn->pages_write_acquired_last_.remove(current_page);
-            current_page->last_write_acquirer_ = NULL;
+            current_page->last_write_acquirer_ = nullptr;
             page_cache->consider_evicting_current_page(current_page->block_id_);
         }
 
-        if (txn->cache_conn_ != NULL) {
+        if (txn->cache_conn_ != nullptr) {
             rassert(txn->cache_conn_->newest_txn_ == txn);
-            txn->cache_conn_->newest_txn_ = NULL;
-            txn->cache_conn_ = NULL;
+            txn->cache_conn_->newest_txn_ = nullptr;
+            txn->cache_conn_ = nullptr;
         }
 
         txn->flush_complete_cond_.pulse();
@@ -1200,7 +1200,7 @@ struct block_token_tstamp_t {
     bool is_deleted;
     counted_t<standard_block_token_t> block_token;
     repli_timestamp_t tstamp;
-    // The page, or NULL, if we don't know it.
+    // The page, or nullptr, if we don't know it.
     page_t *page;
 };
 
@@ -1230,13 +1230,13 @@ void page_cache_t::do_flush_changes(page_cache_t *page_cache,
 
         for (auto it = changes.begin(); it != changes.end(); ++it) {
             if (it->second.modified) {
-                if (it->second.page == NULL) {
+                if (it->second.page == nullptr) {
                     // The block is deleted.
                     blocks_by_tokens.push_back(block_token_tstamp_t(it->first,
                                                                     true,
                                                                     counted_t<standard_block_token_t>(),
                                                                     repli_timestamp_t::invalid,
-                                                                    NULL));
+                                                                    nullptr));
                 } else {
                     page_t *page = it->second.page;
                     if (page->block_token().has()) {
@@ -1272,7 +1272,7 @@ void page_cache_t::do_flush_changes(page_cache_t *page_cache,
                                                                 false,
                                                                 counted_t<standard_block_token_t>(),
                                                                 it->second.tstamp,
-                                                                NULL));
+                                                                nullptr));
             }
         }
     }
@@ -1345,7 +1345,7 @@ void page_cache_t::do_flush_changes(page_cache_t *page_cache,
                 coro_t::spawn_on_thread([&]() {
                     // Update the block tokens of the written blocks
                     for (auto &block : blocks_by_tokens) {
-                        if (block.block_token.has() && block.page != NULL) {
+                        if (block.block_token.has() && block.page != nullptr) {
                             // We know page is still a valid pointer because of the
                             // page_ptr_t in snapshotted_dirtied_pages_.
 

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -49,7 +49,7 @@ class cache_conn_t {
 public:
     explicit cache_conn_t(cache_t *cache)
         : cache_(cache),
-          newest_txn_(NULL) { }
+          newest_txn_(nullptr) { }
     ~cache_conn_t();
 
     cache_t *cache() const { return cache_; }

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -43,7 +43,7 @@
 
 http_conn_cache_t::http_conn_t::http_conn_t(rdb_context_t *rdb_ctx,
                                             ip_and_port_t client_addr_port) :
-    last_accessed(time(0)),
+    last_accessed(time(nullptr)),
     // We always return empty normal batches after the timeout for HTTP
     // connections; I think we have to do this to keep the conn cache
     // from timing out.
@@ -52,7 +52,7 @@ http_conn_cache_t::http_conn_t::http_conn_t(rdb_context_t *rdb_ctx,
     counter(&rdb_ctx->stats.client_connections) { }
 
 ql::query_cache_t *http_conn_cache_t::http_conn_t::get_query_cache() {
-    last_accessed = time(0);
+    last_accessed = time(nullptr);
     return query_cache.get();
 }
 
@@ -103,7 +103,7 @@ std::string http_conn_cache_t::expired_error_message() const {
 }
 
 bool http_conn_cache_t::is_expired(const http_conn_t &conn) const {
-    return difftime(time(0), conn.last_accessed_time()) > http_timeout_sec;
+    return difftime(time(nullptr), conn.last_accessed_time()) > http_timeout_sec;
 }
 
 counted_t<http_conn_cache_t::http_conn_t> http_conn_cache_t::find(
@@ -198,7 +198,7 @@ query_server_t::query_server_t(rdb_context_t *_rdb_ctx,
         handler(_handler),
         http_conn_cache(http_timeout_sec),
         next_thread(0) {
-    rassert(rdb_ctx != NULL);
+    rassert(rdb_ctx != nullptr);
     try {
         tcp_listener.init(new tcp_listener_t(local_addresses, port,
             std::bind(&query_server_t::handle_conn,

--- a/src/clustering/administration/issues/non_transitive.cc
+++ b/src/clustering/administration/issues/non_transitive.cc
@@ -73,5 +73,5 @@ std::vector<scoped_ptr_t<issue_t> > non_transitive_issue_tracker_t::get_issues(
     if (interruptor->is_pulsed()) {
         throw interrupted_exc_t();
     }
-    return std::move(issues);
+    return issues;
 }

--- a/src/clustering/administration/logs/log_writer.cc
+++ b/src/clustering/administration/logs/log_writer.cc
@@ -320,7 +320,7 @@ void fallback_log_writer_t::install(const std::string &logfile_name) {
     filename = base_path_t(logfile_name);
 
 #ifdef _WIN32
-    HANDLE h = CreateFile(filename.path().c_str(), FILE_APPEND_DATA, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE h = CreateFile(filename.path().c_str(), FILE_APPEND_DATA, 0, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     fd.reset(h);
 
     if (fd.get() == INVALID_FD) {
@@ -470,7 +470,7 @@ bool fallback_log_writer_t::write(const log_message_t &msg, std::string *error_o
 
 #ifdef _WIN32
     DWORD bytes_written;
-    BOOL res = WriteFile(fd.get(), formatted.data(), formatted.length(), &bytes_written, NULL);
+    BOOL res = WriteFile(fd.get(), formatted.data(), formatted.length(), &bytes_written, nullptr);
     if (!res) {
         error_out->assign("cannot write to log file: " + winerr_string(GetLastError()));
         return false;
@@ -570,7 +570,7 @@ std::vector<log_message_t> thread_pool_log_writer_t::tail(
 
 void thread_pool_log_writer_t::install_on_thread(int i) {
     on_thread_t thread_switcher((threadnum_t(i)));
-    guarantee(TLS_get_global_log_writer() == NULL);
+    guarantee(TLS_get_global_log_writer() == nullptr);
     TLS_set_global_log_drainer(new auto_drainer_t);
     TLS_set_global_log_writer(this);
 }
@@ -611,7 +611,7 @@ void thread_pool_log_writer_t::tail_blocking(
     try {
         scoped_fd_t fd;
 #ifdef _WIN32
-        fd.reset(CreateFile(fallback_log_writer.filename.path().c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+        fd.reset(CreateFile(fallback_log_writer.filename.path().c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
 #else
         do {
             fd.reset(open(fallback_log_writer.filename.path().c_str(), O_RDONLY));

--- a/src/clustering/administration/main/cache_size.cc
+++ b/src/clustering/administration/main/cache_size.cc
@@ -239,7 +239,7 @@ bool get_proc_meminfo_available_memory_size(uint64_t *mem_avail_out) {
 bool osx_runtime_version_check() {
     char str[256];
     size_t size = sizeof(str);
-    int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
+    int ret = sysctlbyname("kern.osrelease", str, &size, nullptr, 0);
     if (ret == -1) {
         return false;
     }

--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -57,7 +57,7 @@
 MUST_USE bool numwrite(const char *path, int number) {
     // Try to figure out what this function does.
     FILE *fp1 = fopen(path, "w");
-    if (fp1 == NULL) {
+    if (fp1 == nullptr) {
         return false;
     }
     fprintf(fp1, "%d", number);
@@ -165,7 +165,7 @@ bool get_group_id(const char *name, gid_t *group_id_out) {
         } while (res == EINTR);
 
         if (res == 0) {
-            if (result == NULL) {
+            if (result == nullptr) {
                 return false;
             } else {
                 *group_id_out = result->gr_gid;
@@ -207,7 +207,7 @@ bool get_user_ids(const char *name, uid_t *user_id_out, gid_t *user_group_id_out
         } while (res == EINTR);
 
         if (res == 0) {
-            if (result == NULL) {
+            if (result == nullptr) {
                 return false;
             } else {
                 *user_id_out = result->pw_uid;
@@ -860,7 +860,7 @@ void run_rethinkdb_porcelain(const base_path_t &base_path,
     if (!new_directory) {
         run_rethinkdb_serve(base_path, serve_info, direct_io_mode,
                             max_concurrent_io_requests, total_cache_size,
-                            NULL, NULL, NULL, data_directory_lock,
+                            nullptr, nullptr, nullptr, data_directory_lock,
                             result_out);
     } else {
         logNTC("Initializing directory %s\n", base_path.path().c_str());
@@ -1422,13 +1422,13 @@ bool maybe_daemonize(const std::map<std::string, options::values_t> &opts) {
             throw std::runtime_error(strprintf("Failed to change directory: %s\n", errno_string(get_errno()).c_str()).c_str());
         }
 
-        if (freopen("/dev/null", "r", stdin) == NULL) {
+        if (freopen("/dev/null", "r", stdin) == nullptr) {
             throw std::runtime_error(strprintf("Failed to redirect stdin for daemon: %s\n", errno_string(get_errno()).c_str()).c_str());
         }
-        if (freopen("/dev/null", "w", stdout) == NULL) {
+        if (freopen("/dev/null", "w", stdout) == nullptr) {
             throw std::runtime_error(strprintf("Failed to redirect stdin for daemon: %s\n", errno_string(get_errno()).c_str()).c_str());
         }
-        if (freopen("/dev/null", "w", stderr) == NULL) {
+        if (freopen("/dev/null", "w", stderr) == nullptr) {
             throw std::runtime_error(strprintf("Failed to redirect stderr for daemon: %s\n", errno_string(get_errno()).c_str()).c_str());
         }
 #endif
@@ -1519,9 +1519,9 @@ int main_rethinkdb_serve(int argc, char *argv[]) {
                                      direct_io_mode,
                                      max_concurrent_io_requests,
                                      total_cache_size,
-                                     static_cast<server_id_t*>(NULL),
-                                     static_cast<server_config_versioned_t *>(NULL),
-                                     static_cast<cluster_semilattice_metadata_t*>(NULL),
+                                     static_cast<server_id_t*>(nullptr),
+                                     static_cast<server_config_versioned_t *>(nullptr),
+                                     static_cast<cluster_semilattice_metadata_t*>(nullptr),
                                      &data_directory_lock,
                                      &result),
                            num_workers);
@@ -1856,34 +1856,34 @@ void help_rethinkdb_proxy() {
 void help_rethinkdb_export() {
     char help_arg[] = "--help";
     char dummy_arg[] = RETHINKDB_EXPORT_SCRIPT;
-    char* args[3] = { dummy_arg, help_arg, NULL };
+    char* args[3] = { dummy_arg, help_arg, nullptr };
     run_backup_script(RETHINKDB_EXPORT_SCRIPT, args);
 }
 
 void help_rethinkdb_import() {
     char help_arg[] = "--help";
     char dummy_arg[] = RETHINKDB_IMPORT_SCRIPT;
-    char* args[3] = { dummy_arg, help_arg, NULL };
+    char* args[3] = { dummy_arg, help_arg, nullptr };
     run_backup_script(RETHINKDB_IMPORT_SCRIPT, args);
 }
 
 void help_rethinkdb_dump() {
     char help_arg[] = "--help";
     char dummy_arg[] = RETHINKDB_DUMP_SCRIPT;
-    char* args[3] = { dummy_arg, help_arg, NULL };
+    char* args[3] = { dummy_arg, help_arg, nullptr };
     run_backup_script(RETHINKDB_DUMP_SCRIPT, args);
 }
 
 void help_rethinkdb_restore() {
     char help_arg[] = "--help";
     char dummy_arg[] = RETHINKDB_RESTORE_SCRIPT;
-    char* args[3] = { dummy_arg, help_arg, NULL };
+    char* args[3] = { dummy_arg, help_arg, nullptr };
     run_backup_script(RETHINKDB_RESTORE_SCRIPT, args);
 }
 
 void help_rethinkdb_index_rebuild() {
     char help_arg[] = "--help";
     char dummy_arg[] = RETHINKDB_INDEX_REBUILD_SCRIPT;
-    char* args[3] = { dummy_arg, help_arg, NULL };
+    char* args[3] = { dummy_arg, help_arg, nullptr };
     run_backup_script(RETHINKDB_INDEX_REBUILD_SCRIPT, args);
 }

--- a/src/clustering/administration/main/directory_lock.cc
+++ b/src/clustering/administration/main/directory_lock.cc
@@ -32,7 +32,7 @@ bool check_dir_emptiness(const base_path_t& base_path) {
     struct dirent *ep;
 
     dp = opendir(base_path.path().c_str());
-    if (dp == NULL) {
+    if (dp == nullptr) {
         throw directory_open_failed_exc_t(get_errno(), base_path);
     }
 
@@ -43,7 +43,7 @@ bool check_dir_emptiness(const base_path_t& base_path) {
     // and Linux glibc both allocate per-directory buffers.  readdir_r is unsafe
     // because you can't specify the length of the struct dirent buffer you pass in
     // to it.  See http://elliotth.blogspot.com/2012/10/how-not-to-use-readdirr3.html
-    while ((ep = readdir(dp)) != NULL) {  // NOLINT(runtime/threadsafe_fn)
+    while ((ep = readdir(dp)) != nullptr) {  // NOLINT(runtime/threadsafe_fn)
         if (strcmp(ep->d_name, ".") != 0 && strcmp(ep->d_name, "..") != 0) {
             closedir(dp);
             return false;
@@ -94,8 +94,8 @@ directory_lock_t::directory_lock_t(const base_path_t &path, bool create, bool *c
 
 #ifdef _WIN32
     // TODO WINDOWS: issue #5165
-    directory_fd.reset(CreateFile(directory_path.path().c_str(), GENERIC_READ, 0, NULL,
-                                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL));
+    directory_fd.reset(CreateFile(directory_path.path().c_str(), GENERIC_READ, 0, nullptr,
+                                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, nullptr));
     if (directory_fd.get() == INVALID_FD) {
         logERR("CreateFile failed: %s", winerr_string(GetLastError()).c_str());
         throw directory_open_failed_exc_t(EIO, directory_path);

--- a/src/clustering/administration/main/initial_join.cc
+++ b/src/clustering/administration/main/initial_join.cc
@@ -73,7 +73,7 @@ initial_joiner_t::initial_joiner_t(
     auto_drainer_t::lock_t connection_keepalive;
     connectivity_cluster_t::connection_t *loopback =
         cluster->get_connection(cluster->get_me(), &connection_keepalive);
-    guarantee(loopback != NULL);
+    guarantee(loopback != nullptr);
     peer_address_t self_addr = loopback->get_peer_address();
     for (peer_address_set_t::iterator join_self_it = find_peer_address_in_set(peers_not_heard_from, self_addr);
          join_self_it != peers_not_heard_from.end();

--- a/src/clustering/administration/main/options.cc
+++ b/src/clustering/administration/main/options.cc
@@ -112,7 +112,7 @@ const option_t *find_option(const char *const option_name, const std::vector<opt
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 std::map<std::string, values_t> default_values_map(const std::vector<option_t> &options) {
@@ -157,7 +157,7 @@ std::map<std::string, values_t> do_parse_command_line(
 
         const option_t *const option = find_option(option_name, options);
         if (!option) {
-            if (unrecognized_out != NULL) {
+            if (unrecognized_out != nullptr) {
                 unrecognized.push_back(option_name);
                 continue;
             } else if (looks_like_option_name(option_name)) {
@@ -192,7 +192,7 @@ std::map<std::string, values_t> do_parse_command_line(
         }
     }
 
-    if (unrecognized_out != NULL) {
+    if (unrecognized_out != nullptr) {
         unrecognized_out->swap(unrecognized);
     }
 
@@ -200,7 +200,7 @@ std::map<std::string, values_t> do_parse_command_line(
 }
 
 std::map<std::string, values_t> parse_command_line(const int argc, const char *const *const argv, const std::vector<option_t> &options) {
-    return do_parse_command_line(argc, argv, options, NULL);
+    return do_parse_command_line(argc, argv, options, nullptr);
 }
 
 std::map<std::string, values_t> parse_command_line_and_collect_unrecognized(
@@ -208,7 +208,7 @@ std::map<std::string, values_t> parse_command_line_and_collect_unrecognized(
     std::vector<std::string> *unrecognized_out) {
     // We check that unrecognized_out is not NULL because do_parse_command_line
     // throws some exceptions depending on the nullness of that value.
-    guarantee(unrecognized_out != NULL);
+    guarantee(unrecognized_out != nullptr);
 
     return do_parse_command_line(argc, argv, options, unrecognized_out);
 }
@@ -307,9 +307,9 @@ std::map<std::string, values_t> parse_config_file(const std::string &file_conten
         const std::string option_name = "--" + name;
         const option_t *option = find_option(option_name.c_str(), options);
 
-        if (option == NULL) {
+        if (option == nullptr) {
             // Ignore 'known' options that are not valid now, but exist in the superset
-            if (find_option(option_name.c_str(), options_superset) == NULL) {
+            if (find_option(option_name.c_str(), options_superset) == nullptr) {
                 throw file_parse_error_t(source,
                                          strprintf("Config file %s: parse error at line %zu: unrecognized option name '%s'",
                                                    filepath.c_str(), it - lines.begin(), name.c_str()));

--- a/src/clustering/administration/main/serve.cc
+++ b/src/clustering/administration/main/serve.cc
@@ -259,7 +259,7 @@ bool do_serve(io_backender_t *io_backender,
         needs. */
         rdb_context_t rdb_ctx(&extproc_pool,
                               &mailbox_manager,
-                              NULL,   /* we'll fill this in later */
+                              nullptr,   /* we'll fill this in later */
                               semilattice_manager_auth.get_root_view(),
                               &get_global_perfmon_collection(),
                               serve_info.reql_http_proxy);
@@ -664,7 +664,7 @@ bool serve_proxy(const serve_info_t &serve_info,
                  os_signal_cond_t *stop_cond) {
     // TODO: filepath doesn't _seem_ ignored.
     // filepath and persistent_file are ignored for proxies, so we use the empty string & NULL respectively.
-    return do_serve(NULL,
+    return do_serve(nullptr,
                     false,
                     base_path_t(""),
                     nullptr,

--- a/src/clustering/administration/main/version_check.cc
+++ b/src/clustering/administration/main/version_check.cc
@@ -33,7 +33,7 @@ version_checker_t::version_checker_t(
     table_meta_client(_table_meta_client),
     server_config_client(_server_config_client),
     timer(day_in_ms, this) {
-    rassert(rdb_ctx != NULL);
+    rassert(rdb_ctx != nullptr);
     coro_t::spawn_sometime(std::bind(&version_checker_t::do_check,
                                      this, true, drainer.lock()));
 }

--- a/src/clustering/administration/namespace_interface_repository.cc
+++ b/src/clustering/administration/namespace_interface_repository.cc
@@ -195,8 +195,8 @@ namespace_interface_access_t namespace_repo_t::get_namespace_interface(
         if (cache->entries.find(ns_id) == cache->entries.end()) {
             cache_entry = new namespace_cache_entry_t;
             cache_entry->ref_count = 0;
-            cache_entry->pulse_when_ref_count_becomes_zero = NULL;
-            cache_entry->pulse_when_ref_count_becomes_nonzero = NULL;
+            cache_entry->pulse_when_ref_count_becomes_zero = nullptr;
+            cache_entry->pulse_when_ref_count_becomes_nonzero = nullptr;
 
             namespace_id_t id(ns_id);
             cache->entries.insert(std::make_pair(id,

--- a/src/clustering/generic/registrar.hpp
+++ b/src/clustering/generic/registrar.hpp
@@ -131,7 +131,7 @@ private:
         NULL in the `registrations` map. */
         typename std::map<registration_id_t, cond_t *>::iterator it = registrations.find(rid);
         if (it != registrations.end()) {
-            guarantee(it->second == NULL);
+            guarantee(it->second == nullptr);
             registrations.erase(it);
             return;
         }
@@ -163,7 +163,7 @@ private:
             created and the deregistration message arrived before the
             registration message. Insert a NULL into the map so that
             `on_create()` realizes it. */
-            cond_t *const zero = 0;
+            cond_t *const zero = nullptr;
             std::pair<registration_id_t, cond_t *> value(rid, zero);
             registrations.insert(value);
         }

--- a/src/clustering/query_routing/table_query_client.cc
+++ b/src/clustering/query_routing/table_query_client.cc
@@ -28,7 +28,7 @@ table_query_client_t::table_query_client_t(
         std::bind(&table_query_client_t::update_registrant,
             this, ph::_1, ph::_2),
         initial_call_t::YES) {
-    rassert(ctx != NULL);
+    rassert(ctx != nullptr);
     starting_up = false;
     if (start_count == 0) {
         start_cond.pulse();
@@ -164,7 +164,7 @@ void table_query_client_t::dispatch_immediate_op(
     relationships.visit(region_t::universe(),
     [&](const region_t &reg, const std::set<relationship_t *> &rels) {
         if (op.shard(reg, &new_op_info->sharded_op)) {
-            relationship_t *chosen_relationship = NULL;
+            relationship_t *chosen_relationship = nullptr;
             for (auto jt = rels.begin(); jt != rels.end(); ++jt) {
                 if ((*jt)->primary_client) {
                     if (chosen_relationship) {
@@ -300,7 +300,7 @@ void table_query_client_t::dispatch_outdated_read(
     [&](const region_t &region, const std::set<relationship_t *> &rels) {
         if (op.shard(region, &new_op_info->sharded_op)) {
             std::vector<relationship_t *> potential_relationships;
-            relationship_t *chosen_relationship = NULL;
+            relationship_t *chosen_relationship = nullptr;
             for (auto jt = rels.begin(); jt != rels.end(); ++jt) {
                 if ((*jt)->direct_bcard != nullptr) {
                     if ((*jt)->is_local) {

--- a/src/concurrency/auto_drainer.cc
+++ b/src/concurrency/auto_drainer.cc
@@ -15,11 +15,11 @@ auto_drainer_t::~auto_drainer_t() {
     guarantee(refcount == 0);
 }
 
-auto_drainer_t::lock_t::lock_t() : parent(NULL) {
+auto_drainer_t::lock_t::lock_t() : parent(nullptr) {
 }
 
 auto_drainer_t::lock_t::lock_t(auto_drainer_t *p, throw_if_draining_t thr) : parent(p) {
-    guarantee(parent != NULL);
+    guarantee(parent != nullptr);
     if (thr == throw_if_draining_t::YES && parent->is_draining()) {
         throw interrupted_exc_t();
     }
@@ -40,7 +40,7 @@ auto_drainer_t::lock_t &auto_drainer_t::lock_t::operator=(const lock_t &l) {
 }
 
 auto_drainer_t::lock_t::lock_t(lock_t &&l) : parent(l.parent) {
-    l.parent = NULL;
+    l.parent = nullptr;
 }
 
 auto_drainer_t::lock_t &auto_drainer_t::lock_t::operator=(lock_t &&l) {
@@ -55,11 +55,11 @@ auto_drainer_t::lock_t auto_drainer_t::lock() {
 
 void auto_drainer_t::lock_t::reset() {
     if (parent) parent->decref();
-    parent = NULL;
+    parent = nullptr;
 }
 
 bool auto_drainer_t::lock_t::has_lock() const {
-    return parent != NULL;
+    return parent != nullptr;
 }
 
 signal_t *auto_drainer_t::lock_t::get_drain_signal() const {

--- a/src/concurrency/cond_var.cc
+++ b/src/concurrency/cond_var.cc
@@ -19,7 +19,7 @@ void one_waiter_cond_t::pulse() {
     pulsed_ = true;
     if (waiter_) {
         coro_t *tmp = waiter_;
-        waiter_ = NULL;
+        waiter_ = nullptr;
         tmp->notify_later_ordered();
     }
 }

--- a/src/concurrency/cond_var.hpp
+++ b/src/concurrency/cond_var.hpp
@@ -25,7 +25,7 @@ private:
 
 class one_waiter_cond_t {
 public:
-    one_waiter_cond_t() : pulsed_(false), waiter_(NULL) { }
+    one_waiter_cond_t() : pulsed_(false), waiter_(nullptr) { }
     ~one_waiter_cond_t() {
         rassert(pulsed_);
         rassert(!waiter_);

--- a/src/concurrency/cross_thread_mutex.cc
+++ b/src/concurrency/cross_thread_mutex.cc
@@ -4,7 +4,7 @@
 #include "arch/runtime/coroutines.hpp"
 
 
-cross_thread_mutex_t::acq_t::acq_t(cross_thread_mutex_t *l) : lock_(NULL) {
+cross_thread_mutex_t::acq_t::acq_t(cross_thread_mutex_t *l) : lock_(nullptr) {
     reset(l);
 }
 
@@ -16,7 +16,7 @@ void cross_thread_mutex_t::acq_t::reset() {
     if (lock_) {
         lock_->unlock();
     }
-    lock_ = NULL;
+    lock_ = nullptr;
 }
 
 void cross_thread_mutex_t::acq_t::reset(cross_thread_mutex_t *l) {

--- a/src/concurrency/cross_thread_mutex.hpp
+++ b/src/concurrency/cross_thread_mutex.hpp
@@ -22,7 +22,7 @@ class cross_thread_mutex_t {
 public:
     class acq_t {
     public:
-        acq_t() : lock_(NULL) { }
+        acq_t() : lock_(nullptr) { }
         explicit acq_t(cross_thread_mutex_t *l);
         ~acq_t();
         void reset();
@@ -40,7 +40,7 @@ public:
     };
 
     explicit cross_thread_mutex_t(bool recursive = false) :
-        is_recursive(recursive), locked_count(0), lock_holder(NULL) { }
+        is_recursive(recursive), locked_count(0), lock_holder(nullptr) { }
     ~cross_thread_mutex_t() {
 #ifndef NDEBUG
         spinlock_acq_t acq(&spinlock);

--- a/src/concurrency/cross_thread_semaphore.hpp
+++ b/src/concurrency/cross_thread_semaphore.hpp
@@ -53,12 +53,12 @@ private:
         explicit request_node_t(promise_t<value_t *> *_promise_out) :
             thread_id(get_thread_id()),
             promise_out(_promise_out) {
-            guarantee(promise_out != NULL);
+            guarantee(promise_out != nullptr);
         }
 
-        bool is_abandoned() const { return promise_out == NULL; }
+        bool is_abandoned() const { return promise_out == nullptr; }
         threadnum_t get_thread() const { return thread_id; }
-        void abandon() { promise_out = NULL; }
+        void abandon() { promise_out = nullptr; }
 
         void fulfill_promise(value_t *value) {
             guarantee(!is_abandoned());
@@ -114,7 +114,7 @@ private:
 template <class value_t>
 cross_thread_semaphore_t<value_t>::~cross_thread_semaphore_t() {
     for (size_t i = 0; i < values.size(); ++i) {
-        delete lock(NULL);
+        delete lock(nullptr);
     }
 }
 
@@ -136,7 +136,7 @@ void cross_thread_semaphore_t<value_t>::pass_value_coroutine(request_node_t *req
 template <class value_t>
 value_t *cross_thread_semaphore_t<value_t>::lock(signal_t *interruptor) {
     system_mutex_t::lock_t lock(&mutex);
-    value_t *result = NULL;
+    value_t *result = nullptr;
 
     if (available_value_index == values.size()) {
         request_t request(this);
@@ -144,11 +144,11 @@ value_t *cross_thread_semaphore_t<value_t>::lock(signal_t *interruptor) {
         result = request.wait_and_get(interruptor);
     } else {
         result = values[available_value_index];
-        values[available_value_index] = NULL;
+        values[available_value_index] = nullptr;
         ++available_value_index;
     }
 
-    guarantee(result != NULL);
+    guarantee(result != nullptr);
     return result;
 }
 
@@ -157,7 +157,7 @@ void cross_thread_semaphore_t<value_t>::unlock(value_t *value) {
     system_mutex_t::lock_t lock(&mutex);
 
     if (request_queue.size() > 0) {
-        request_node_t *request = NULL;
+        request_node_t *request = nullptr;
         while (request_queue.size() > 0) {
             request = request_queue.head();
             request_queue.remove(request);
@@ -167,10 +167,10 @@ void cross_thread_semaphore_t<value_t>::unlock(value_t *value) {
             }
 
             delete request;
-            request = NULL;
+            request = nullptr;
         }
 
-        if (request != NULL) {
+        if (request != nullptr) {
             coro_t::spawn_sometime(std::bind(&cross_thread_semaphore_t<value_t>::pass_value_coroutine,
                                              this, request, value));
             return;
@@ -179,7 +179,7 @@ void cross_thread_semaphore_t<value_t>::unlock(value_t *value) {
 
     // If we get here, there were no valid requests in the queue
     guarantee(available_value_index > 0);
-    guarantee(values[available_value_index - 1] == NULL);
+    guarantee(values[available_value_index - 1] == nullptr);
     values[available_value_index - 1] = value;
     --available_value_index;
 }
@@ -209,9 +209,9 @@ cross_thread_semaphore_t<value_t>::request_t::~request_t() {
 
 template <class value_t>
 value_t *cross_thread_semaphore_t<value_t>::request_t::wait_and_get(signal_t *interruptor) {
-    value_t *result = NULL;
+    value_t *result = nullptr;
 
-    if (interruptor == NULL) {
+    if (interruptor == nullptr) {
         value_promise.wait();
     } else {
         wait_interruptible(value_promise.get_ready_signal(), interruptor);

--- a/src/concurrency/fifo_enforcer.cc
+++ b/src/concurrency/fifo_enforcer.cc
@@ -34,17 +34,17 @@ fifo_enforcer_write_token_t fifo_enforcer_source_t::enter_write() THROWS_NOTHING
 }
 
 fifo_enforcer_sink_t::exit_read_t::exit_read_t() THROWS_NOTHING :
-    parent(NULL), ended(false) { }
+    parent(nullptr), ended(false) { }
 
 fifo_enforcer_sink_t::exit_read_t::exit_read_t(fifo_enforcer_sink_t *p, fifo_enforcer_read_token_t t) THROWS_NOTHING :
-    parent(NULL), ended(false)
+    parent(nullptr), ended(false)
 {
     begin(p, t);
 }
 
 void fifo_enforcer_sink_t::exit_read_t::begin(fifo_enforcer_sink_t *p, fifo_enforcer_read_token_t t) THROWS_NOTHING {
-    rassert(parent == NULL);
-    rassert(p != NULL);
+    rassert(parent == nullptr);
+    rassert(p != nullptr);
     parent = p;
     token = t;
 
@@ -94,10 +94,10 @@ fifo_enforcer_sink_t::exit_read_t::~exit_read_t() THROWS_NOTHING {
 }
 
 fifo_enforcer_sink_t::exit_write_t::exit_write_t() THROWS_NOTHING :
-    parent(NULL), ended(false) { }
+    parent(nullptr), ended(false) { }
 
 fifo_enforcer_sink_t::exit_write_t::exit_write_t(fifo_enforcer_sink_t *p, fifo_enforcer_write_token_t t) THROWS_NOTHING :
-    parent(NULL), ended(false)
+    parent(nullptr), ended(false)
 {
     begin(p, t);
 }
@@ -105,8 +105,8 @@ fifo_enforcer_sink_t::exit_write_t::exit_write_t(fifo_enforcer_sink_t *p, fifo_e
 void fifo_enforcer_sink_t::exit_write_t::begin(fifo_enforcer_sink_t *p, fifo_enforcer_write_token_t t) THROWS_NOTHING {
     ASSERT_FINITE_CORO_WAITING;
 
-    rassert(parent == NULL);
-    rassert(p != NULL);
+    rassert(parent == nullptr);
+    rassert(p != nullptr);
     parent = p;
     token = t;
 

--- a/src/concurrency/mutex.cc
+++ b/src/concurrency/mutex.cc
@@ -3,7 +3,7 @@
 
 #include "arch/runtime/coroutines.hpp"
 
-mutex_t::acq_t::acq_t(mutex_t *l, bool eager) : lock_(NULL), eager_(false) {
+mutex_t::acq_t::acq_t(mutex_t *l, bool eager) : lock_(nullptr), eager_(false) {
     reset(l, eager);
 }
 
@@ -15,7 +15,7 @@ void mutex_t::acq_t::reset() {
     if (lock_) {
         unlock_mutex(lock_, eager_);
     }
-    lock_ = NULL;
+    lock_ = nullptr;
 }
 
 void mutex_t::acq_t::reset(mutex_t *l, bool eager) {

--- a/src/concurrency/mutex.hpp
+++ b/src/concurrency/mutex.hpp
@@ -18,8 +18,8 @@ class mutex_t {
 public:
     class acq_t {
     public:
-        acq_t() : lock_(NULL), eager_(false) { }
-        explicit acq_t(acq_t &&other) : lock_(NULL), eager_(false) {
+        acq_t() : lock_(nullptr), eager_(false) { }
+        explicit acq_t(acq_t &&other) : lock_(nullptr), eager_(false) {
             swap(*this, other);
         }
         explicit acq_t(mutex_t *l, bool eager = false);

--- a/src/concurrency/mutex_assertion.hpp
+++ b/src/concurrency/mutex_assertion.hpp
@@ -180,7 +180,7 @@ struct mutex_assertion_t {
         /* This is necessary to avoid compiler complaints about unused variables in
         release mode. */
         ~acq_t() { (void)this; }
-        void reset(mutex_assertion_t * = NULL) { }
+        void reset(mutex_assertion_t * = nullptr) { }
         void assert_is_holding(mutex_assertion_t *) { }
     private:
         DISABLE_COPYING(acq_t);
@@ -202,7 +202,7 @@ struct rwi_lock_assertion_t {
         read_acq_t() { }
         explicit read_acq_t(rwi_lock_assertion_t *) { }
         ~read_acq_t() { (void)this; }
-        void reset(rwi_lock_assertion_t * = NULL) { }
+        void reset(rwi_lock_assertion_t * = nullptr) { }
         void assert_is_holding(rwi_lock_assertion_t *) { }
     private:
         DISABLE_COPYING(read_acq_t);
@@ -211,7 +211,7 @@ struct rwi_lock_assertion_t {
         write_acq_t() { }
         explicit write_acq_t(rwi_lock_assertion_t *) { }
         ~write_acq_t() { (void)this; }
-        void reset(rwi_lock_assertion_t * = NULL) { }
+        void reset(rwi_lock_assertion_t * = nullptr) { }
         void assert_is_holding(rwi_lock_assertion_t *) { }
     private:
         DISABLE_COPYING(write_acq_t);

--- a/src/concurrency/new_semaphore.cc
+++ b/src/concurrency/new_semaphore.cc
@@ -53,24 +53,24 @@ new_semaphore_in_line_t::~new_semaphore_in_line_t() {
 }
 
 void new_semaphore_in_line_t::reset() {
-    if (semaphore_ != NULL) {
+    if (semaphore_ != nullptr) {
         semaphore_->remove_acquirer(this);
-        semaphore_ = NULL;
+        semaphore_ = nullptr;
         count_ = 0;
         cond_.reset();
     }
 }
 
 new_semaphore_in_line_t::new_semaphore_in_line_t()
-    : semaphore_(NULL), count_(0) { }
+    : semaphore_(nullptr), count_(0) { }
 
 new_semaphore_in_line_t::new_semaphore_in_line_t(new_semaphore_t *semaphore, int64_t count)
-    : semaphore_(NULL), count_(0) {
+    : semaphore_(nullptr), count_(0) {
     init(semaphore, count);
 }
 
 void new_semaphore_in_line_t::init(new_semaphore_t *semaphore, int64_t count) {
-    guarantee(semaphore_ == NULL);
+    guarantee(semaphore_ == nullptr);
     rassert(count_ == 0);
     guarantee(count >= 0);
     semaphore_ = semaphore;
@@ -83,7 +83,7 @@ new_semaphore_in_line_t::new_semaphore_in_line_t(new_semaphore_in_line_t &&movee
       semaphore_(movee.semaphore_),
       count_(movee.count_),
       cond_(std::move(movee.cond_)) {
-    movee.semaphore_ = NULL;
+    movee.semaphore_ = nullptr;
     movee.count_ = 0;
     movee.cond_.reset();
 }
@@ -93,7 +93,7 @@ int64_t new_semaphore_in_line_t::count() const {
 }
 
 void new_semaphore_in_line_t::change_count(int64_t new_count) {
-    guarantee(semaphore_ != NULL);
+    guarantee(semaphore_ != nullptr);
     guarantee(new_count >= 0);
 
     if (cond_.is_pulsed()) {

--- a/src/concurrency/pubsub.hpp
+++ b/src/concurrency/pubsub.hpp
@@ -31,7 +31,7 @@ public:
     public:
         /* Construct a `subscription_t` that is not subscribed to any publisher.
         */
-        explicit subscription_t(subscriber_t sub) : subscriber(sub), publisher(NULL) { }
+        explicit subscription_t(subscriber_t sub) : subscriber(sub), publisher(nullptr) { }
 
         /* Construct a `subscription_t` and subscribe to the given publisher. */
         subscription_t(subscriber_t sub, publisher_t *pub) : subscriber(sub), publisher(NULL) {
@@ -42,12 +42,12 @@ public:
             : intrusive_list_node_t<subscription_t>(std::move(movee)),
               subscriber(std::move(movee.subscriber)),
               publisher(movee.publisher) {
-            movee.publisher = NULL;
+            movee.publisher = nullptr;
         }
 
         /* Cause us to be subscribed to the given publisher (if any) and not to
         any other publisher. */
-        void reset(publisher_t *pub = NULL) {
+        void reset(publisher_t *pub = nullptr) {
             if (publisher) {
                 DEBUG_VAR mutex_assertion_t::acq_t acq(&publisher->mutex);
                 publisher->subscriptions.remove(this);
@@ -95,7 +95,7 @@ private:
     publisher_t(publisher_t &&movee)
         : subscriptions(std::move(movee.subscriptions)),
           mutex(std::move(movee.mutex)) {
-        for (subscription_t *p = subscriptions.head(); p != NULL;
+        for (subscription_t *p = subscriptions.head(); p != nullptr;
              p = subscriptions.next(p)) {
             rassert(p->publisher == &movee);
             p->publisher = this;
@@ -132,7 +132,7 @@ public:
     void publish(const callable_t &callable) {
         DEBUG_VAR mutex_assertion_t::acq_t acq(&publisher.mutex);
         for (auto sub = publisher.subscriptions.head();
-             sub != NULL;
+             sub != nullptr;
              sub = publisher.subscriptions.next(sub)) {
             /* `callable()` should not block */
             ASSERT_FINITE_CORO_WAITING;

--- a/src/concurrency/queue/disk_backed_queue_wrapper.hpp
+++ b/src/concurrency/queue/disk_backed_queue_wrapper.hpp
@@ -31,7 +31,7 @@ public:
             int64_t memory_queue_bytes) :
         passive_producer_t<T>(&available_control),
         memory_queue_free_space(memory_queue_bytes),
-        notify_when_room_in_memory_queue(NULL),
+        notify_when_room_in_memory_queue(nullptr),
         items_in_queue(0),
         io_backender(_io_backender),
         filename(_filename),
@@ -89,7 +89,7 @@ private:
         if (memory_queue.empty()) {
             available_control.set_available(false);
         }
-        if (notify_when_room_in_memory_queue != NULL) {
+        if (notify_when_room_in_memory_queue != nullptr) {
             notify_when_room_in_memory_queue->pulse_if_not_already_pulsed();
         }
         // TODO: This does some unnecessary copying.
@@ -124,7 +124,7 @@ private:
                 copying_viewer_t viewer(&wm);
                 disk_queue->pop(&viewer);
                 if (memory_queue_free_space <= 0) {
-                    guarantee(notify_when_room_in_memory_queue == NULL);
+                    guarantee(notify_when_room_in_memory_queue == nullptr);
                     cond_t cond;
                     assignment_sentry_t<cond_t *> assignment_sentry(
                         &notify_when_room_in_memory_queue, &cond);

--- a/src/concurrency/queue/limited_fifo.hpp
+++ b/src/concurrency/queue/limited_fifo.hpp
@@ -21,7 +21,7 @@ struct limited_fifo_queue_t :
     public passive_producer_t<value_t> {
 
     limited_fifo_queue_t(
-        int capacity, double trickle_fraction = 0.0, perfmon_counter_t *_counter = NULL)
+        int capacity, double trickle_fraction = 0.0, perfmon_counter_t *_counter = nullptr)
         : passive_producer_t<value_t>(&available_control),
           semaphore(capacity, trickle_fraction),
           counter(_counter) { }

--- a/src/concurrency/queue/passive_producer.hpp
+++ b/src/concurrency/queue/passive_producer.hpp
@@ -34,7 +34,7 @@ protected:
 
 class availability_t {
 public:
-    availability_t() : available(false), callback(NULL) { }
+    availability_t() : available(false), callback(nullptr) { }
     bool get() { return available; }
     void set_callback(availability_callback_t *cb) {
         rassert(!callback);
@@ -43,7 +43,7 @@ public:
     }
     void unset_callback() {
         rassert(callback);
-        callback = NULL;
+        callback = nullptr;
     }
 private:
     friend class availability_control_t;

--- a/src/concurrency/queue/unlimited_fifo.hpp
+++ b/src/concurrency/queue/unlimited_fifo.hpp
@@ -31,7 +31,7 @@ template<class value_t, class queue_t = std::list<value_t> >
 struct unlimited_fifo_queue_t : public passive_producer_t<value_t> {
     unlimited_fifo_queue_t()
         : passive_producer_t<value_t>(&available_control),
-          counter(NULL)
+          counter(nullptr)
     { }
 
     explicit unlimited_fifo_queue_t(perfmon_counter_t *_counter)

--- a/src/concurrency/rwlock.cc
+++ b/src/concurrency/rwlock.cc
@@ -24,7 +24,7 @@ void rwlock_t::remove_acq(rwlock_in_line_t *acq) {
 // different.
 void rwlock_t::pulse_pulsables(rwlock_in_line_t *p) {
     // We might not have to do any pulsing at all.
-    if (p == NULL) {
+    if (p == nullptr) {
         return;
     } else if (p->read_cond_.is_pulsed()) {
         // p is already pulsed for read.  We don't want to re-pulse the same chain of
@@ -32,7 +32,7 @@ void rwlock_t::pulse_pulsables(rwlock_in_line_t *p) {
         // (This is typical: When we remove a read-acquirer that has been pulsed for
         // read, the subsequent chain of nodes will already have been pulsed for
         // read.)
-        if (p->access_ == access_t::write && acqs_.prev(p) == NULL) {
+        if (p->access_ == access_t::write && acqs_.prev(p) == nullptr) {
             p->write_cond_.pulse_if_not_already_pulsed();
         }
         return;
@@ -40,7 +40,7 @@ void rwlock_t::pulse_pulsables(rwlock_in_line_t *p) {
         rwlock_in_line_t *prev = acqs_.prev(p);
         do {
             // p is not null.  Should we pulse p for read and continue?
-            if (prev != NULL &&
+            if (prev != nullptr &&
                 !(prev->access_ == access_t::read && prev->read_cond_.is_pulsed())) {
                 // We're done, because the previous node is present and isn't a
                 // pulsed read-acquirer.
@@ -50,20 +50,20 @@ void rwlock_t::pulse_pulsables(rwlock_in_line_t *p) {
 
             // Should we also pulse p for write (and exit, of course)?
             if (p->access_ == access_t::write) {
-                if (prev == NULL) {
+                if (prev == nullptr) {
                     p->write_cond_.pulse();
                 }
                 return;
             }
             prev = p;
             p = acqs_.next(p);
-        } while (p != NULL);
+        } while (p != nullptr);
         return;
     }
 }
 
 rwlock_in_line_t::rwlock_in_line_t()
-    : lock_(NULL), access_(valgrind_undefined(access_t::read)) { }
+    : lock_(nullptr), access_(valgrind_undefined(access_t::read)) { }
 
 rwlock_in_line_t::rwlock_in_line_t(rwlock_t *lock, access_t access)
     : lock_(lock), access_(access) {
@@ -75,9 +75,9 @@ rwlock_in_line_t::~rwlock_in_line_t() {
 }
 
 void rwlock_in_line_t::reset() {
-    if (lock_ != NULL) {
+    if (lock_ != nullptr) {
         lock_->remove_acq(this);
-        lock_ = NULL;
+        lock_ = nullptr;
         access_ = valgrind_undefined(access_t::read);
         read_cond_.reset();
         write_cond_.reset();

--- a/src/concurrency/semaphore.cc
+++ b/src/concurrency/semaphore.cc
@@ -43,7 +43,7 @@ void static_semaphore_t::co_lock_interruptible(signal_t *interruptor, int64_t co
         wait_interruptible(&cb, interruptor);
     } catch (const interrupted_exc_t &ex) {
         // Remove our lock request from the queue
-        for (lock_request_t *request = waiters.head(); request != NULL; request = waiters.next(request)) {
+        for (lock_request_t *request = waiters.head(); request != nullptr; request = waiters.next(request)) {
             if (request->cb == &cb) {
                 waiters.remove(request);
                 delete request;
@@ -121,7 +121,7 @@ void adjustable_semaphore_t::co_lock_interruptible(signal_t *interruptor, int64_
         wait_interruptible(&cb, interruptor);
     } catch (const interrupted_exc_t& ex) {
         // Remove our lock request from the queue
-        for (lock_request_t *request = waiters.head(); request != NULL; request = waiters.next(request)) {
+        for (lock_request_t *request = waiters.head(); request != nullptr; request = waiters.next(request)) {
             if (request->cb == &cb) {
                 waiters.remove(request);
                 delete request;

--- a/src/concurrency/semaphore.hpp
+++ b/src/concurrency/semaphore.hpp
@@ -153,7 +153,7 @@ public:
         acquiree(movee.acquiree),
         count(movee.count) {
 
-        movee.acquiree = NULL;
+        movee.acquiree = nullptr;
     }
 
     ~semaphore_acq_t() {

--- a/src/concurrency/signal.hpp
+++ b/src/concurrency/signal.hpp
@@ -52,7 +52,7 @@ public:
 
         virtual ~subscription_t() { }
 
-        void reset(signal_t *s = NULL) {
+        void reset(signal_t *s = nullptr) {
             if (s) {
                 mutex_assertion_t::acq_t acq(&s->lock);
                 if (s->is_pulsed()) {
@@ -61,7 +61,7 @@ public:
                     subs.reset(s->publisher_controller.get_publisher());
                 }
             } else {
-                subs.reset(NULL);
+                subs.reset(nullptr);
             }
         }
 

--- a/src/concurrency/watchable.tcc
+++ b/src/concurrency/watchable.tcc
@@ -136,7 +136,7 @@ public:
     }
 
     bool operator()(const outer_type &input, result_type *current_out) {
-        guarantee(current_out != NULL);
+        guarantee(current_out != nullptr);
         result_type old_value = *current_out;
         *current_out = inner(input);
         /* We can't use `!=` here because sometimes lazy programmers will implement `==`

--- a/src/containers/archive/archive.cc
+++ b/src/containers/archive/archive.cc
@@ -83,7 +83,7 @@ void write_message_t::append(const void *p, int64_t n) {
 
 size_t write_message_t::size() const {
     size_t ret = 0;
-    for (write_buffer_t *h = buffers_.head(); h != NULL; h = buffers_.next(h)) {
+    for (write_buffer_t *h = buffers_.head(); h != nullptr; h = buffers_.next(h)) {
         ret += h->size;
     }
     return ret;

--- a/src/containers/archive/socket_stream.cc
+++ b/src/containers/archive/socket_stream.cc
@@ -58,7 +58,7 @@ void blocking_fd_watcher_t::init_callback(UNUSED linux_event_callback_t *cb) {}
 // -------------------- linux_event_fd_watcher_t --------------------
 linux_event_fd_watcher_t::linux_event_fd_watcher_t(fd_t fd)
     : io_in_progress_(false),
-      event_callback_(NULL),
+      event_callback_(nullptr),
       event_watcher_(fd, this)
 {
     int res = fcntl(fd, F_SETFL, O_NONBLOCK);
@@ -146,7 +146,7 @@ linux_event_fd_watcher_t::~linux_event_fd_watcher_t() {
 socket_stream_t::socket_stream_t(fd_t fd, fd_watcher_t *watcher)
     : fd_(fd),
       fd_watcher_(watcher ? watcher : new linux_event_fd_watcher_t(fd)),
-      interruptor(NULL)
+      interruptor(nullptr)
 {
     guarantee(fd != INVALID_FD);
     fd_watcher_->init_callback(this);

--- a/src/containers/archive/socket_stream.hpp
+++ b/src/containers/archive/socket_stream.hpp
@@ -103,7 +103,7 @@ class socket_stream_t :
     public write_stream_t,
     private linux_event_callback_t {
 public:
-    explicit socket_stream_t(fd_t fd, fd_watcher_t *watcher = NULL);
+    explicit socket_stream_t(fd_t fd, fd_watcher_t *watcher = nullptr);
     virtual ~socket_stream_t();
 
     // interruptible {read,write}_stream_t functions

--- a/src/containers/archive/tcp_conn_stream.cc
+++ b/src/containers/archive/tcp_conn_stream.cc
@@ -7,7 +7,7 @@ tcp_conn_stream_t::tcp_conn_stream_t(const ip_address_t &host, int port, signal_
     : conn_(new tcp_conn_t(host, port, interruptor, local_port)) { }
 
 tcp_conn_stream_t::tcp_conn_stream_t(tcp_conn_t *conn) : conn_(conn) {
-    rassert(conn_ != NULL);
+    rassert(conn_ != nullptr);
 }
 
 tcp_conn_stream_t::~tcp_conn_stream_t() {
@@ -95,11 +95,11 @@ int64_t make_buffered_tcp_conn_stream_wrapper_t::write(const void *p, int64_t n)
 
 keepalive_tcp_conn_stream_t::keepalive_tcp_conn_stream_t(const ip_address_t &host, int port, signal_t *interruptor, int local_port) :
     tcp_conn_stream_t(host, port, interruptor, local_port),
-    keepalive_callback(NULL) { }
+    keepalive_callback(nullptr) { }
 
 keepalive_tcp_conn_stream_t::keepalive_tcp_conn_stream_t(tcp_conn_t *conn) :
     tcp_conn_stream_t(conn),
-    keepalive_callback(NULL) { }
+    keepalive_callback(nullptr) { }
 
 keepalive_tcp_conn_stream_t::~keepalive_tcp_conn_stream_t() {
     // Do nothing
@@ -112,7 +112,7 @@ void keepalive_tcp_conn_stream_t::set_keepalive_callback(keepalive_callback_t *_
 int64_t keepalive_tcp_conn_stream_t::read(void *p, int64_t n) {
     int64_t result = tcp_conn_stream_t::read(p, n);
 
-    if (result > 0 && keepalive_callback != NULL) {
+    if (result > 0 && keepalive_callback != nullptr) {
         keepalive_callback->keepalive_read();
     }
 
@@ -120,7 +120,7 @@ int64_t keepalive_tcp_conn_stream_t::read(void *p, int64_t n) {
 }
 
 int64_t keepalive_tcp_conn_stream_t::write(const void *p, int64_t n) {
-    if (keepalive_callback != NULL) {
+    if (keepalive_callback != nullptr) {
         keepalive_callback->keepalive_write();
     }
 
@@ -128,7 +128,7 @@ int64_t keepalive_tcp_conn_stream_t::write(const void *p, int64_t n) {
 }
 
 int64_t keepalive_tcp_conn_stream_t::write_buffered(const void *p, int64_t n) {
-    if (keepalive_callback != NULL) {
+    if (keepalive_callback != nullptr) {
         keepalive_callback->keepalive_write();
     }
 
@@ -136,7 +136,7 @@ int64_t keepalive_tcp_conn_stream_t::write_buffered(const void *p, int64_t n) {
 }
 
 bool keepalive_tcp_conn_stream_t::flush_buffer() {
-    if (keepalive_callback != NULL) {
+    if (keepalive_callback != nullptr) {
         keepalive_callback->keepalive_write();
     }
 

--- a/src/containers/counted.hpp
+++ b/src/containers/counted.hpp
@@ -24,7 +24,7 @@ public:
     template <class U>
     friend class counted_t;
 
-    counted_t() : p_(NULL) { }
+    counted_t() : p_(nullptr) { }
     explicit counted_t(T *p) : p_(p) {
         if (p_ != nullptr) { counted_add_ref(p_); }
     }
@@ -43,12 +43,12 @@ public:
     }
 
     counted_t(counted_t &&movee) noexcept : p_(movee.p_) {
-        movee.p_ = NULL;
+        movee.p_ = nullptr;
     }
 
     template <class U>
     counted_t(counted_t<U> &&movee) noexcept : p_(movee.p_) {
-        movee.p_ = NULL;
+        movee.p_ = nullptr;
     }
 
 // Avoid a spurious warning when building on Saucy. See issue #1674
@@ -113,7 +113,7 @@ public:
     }
 
     bool has() const {
-        return p_ != NULL;
+        return p_ != nullptr;
     }
 
     bool unique() const {
@@ -121,7 +121,7 @@ public:
     }
 
     explicit operator bool() const {
-        return p_ != NULL;
+        return p_ != nullptr;
     }
 
 private:

--- a/src/containers/disk_backed_queue.cc
+++ b/src/containers/disk_backed_queue.cc
@@ -90,7 +90,7 @@ void internal_disk_backed_queue_t::push_single(txn_t *txn, const write_message_t
 
     if (static_cast<size_t>((head->data + head->data_size) - reinterpret_cast<char *>(head)) + blob.refsize(cache->max_block_size()) > cache->max_block_size().value()) {
         // The data won't fit in our current head block, so it's time to make a new one.
-        head = NULL;
+        head = nullptr;
         write.reset();
         _head.reset();
         add_block_to_head(txn);

--- a/src/containers/intrusive_list.hpp
+++ b/src/containers/intrusive_list.hpp
@@ -10,31 +10,31 @@ template <class T>
 class intrusive_list_node_t {
 public:
     bool in_a_list() const {
-        guarantee((next_ == NULL) == (prev_ == NULL));
-        return prev_ != NULL;
+        guarantee((next_ == nullptr) == (prev_ == nullptr));
+        return prev_ != nullptr;
     }
 
 protected:
-    intrusive_list_node_t() : prev_(NULL), next_(NULL) { }
+    intrusive_list_node_t() : prev_(nullptr), next_(nullptr) { }
     ~intrusive_list_node_t() {
-        guarantee(prev_ == NULL,
+        guarantee(prev_ == nullptr,
                   "non-detached intrusive list node destroyed");
-        guarantee(next_ == NULL,
+        guarantee(next_ == nullptr,
                   "inconsistent intrusive list node!");
     }
 
     intrusive_list_node_t(intrusive_list_node_t &&movee) {
-        guarantee((movee.prev_ == NULL) == (movee.next_ == NULL));
+        guarantee((movee.prev_ == nullptr) == (movee.next_ == nullptr));
         guarantee(movee.prev_ != &movee,
                 "Only intrusive_list_t can be a self-pointing node.");
         prev_ = movee.prev_;
         next_ = movee.next_;
-        if (prev_ != NULL) {
+        if (prev_ != nullptr) {
             prev_->next_ = this;
             next_->prev_ = this;
         }
-        movee.prev_ = NULL;
-        movee.next_ = NULL;
+        movee.prev_ = nullptr;
+        movee.next_ = nullptr;
     }
 
     // Don't implement this.  _Maybe_ you won't fuck it up.  Just use the
@@ -77,8 +77,8 @@ public:
         guarantee(size_ == 0, "empty intrusive list destroyed with non-zero size");
 
         // Set these to NULL to appease base class destructor's assertions.
-        this->prev_ = NULL;
-        this->next_ = NULL;
+        this->prev_ = nullptr;
+        this->next_ = nullptr;
     }
 
     bool empty() const {
@@ -172,9 +172,9 @@ private:
                                intrusive_list_node_t<T> *after) {
         intrusive_list_node_t<T> *node = item;
         guarantee(!node->in_a_list());
-        guarantee(before != NULL);
+        guarantee(before != nullptr);
         guarantee(before->in_a_list());
-        guarantee(after != NULL);
+        guarantee(after != nullptr);
         guarantee(after->in_a_list());
         before->next_ = node;
         after->prev_ = node;
@@ -187,12 +187,12 @@ private:
         guarantee(node->in_a_list());
         node->prev_->next_ = node->next_;
         node->next_->prev_ = node->prev_;
-        node->prev_ = NULL;
-        node->next_ = NULL;
+        node->prev_ = nullptr;
+        node->next_ = nullptr;
     }
 
     T *null_if_self(intrusive_list_node_t<T> *node) const {
-        return node == this ? NULL : static_cast<T *>(node);
+        return node == this ? nullptr : static_cast<T *>(node);
     }
 
     size_t size_;

--- a/src/containers/intrusive_priority_queue.hpp
+++ b/src/containers/intrusive_priority_queue.hpp
@@ -81,7 +81,7 @@ public:
 
     node_t *peek() {
         if (nodes.empty()) {
-            return NULL;
+            return nullptr;
         } else {
             return nodes.front();
         }
@@ -89,7 +89,7 @@ public:
 
     node_t *pop() {
         if (nodes.empty()) {
-            return NULL;
+            return nullptr;
         } else {
             node_t *x = nodes.front();
             rassert(node_queue(x) == this);

--- a/src/containers/map_sentries.hpp
+++ b/src/containers/map_sentries.hpp
@@ -135,7 +135,7 @@ template<class obj_t>
 class set_insertion_sentry_t {
 public:
     set_insertion_sentry_t() : set(NULL) { }
-    set_insertion_sentry_t(std::set<obj_t> *s, const obj_t &obj) : set(NULL) {
+    set_insertion_sentry_t(std::set<obj_t> *s, const obj_t &obj) : set(nullptr) {
         reset(s, obj);
     }
     ~set_insertion_sentry_t() {
@@ -146,7 +146,7 @@ public:
     void reset() {
         if (set) {
             set->erase(it);
-            set = NULL;
+            set = nullptr;
         }
     }
     void reset(std::set<obj_t> *s, const obj_t &obj) {

--- a/src/containers/priority_queue.hpp
+++ b/src/containers/priority_queue.hpp
@@ -30,7 +30,7 @@ public:
         void update();
         bool operator< (const entry_t &b) {return Less(b.data, data);}
         entry_t()
-            : pq(0), index(0)
+            : pq(nullptr), index(0)
         {}
     };
 private:

--- a/src/containers/scoped.hpp
+++ b/src/containers/scoped.hpp
@@ -17,18 +17,18 @@ public:
     template <class U>
     friend class scoped_ptr_t;
 
-    scoped_ptr_t() : ptr_(NULL) { }
+    scoped_ptr_t() : ptr_(nullptr) { }
     explicit scoped_ptr_t(T *p) : ptr_(p) { }
 
     // (These noexcepts don't actually do anything w.r.t. STL containers, since the
     // type's not copyable.  There is no specific reason why these are many other
     // functions need be marked noexcept with any degree of urgency.)
     scoped_ptr_t(scoped_ptr_t &&movee) noexcept : ptr_(movee.ptr_) {
-        movee.ptr_ = NULL;
+        movee.ptr_ = nullptr;
     }
     template <class U>
     scoped_ptr_t(scoped_ptr_t<U> &&movee) noexcept : ptr_(movee.ptr_) {
-        movee.ptr_ = NULL;
+        movee.ptr_ = nullptr;
     }
 
     ~scoped_ptr_t() {
@@ -69,13 +69,13 @@ public:
 
     void reset() {
         T *tmp = ptr_;
-        ptr_ = NULL;
+        ptr_ = nullptr;
         delete tmp;
     }
 
     MUST_USE T *release() {
         T *tmp = ptr_;
-        ptr_ = NULL;
+        ptr_ = nullptr;
         return tmp;
     }
 
@@ -105,11 +105,11 @@ public:
     }
 
     bool has() const {
-        return ptr_ != NULL;
+        return ptr_ != nullptr;
     }
 
     explicit operator bool() const {
-        return ptr_ != NULL;
+        return ptr_ != nullptr;
     }
 
 private:
@@ -127,12 +127,12 @@ scoped_ptr_t<T> make_scoped(Args&&... args) {
 template <class T>
 class scoped_array_t {
 public:
-    scoped_array_t() : ptr_(NULL), size_(0) { }
-    explicit scoped_array_t(size_t n) : ptr_(NULL), size_(0) {
+    scoped_array_t() : ptr_(nullptr), size_(0) { }
+    explicit scoped_array_t(size_t n) : ptr_(nullptr), size_(0) {
         init(n);
     }
 
-    scoped_array_t(T *ptr, size_t _size) : ptr_(NULL), size_(0) {
+    scoped_array_t(T *ptr, size_t _size) : ptr_(nullptr), size_(0) {
         init(ptr, _size);
     }
 
@@ -141,7 +141,7 @@ public:
     // functions need be marked noexcept with any degree of urgency.)
     scoped_array_t(scoped_array_t &&movee) noexcept
         : ptr_(movee.ptr_), size_(movee.size_) {
-        movee.ptr_ = NULL;
+        movee.ptr_ = nullptr;
         movee.size_ = 0;
     }
 
@@ -172,7 +172,7 @@ public:
 
     void reset() {
         T *tmp = ptr_;
-        ptr_ = NULL;
+        ptr_ = nullptr;
         size_ = 0;
         delete[] tmp;
     }
@@ -263,7 +263,7 @@ public:
     template <class U, void*(*alloc_)(size_t), void(*dealloc_)(void*)>
     friend class scoped_alloc_t;
 
-    scoped_alloc_t() : ptr_(NULL) { }
+    scoped_alloc_t() : ptr_(nullptr) { }
     explicit scoped_alloc_t(size_t n) : ptr_(static_cast<T *>(alloc(n))) { }
     scoped_alloc_t(const void *beg, size_t n) {
         ptr_ = static_cast<T *>(alloc(n));
@@ -274,13 +274,13 @@ public:
     // functions need be marked noexcept with any degree of urgency.)
     scoped_alloc_t(scoped_alloc_t &&movee) noexcept
         : ptr_(movee.ptr_) {
-        movee.ptr_ = NULL;
+        movee.ptr_ = nullptr;
     }
 
     template <class U>
     scoped_alloc_t(scoped_alloc_t<U, alloc, dealloc> &&movee) noexcept
         : ptr_(movee.ptr_) {
-        movee.ptr_ = NULL;
+        movee.ptr_ = nullptr;
     }
 
     template <class U>
@@ -298,7 +298,7 @@ public:
     T *operator->() const { return ptr_; }
 
     bool has() const {
-        return ptr_ != NULL;
+        return ptr_ != nullptr;
     }
 
     void reset() {

--- a/src/containers/segmented_vector.hpp
+++ b/src/containers/segmented_vector.hpp
@@ -99,7 +99,7 @@ private:
         guarantee(index < size_, "index = %zu, size_ = %zu", index, size_);
         const size_t segment_index = index / ELEMENTS_PER_SEGMENT;
         segment_t *seg = segments_[segment_index];
-        if (seg == NULL) {
+        if (seg == nullptr) {
             seg = new segment_t();
             segments_[segment_index] = seg;
         }
@@ -119,7 +119,7 @@ private:
             segments_.pop_back();
         }
         while (segments_.size() < new_num_segs) {
-            segments_.push_back(NULL);
+            segments_.push_back(nullptr);
         }
 
         size_ = new_size;

--- a/src/containers/two_level_array.hpp
+++ b/src/containers/two_level_array.hpp
@@ -55,7 +55,7 @@ public:
 
     value_t get(size_t key) const {
         size_t chunk_id = chunk_for_key(key);
-        if (chunk_id < chunks.size() && chunks[chunk_id] != NULL) {
+        if (chunk_id < chunks.size() && chunks[chunk_id] != nullptr) {
             return chunks[chunk_id]->values[index_for_key(key)];
         } else {
             return value_t();
@@ -64,12 +64,12 @@ public:
 
     void set(size_t key, value_t value) {
         const size_t chunk_id = chunk_for_key(key);
-        if (chunk_id >= chunks.size() || chunks[chunk_id] == NULL) {
+        if (chunk_id >= chunks.size() || chunks[chunk_id] == nullptr) {
             if (value == value_t()) {
                 return;
             } else {
                 if (chunk_id >= chunks.size()) {
-                    chunks.resize(chunk_id + 1, NULL);
+                    chunks.resize(chunk_id + 1, nullptr);
                 }
                 chunks[chunk_id] = new chunk_t;
             }
@@ -86,10 +86,10 @@ public:
         }
 
         if (chunk->count == 0) {
-            chunks[chunk_id] = NULL;
+            chunks[chunk_id] = nullptr;
             delete chunk;
 
-            while (!chunks.empty() && chunks.back() == NULL) {
+            while (!chunks.empty() && chunks.back() == nullptr) {
                 chunks.pop_back();
             }
         }

--- a/src/errors.cc
+++ b/src/errors.cc
@@ -106,7 +106,7 @@ const char *errno_string_maybe_using_buffer(int errsv, char *buf, size_t buflen)
 MUST_USE const std::string winerr_string(DWORD winerr) {
     char *errmsg;
     DWORD res = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                   NULL, winerr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&errmsg, 0, NULL);
+                   nullptr, winerr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&errmsg, 0, nullptr);
     if (res != 0) {
         size_t end = strlen(errmsg);
         while (end > 0 && isspace(errmsg[end-1])) {
@@ -274,15 +274,15 @@ void install_generic_crash_handler() {
     {
         struct sigaction sa = make_sa_handler(0, generic_crash_handler);
 
-        int res = sigaction(SIGSEGV, &sa, NULL);
+        int res = sigaction(SIGSEGV, &sa, nullptr);
         guarantee_err(res == 0, "Could not install SEGV signal handler");
-        res = sigaction(SIGBUS, &sa, NULL);
+        res = sigaction(SIGBUS, &sa, nullptr);
         guarantee_err(res == 0, "Could not install BUS signal handler");
     }
 #endif
 
     struct sigaction sa = make_sa_handler(0, SIG_IGN);
-    int res = sigaction(SIGPIPE, &sa, NULL);
+    int res = sigaction(SIGPIPE, &sa, nullptr);
     guarantee_err(res == 0, "Could not install PIPE handler");
 #endif
 

--- a/src/extproc/extproc_job.cc
+++ b/src/extproc/extproc_job.cc
@@ -11,7 +11,7 @@ extproc_job_t::extproc_job_t(extproc_pool_t *_pool,
     user_interruptor(_user_interruptor),
     combined_interruptor(pool->get_shutdown_signal())
 {
-    if (user_interruptor != NULL) {
+    if (user_interruptor != nullptr) {
         combined_interruptor.add(user_interruptor);
     }
 

--- a/src/extproc/extproc_spawner.cc
+++ b/src/extproc/extproc_spawner.cc
@@ -12,7 +12,7 @@
 #include "extproc/extproc_worker.hpp"
 #include "arch/fd_send_recv.hpp"
 
-extproc_spawner_t *extproc_spawner_t::instance = NULL;
+extproc_spawner_t *extproc_spawner_t::instance = nullptr;
 
 // This is the class that runs in the external process, doing all the work
 class worker_run_t {
@@ -24,7 +24,7 @@ public:
 
         // Set ourselves to get interrupted when our parent dies
         struct sigaction sa = make_sa_handler(0, check_ppid_for_death);
-        const int sigaction_res = sigaction(SIGALRM, &sa, NULL);
+        const int sigaction_res = sigaction(SIGALRM, &sa, nullptr);
         guarantee_err(sigaction_res == 0, "worker: could not set action for ALRM signal");
 
         struct itimerval timerval;
@@ -122,7 +122,7 @@ public:
             // NB. According to `man 2 sigaction` on linux, POSIX.1-2001 says that
             // this will prevent zombies, but may not be "fully portable".
             struct sigaction sa = make_sa_handler(0, SIG_IGN);
-            const int res = sigaction(SIGCHLD, &sa, NULL);
+            const int res = sigaction(SIGCHLD, &sa, nullptr);
             guarantee_err(res == 0, "spawner: Could not ignore SIGCHLD");
         }
     }
@@ -159,7 +159,7 @@ extproc_spawner_t::extproc_spawner_t() :
     spawner_pid(-1)
 {
     // TODO: guarantee we aren't in a thread pool
-    guarantee(instance == NULL);
+    guarantee(instance == nullptr);
     instance = this;
 
     fork_spawner();
@@ -168,7 +168,7 @@ extproc_spawner_t::extproc_spawner_t() :
 extproc_spawner_t::~extproc_spawner_t() {
     // TODO: guarantee we aren't in a thread pool
     guarantee(instance == this);
-    instance = NULL;
+    instance = nullptr;
 
     // This should trigger the spawner to exit
     spawner_socket.reset();

--- a/src/extproc/extproc_worker.cc
+++ b/src/extproc/extproc_worker.cc
@@ -27,7 +27,7 @@ NORETURN bool worker_exit_fn(read_stream_t *stream_in, write_stream_t *) {
 extproc_worker_t::extproc_worker_t(extproc_spawner_t *_spawner) :
     spawner(_spawner),
     worker_pid(-1),
-    interruptor(NULL) { }
+    interruptor(nullptr) { }
 
 extproc_worker_t::~extproc_worker_t() {
     if (worker_pid != -1) {
@@ -67,18 +67,18 @@ void extproc_worker_t::acquired(signal_t *_interruptor) {
     }
 
     // Apply the user interruptor to our stream along with the extproc pool's interruptor
-    guarantee(interruptor == NULL);
+    guarantee(interruptor == nullptr);
     interruptor = _interruptor;
-    guarantee(interruptor != NULL);
+    guarantee(interruptor != nullptr);
     socket_stream.get()->set_interruptor(interruptor);
 }
 
 void extproc_worker_t::released(bool user_error, signal_t *user_interruptor) {
-    guarantee(interruptor != NULL);
+    guarantee(interruptor != nullptr);
     bool errored = user_error;
 
     // If we were interrupted by the user, we can't count on the worker being valid
-    if (user_interruptor != NULL && user_interruptor->is_pulsed()) {
+    if (user_interruptor != nullptr && user_interruptor->is_pulsed()) {
         errored = true;
     } else if (!errored) {
         // Set up a timeout interruptor for the final write/read
@@ -116,7 +116,7 @@ void extproc_worker_t::released(bool user_error, signal_t *user_interruptor) {
     }
 
     socket_stream.reset();
-    interruptor = NULL;
+    interruptor = nullptr;
 
     // If anything went wrong, we just kill the worker and recreate it later
     if (errored) {

--- a/src/extproc/http_job.cc
+++ b/src/extproc/http_job.cc
@@ -73,10 +73,10 @@ private:
 class scoped_curl_slist_t {
 public:
     scoped_curl_slist_t() :
-        slist(NULL) { }
+        slist(nullptr) { }
 
     ~scoped_curl_slist_t() {
-        if (slist != NULL) {
+        if (slist != nullptr) {
             curl_slist_free_all(slist);
         }
     }
@@ -87,7 +87,7 @@ public:
 
     void add(const std::string &str) {
         slist = curl_slist_append(slist, str.c_str());
-        if (slist == NULL) {
+        if (slist == nullptr) {
             throw curl_exc_t("appending header, allocation failure");
         }
     }
@@ -249,7 +249,7 @@ std::string exc_encode(CURL *curl_handle, const std::string &str) {
 
     if (str.size() != 0) {
         char *curl_res = curl_easy_escape(curl_handle, str.data(), str.size());
-        if (curl_res == NULL) {
+        if (curl_res == nullptr) {
             throw curl_exc_t("encode string");
         }
         res.assign(curl_res);
@@ -357,7 +357,7 @@ std::string url_encode_fields(CURL *curl_handle,
         } else if (pair.second.get_type() != ql::datum_t::R_NULL) {
             // This shouldn't happen because we check this in the main process anyway
             throw curl_exc_t(strprintf("expected `params.%s` to be a NUMBER, STRING, "
-                                       "or NULL, but found %s",
+                                       "or nullptr, but found %s",
                                        pair.first.to_std().c_str(),
                                        pair.second.get_type_name().c_str()));
         }
@@ -460,7 +460,7 @@ void transfer_header_opt(const std::vector<std::string> &header,
         curl_data->header.add(*it);
     }
 
-    if (curl_data->header.get() != NULL) {
+    if (curl_data->header.get() != nullptr) {
         exc_setopt(curl_handle, CURLOPT_HTTPHEADER, curl_data->header.get(), "HEADER");
     }
 }
@@ -539,7 +539,7 @@ void perform_http(http_opts_t *opts, http_result_t *res_out) {
     scoped_curl_handle_t curl_handle;
     curl_data_t curl_data;
 
-    if (curl_handle.get() == NULL) {
+    if (curl_handle.get() == nullptr) {
         res_out->error.assign("initialization");
         return;
     }
@@ -619,12 +619,12 @@ void perform_http(http_opts_t *opts, http_result_t *res_out) {
         case http_result_format_t::AUTO:
             {
                 std::string content_type;
-                char *content_type_buffer = NULL;
+                char *content_type_buffer = nullptr;
                 curl_easy_getinfo(curl_handle.get(),
                                   CURLINFO_CONTENT_TYPE,
                                   &content_type_buffer);
 
-                if (content_type_buffer != NULL) {
+                if (content_type_buffer != nullptr) {
                     content_type.assign(content_type_buffer);
                 }
 
@@ -710,7 +710,7 @@ private:
     std::map<datum_string_t, ql::datum_t> link_headers;
     std::string current_field;
 };
-header_parser_singleton_t *header_parser_singleton_t::instance = NULL;
+header_parser_singleton_t *header_parser_singleton_t::instance = nullptr;
 
 // The link_parser regular expression is used to parse 'Link' headers from HTTP
 // responses (see RFC 5988 - http://tools.ietf.org/html/rfc5988).  We are interested
@@ -744,7 +744,7 @@ header_parser_singleton_t::header_parser_singleton_t() :
 }
 
 void header_parser_singleton_t::initialize() {
-    if (instance == NULL) {
+    if (instance == nullptr) {
         instance = new header_parser_singleton_t();
     }
 
@@ -848,11 +848,11 @@ void save_cookies(CURL *curl_handle, http_result_t *res_out) {
     }
 
     res_out->cookies.clear();
-    for (curl_slist *current = cookies; current != NULL; current = current->next) {
+    for (curl_slist *current = cookies; current != nullptr; current = current->next) {
         res_out->cookies.push_back(std::string(current->data));
     }
 
-    if (cookies != NULL) {
+    if (cookies != nullptr) {
         curl_slist_free_all(cookies);
     }
 }
@@ -901,7 +901,7 @@ private:
     { }
 
     static void initialize_if_needed() {
-        if (instance == NULL) {
+        if (instance == nullptr) {
             instance = new jsonp_parser_singleton_t();
         }
     }
@@ -920,7 +920,7 @@ private:
 };
 
 // Static const initializations for above
-jsonp_parser_singleton_t *jsonp_parser_singleton_t::instance = NULL;
+jsonp_parser_singleton_t *jsonp_parser_singleton_t::instance = nullptr;
 const char *jsonp_parser_singleton_t::fn_call = "\\(((?s).*)\\)";
 const char *jsonp_parser_singleton_t::expr_end = "\\s*;?\\s*";
 const char *jsonp_parser_singleton_t::js_ident =

--- a/src/extproc/js_job.cc
+++ b/src/extproc/js_job.cc
@@ -49,7 +49,7 @@ private:
     scoped_ptr_t<v8::Platform> platform;
 };
 
-js_instance_t *js_instance_t::instance = NULL;
+js_instance_t *js_instance_t::instance = nullptr;
 
 js_instance_t::js_instance_t() {
     v8::V8::InitializeICU();
@@ -76,7 +76,7 @@ v8::Isolate *js_instance_t::isolate() {
 }
 
 void js_instance_t::maybe_initialize_v8() {
-    if (instance == NULL) {
+    if (instance == nullptr) {
         instance = new js_instance_t;
     }
 }
@@ -378,7 +378,7 @@ static void append_caught_error(std::string *err_out, const v8::TryCatch &try_ca
 
     v8::String::Utf8Value exception(try_catch.Exception());
     const char *message = *exception;
-    guarantee(message != NULL);
+    guarantee(message != nullptr);
     err_out->append(message, strlen(message));
 }
 
@@ -645,7 +645,7 @@ ql::datum_t js_to_datum(const v8::Handle<v8::Value> &value,
                         const ql::configured_limits_t &limits,
                         std::string *err_out) {
     guarantee(!value.IsEmpty());
-    guarantee(err_out != NULL);
+    guarantee(err_out != nullptr);
 
     v8::HandleScope handle_scope(js_instance_t::isolate());
     err_out->assign("Unknown error when converting to ql::datum_t.");

--- a/src/http/http_parser.cc
+++ b/src/http/http_parser.cc
@@ -100,7 +100,7 @@
                     return (ER);                                     \
                 }                                                    \
             }                                                        \
-            FOR##_mark = NULL;                                       \
+            FOR##_mark = nullptr;                                      \
         }                                                            \
     } while (0)
   
@@ -586,11 +586,11 @@ size_t http_parser_execute (http_parser *parser,
   char c, ch;
   int8_t unhex_val;
   const char *p = data;
-  const char *header_field_mark = 0;
-  const char *header_value_mark = 0;
-  const char *url_mark = 0;
-  const char *body_mark = 0;
-  const char *status_mark = 0;
+  const char *header_field_mark = nullptr;
+  const char *header_value_mark = nullptr;
+  const char *url_mark = nullptr;
+  const char *body_mark = nullptr;
+  const char *status_mark = nullptr;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -2222,7 +2222,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   if (u->field_set & (1 << UF_PORT)) {
     /* Don't bother with endp; we've already validated the string */
-    unsigned long v = strtoul(buf + u->field_data[UF_PORT].off, NULL, 10);
+    unsigned long v = strtoul(buf + u->field_data[UF_PORT].off, nullptr, 10);
 
     /* Ports have a max value of 2^16 */
     if (v > 0xffff) {

--- a/src/http/routing_app.cc
+++ b/src/http/routing_app.cc
@@ -10,7 +10,7 @@ routing_http_app_t::routing_http_app_t(http_app_t *_defaultroute, std::map<std::
 { }
 
 void routing_http_app_t::add_route(const std::string& route, http_app_t *server) {
-    guarantee(strchr(route.c_str(), '/') == NULL, "Routes should not contain '/'s");
+    guarantee(strchr(route.c_str(), '/') == nullptr, "Routes should not contain '/'s");
     subroutes[route] = server;
 }
 

--- a/src/parsing/utf8.cc
+++ b/src/parsing/utf8.cc
@@ -174,7 +174,7 @@ const char *is_valid_continuation_byte(Iterator position, Iterator end) {
     } else if (!is_continuation(*position)) {
         return "Expected continuation byte, saw something else";
     } else {
-        return 0;
+        return nullptr;
     }
 }
 
@@ -200,7 +200,7 @@ Iterator next_codepoint(Iterator start, Iterator end, char32_t *codepoint,
         // 110xxxxx - two character multibyte
         *codepoint = extract_and_shift(current, HIGH_THREE_BITS, 6);
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++);
@@ -215,12 +215,12 @@ Iterator next_codepoint(Iterator start, Iterator end, char32_t *codepoint,
         // 1110xxxx - three character multibyte
         *codepoint = extract_and_shift(current, HIGH_FOUR_BITS, 12);
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++) << 6;
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++);
@@ -235,17 +235,17 @@ Iterator next_codepoint(Iterator start, Iterator end, char32_t *codepoint,
         // 11110xxx - four character multibyte
         *codepoint = extract_and_shift(current, HIGH_FIVE_BITS, 18);
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++) << 12;
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++) << 6;
         explanation = is_valid_continuation_byte(position, end);
-        if (explanation != 0) {
+        if (explanation != nullptr) {
             return fail(explanation, start, position, codepoint, reason);
         }
         *codepoint |= continuation_data(*position++);

--- a/src/perfmon/core.cc
+++ b/src/perfmon/core.cc
@@ -38,7 +38,7 @@ void *perfmon_collection_t::begin_stats() {
         new stats_collection_context_t(&constituents_access, constituents);
 
     size_t i = 0;
-    for (perfmon_membership_t *p = constituents.head(); p != NULL; p = constituents.next(p), ++i) {
+    for (perfmon_membership_t *p = constituents.head(); p != nullptr; p = constituents.next(p), ++i) {
         ctx->contexts[i] = p->get()->begin_stats();
     }
     return ctx;
@@ -47,7 +47,7 @@ void *perfmon_collection_t::begin_stats() {
 void perfmon_collection_t::visit_stats(void *_context) {
     stats_collection_context_t *ctx = reinterpret_cast<stats_collection_context_t*>(_context);
     size_t i = 0;
-    for (perfmon_membership_t *p = constituents.head(); p != NULL; p = constituents.next(p), ++i) {
+    for (perfmon_membership_t *p = constituents.head(); p != nullptr; p = constituents.next(p), ++i) {
         p->get()->visit_stats(ctx->contexts[i]);
     }
 }
@@ -58,7 +58,7 @@ ql::datum_t perfmon_collection_t::end_stats(void *_context) {
     ql::datum_object_builder_t builder;
 
     size_t i = 0;
-    for (perfmon_membership_t *p = constituents.head(); p != NULL; p = constituents.next(p), ++i) {
+    for (perfmon_membership_t *p = constituents.head(); p != nullptr; p = constituents.next(p), ++i) {
         ql::datum_t stat = p->get()->end_stats(ctx->contexts[i]);
         if (p->splice()) {
             for (size_t j = 0; j < stat.obj_size(); ++j) {
@@ -76,7 +76,7 @@ ql::datum_t perfmon_collection_t::end_stats(void *_context) {
 
 void perfmon_collection_t::add(perfmon_membership_t *perfmon) {
     scoped_ptr_t<on_thread_t> thread_switcher;
-    if (coroutines_have_been_initialized() && coro_t::self() != NULL) {
+    if (coroutines_have_been_initialized() && coro_t::self() != nullptr) {
         thread_switcher.init(new on_thread_t(home_thread()));
     }
 
@@ -86,7 +86,7 @@ void perfmon_collection_t::add(perfmon_membership_t *perfmon) {
 
 void perfmon_collection_t::remove(perfmon_membership_t *perfmon) {
     scoped_ptr_t<on_thread_t> thread_switcher;
-    if (coroutines_have_been_initialized() && coro_t::self() != NULL) {
+    if (coroutines_have_been_initialized() && coro_t::self() != nullptr) {
         thread_switcher.init(new on_thread_t(home_thread()));
     }
 
@@ -95,7 +95,7 @@ void perfmon_collection_t::remove(perfmon_membership_t *perfmon) {
 }
 
 perfmon_membership_t::perfmon_membership_t(perfmon_collection_t *_parent, perfmon_t *_perfmon, const char *_name, bool _own_the_perfmon)
-    : name(_name != NULL ? _name : ""), parent(_parent), perfmon(_perfmon), own_the_perfmon(_own_the_perfmon)
+    : name(_name != nullptr ? _name : ""), parent(_parent), perfmon(_perfmon), own_the_perfmon(_own_the_perfmon)
 {
     parent->add(this);
 }

--- a/src/protocol_api.hpp
+++ b/src/protocol_api.hpp
@@ -84,7 +84,7 @@ public:
     virtual std::set<region_t> get_sharding_scheme()
         THROWS_ONLY(cannot_perform_query_exc_t) = 0;
 
-    virtual signal_t *get_initial_ready_signal() { return NULL; }
+    virtual signal_t *get_initial_ready_signal() { return nullptr; }
 
     virtual bool check_readiness(table_readiness_t readiness,
                                  signal_t *interruptor) = 0;

--- a/src/region/hash_region.cc
+++ b/src/region/hash_region.cc
@@ -57,7 +57,7 @@ const store_key_t *double_key_lookup(int i, const std::vector<hash_region_t<key_
         return &r->inner.left;
     } else {
         if (r->inner.right.unbounded) {
-            return NULL;
+            return nullptr;
         } else {
             return &r->inner.right.key();
         }
@@ -93,14 +93,14 @@ public:
         const store_key_t *jval = double_key_lookup(j, *vec_);
 
         int ret;
-        if (ival == NULL) {
-            if (jval == NULL) {
+        if (ival == nullptr) {
+            if (jval == nullptr) {
                 ret = 0;
             } else {
                 ret = 1;
             }
         } else {
-            if (jval == NULL) {
+            if (jval == nullptr) {
                 ret = -1;
             } else {
                 ret = ival->compare(*jval);
@@ -219,9 +219,9 @@ MUST_USE region_join_result_t region_join(const std::vector< hash_region_t<key_r
     uint64_t out_beg = double_hash_lookup(*hash_beg, vec);
     uint64_t out_end = double_hash_lookup(*(hash_end - 1), vec);
 
-    rassert(out_left != NULL);
+    rassert(out_left != nullptr);
 
-    if (out_right != NULL) {
+    if (out_right != nullptr) {
         *out = hash_region_t<key_range_t>(out_beg, out_end, key_range_t(key_range_t::closed, *out_left, key_range_t::open, *out_right));
     } else {
         *out = hash_region_t<key_range_t>(out_beg, out_end, key_range_t(key_range_t::closed, *out_left, key_range_t::none, store_key_t()));

--- a/src/rethinkdb_backtrace.cc
+++ b/src/rethinkdb_backtrace.cc
@@ -75,7 +75,7 @@ void substitute_pthread_t_stack_fields(pthread_t th, pthread_t_field_locations_t
 
 int rethinkdb_backtrace(void **buffer, int size) {
     coro_t *const coro = coro_t::self();
-    if (coro == NULL) {
+    if (coro == nullptr) {
         return backtrace(buffer, size);
     } else {
         pthread_t_field_locations_t field_locations;

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -255,7 +255,7 @@ connectivity_cluster_t::run_t::run_t(
     `connection_map` on each thread and notifying any listeners that we're now
     connected to ourself. The destructor will remove us from the
     `connection_map` and again notify any listeners. */
-    connection_to_ourself(this, parent->me, _server_id, NULL, routing_table[parent->me]),
+    connection_to_ourself(this, parent->me, _server_id, nullptr, routing_table[parent->me]),
 
     heartbeat_sl_view(_heartbeat_sl_view),
 
@@ -302,7 +302,7 @@ void connectivity_cluster_t::run_t::on_new_connection(
     nconn->make_overcomplicated(&conn);
     keepalive_tcp_conn_stream_t conn_stream(conn);
 
-    handle(&conn_stream, boost::none, boost::none, lock, NULL);
+    handle(&conn_stream, boost::none, boost::none, lock, nullptr);
 }
 
 void connectivity_cluster_t::run_t::connect_to_peer(
@@ -1127,7 +1127,7 @@ void connectivity_cluster_t::run_t::handle(
 
     // This check is so that when trying multiple connections to a peer in parallel, we can
     //  make sure only one of them succeeds
-    if (successful_join != NULL) {
+    if (successful_join != nullptr) {
         if (*successful_join) {
             logWRN("Somehow ended up with two successful joins to a peer, closing one");
             return;
@@ -1208,7 +1208,7 @@ void connectivity_cluster_t::run_t::handle(
                 `heartbeat_manager_t` as soon as the heartbeat arrived. */
                 if (tag != heartbeat_tag) {
                     cluster_message_handler_t *handler = parent->message_handlers[tag];
-                    guarantee(handler != NULL, "Got a message for an unfamiliar tag. "
+                    guarantee(handler != nullptr, "Got a message for an unfamiliar tag. "
                         "Apparently we aren't compatible with the cluster on the other "
                         "end.");
 
@@ -1259,12 +1259,12 @@ connectivity_cluster_t::connectivity_cluster_t() THROWS_NOTHING :
     thread_allocator([](threadnum_t a, threadnum_t b) {
         return a.threadnum > b.threadnum;
     }),
-    current_run(NULL),
+    current_run(nullptr),
     connectivity_collection(),
     stats_membership(&get_global_perfmon_collection(), &connectivity_collection, "connectivity")
 {
     for (int i = 0; i < max_message_tag; i++) {
-        message_handlers[i] = NULL;
+        message_handlers[i] = nullptr;
     }
 }
 
@@ -1454,14 +1454,14 @@ cluster_message_handler_t::cluster_message_handler_t(
     rassert(tag != connectivity_cluster_t::heartbeat_tag,
         "Tag %" PRIu8 " is reserved for heartbeat messages.",
         connectivity_cluster_t::heartbeat_tag);
-    rassert(connectivity_cluster->message_handlers[tag] == NULL);
+    rassert(connectivity_cluster->message_handlers[tag] == nullptr);
     connectivity_cluster->message_handlers[tag] = this;
 }
 
 cluster_message_handler_t::~cluster_message_handler_t() {
     guarantee(!connectivity_cluster->current_run);
     rassert(connectivity_cluster->message_handlers[tag] == this);
-    connectivity_cluster->message_handlers[tag] = NULL;
+    connectivity_cluster->message_handlers[tag] = nullptr;
 }
 
 void cluster_message_handler_t::on_local_message(

--- a/src/rpc/connectivity/cluster.hpp
+++ b/src/rpc/connectivity/cluster.hpp
@@ -125,7 +125,7 @@ public:
 
         /* Returns `true` if this is the loopback connection */
         bool is_loopback() const {
-            return conn == NULL;
+            return conn == nullptr;
         }
 
         /* Drops the connection. */
@@ -209,13 +209,13 @@ public:
         class variable_setter_t {
         public:
             variable_setter_t(run_t **var, run_t *val) : variable(var) , value(val) {
-                guarantee(*variable == NULL);
+                guarantee(*variable == nullptr);
                 *variable = value;
             }
 
             ~variable_setter_t() THROWS_NOTHING {
                 guarantee(*variable == value);
-                *variable = NULL;
+                *variable = nullptr;
             }
         private:
             run_t **variable;

--- a/src/rpc/mailbox/mailbox.cc
+++ b/src/rpc/mailbox/mailbox.cc
@@ -155,7 +155,7 @@ mailbox_manager_t::mailbox_table_t::~mailbox_table_t() {
 raw_mailbox_t *mailbox_manager_t::mailbox_table_t::find_mailbox(raw_mailbox_t::id_t id) {
     std::map<raw_mailbox_t::id_t, raw_mailbox_t *>::iterator it = mailboxes.find(id);
     if (it == mailboxes.end()) {
-        return NULL;
+        return nullptr;
     } else {
         return it->second;
     }
@@ -253,7 +253,7 @@ void mailbox_manager_t::mailbox_read_coroutine(
 
     // Construct a new stream to use
     vector_read_stream_t stream(std::move(*stream_data), stream_data_offset);
-    stream_data = NULL; // <- It is not safe to use `stream_data` anymore once we
+    stream_data = nullptr; // <- It is not safe to use `stream_data` anymore once we
                         //    switch the thread
 
     {
@@ -266,7 +266,7 @@ void mailbox_manager_t::mailbox_read_coroutine(
 
         try {
             raw_mailbox_t *mbox = mailbox_tables.get()->find_mailbox(dest_mailbox_id);
-            if (mbox != NULL) {
+            if (mbox != nullptr) {
                 try {
                     auto_drainer_t::lock_t keepalive(&mbox->drainer);
                     mbox->callback->read(&stream, keepalive.get_drain_signal());
@@ -305,7 +305,7 @@ void mailbox_manager_t::unregister_mailbox(raw_mailbox_t::id_t id) {
 disconnect_watcher_t::disconnect_watcher_t(mailbox_manager_t *mailbox_manager,
                                            peer_id_t peer) {
     if (mailbox_manager->get_connectivity_cluster()->
-            get_connection(peer, &connection_keepalive) != NULL) {
+            get_connection(peer, &connection_keepalive) != nullptr) {
         /* The peer is currently connected. Start watching for when they disconnect. */
         signal_t::subscription_t::reset(connection_keepalive.get_drain_signal());
     } else {

--- a/src/rpc/semilattice/joins/versioned.hpp
+++ b/src/rpc/semilattice/joins/versioned.hpp
@@ -92,7 +92,7 @@ private:
         also important in the case where servers' clocks aren't sane; if one server sets
         `timestamp` to a time far in the future, this logic will still allow the other
         servers to change the stored value. */
-        timestamp = std::max(timestamp+1, time(NULL));
+        timestamp = std::max(timestamp+1, time(nullptr));
         tiebreaker = generate_uuid();
     }
 

--- a/src/rpc/semilattice/semilattice_manager.tcc
+++ b/src/rpc/semilattice/semilattice_manager.tcc
@@ -40,7 +40,7 @@ semilattice_manager_t<metadata_t>::semilattice_manager_t(
 template<class metadata_t>
 semilattice_manager_t<metadata_t>::~semilattice_manager_t() THROWS_NOTHING {
     assert_thread();
-    root_view->parent = NULL;
+    root_view->parent = nullptr;
 }
 
 template<class metadata_t>
@@ -265,7 +265,7 @@ void semilattice_manager_t<metadata_t>::root_view_t::sync_from(peer_id_t peer, s
     connectivity_cluster_t::connection_t *connection =
         parent->get_connectivity_cluster()->
             get_connection(peer, &connection_keepalive);
-    if (connection == NULL) {
+    if (connection == nullptr) {
         throw sync_failed_exc_t();
     }
 
@@ -305,7 +305,7 @@ void semilattice_manager_t<metadata_t>::root_view_t::sync_to(peer_id_t peer, sig
     connectivity_cluster_t::connection_t *connection =
         parent->get_connectivity_cluster()->
             get_connection(peer, &connection_keepalive);
-    if (connection == NULL) {
+    if (connection == nullptr) {
         throw sync_failed_exc_t();
     }
 
@@ -567,7 +567,7 @@ void semilattice_manager_t<metadata_t>::wait_for_version_from_peer(peer_id_t pee
     connectivity_cluster_t::connection_t *connection =
         get_connectivity_cluster()->
             get_connection(peer, &connection_keepalive);
-    if (connection == NULL) {
+    if (connection == nullptr) {
         throw sync_failed_exc_t();
     }
 

--- a/src/rpc/semilattice/view.hpp
+++ b/src/rpc/semilattice/view.hpp
@@ -49,7 +49,7 @@ public:
             view = v;
         }
         void reset() {
-            subs.reset(NULL);
+            subs.reset(nullptr);
             view.reset();
         }
     private:

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -100,7 +100,7 @@ public:
     ~gc_entry_t() {
         uint64_t extent_id = parent->static_config->extent_index(extent_offset);
         guarantee(parent->entries.get(extent_id) == this);
-        parent->entries.set(extent_id, NULL);
+        parent->entries.set(extent_id, nullptr);
 
         --parent->stats->pm_serializer_data_extents;
     }
@@ -171,7 +171,7 @@ public:
             *relative_offset_out = offset;
             *block_index_out = block_infos.size();
             block_infos.push_back(block_info_t{offset, block_size, false, false});
-            update_stats(NULL, &block_infos.back());
+            update_stats(nullptr, &block_infos.back());
             return true;
         }
     }
@@ -243,11 +243,11 @@ public:
         auto it = find_lower_bound_iter(relative_offset);
         if (it == block_infos.end()) {
             block_infos.push_back(block_info_t{relative_offset, block_size, false, true});
-            update_stats(NULL, &block_infos.back());
+            update_stats(nullptr, &block_infos.back());
         } else if (it->relative_offset > relative_offset) {
             guarantee(it->relative_offset >= relative_offset + aligned_value(block_size));
             auto new_block = block_infos.insert(it, block_info_t{relative_offset, block_size, false, true});
-            update_stats(NULL, &*new_block);
+            update_stats(nullptr, &*new_block);
         } else {
             guarantee(it->relative_offset == relative_offset);
             guarantee(it->block_size == block_size);
@@ -307,8 +307,8 @@ private:
 
     // old_block can be NULL if a block_info was freshly added
     void update_stats(const block_info_t *old_block, const block_info_t *new_block) {
-        rassert(new_block != NULL);
-        if (old_block != NULL) {
+        rassert(new_block != nullptr);
+        if (old_block != nullptr) {
             // Undo old_block
             if (old_block->token_referenced || old_block->index_referenced) {
                 // Block is live
@@ -327,7 +327,7 @@ private:
     // Used by constructors.
     void add_self_to_parent_entries() {
         uint64_t extent_id = parent->static_config->extent_index(extent_offset);
-        guarantee(parent->entries.get(extent_id) == NULL);
+        guarantee(parent->entries.get(extent_id) == nullptr);
         parent->entries.set(extent_id, this);
 
         ++parent->stats->pm_serializer_data_extents;
@@ -381,13 +381,13 @@ data_block_manager_t::data_block_manager_t(
         extent_manager_t *em, log_serializer_t *_serializer,
         const log_serializer_on_disk_static_config_t *_static_config,
         log_serializer_stats_t *_stats)
-    : stats(_stats), shutdown_callback(NULL), state(state_unstarted), gc_enabled(true),
+    : stats(_stats), shutdown_callback(nullptr), state(state_unstarted), gc_enabled(true),
       static_config(_static_config), extent_manager(em), serializer(_serializer),
       gc_stats(stats)
 {
-    rassert(static_config != NULL);
-    rassert(extent_manager != NULL);
-    rassert(serializer != NULL);
+    rassert(static_config != nullptr);
+    rassert(extent_manager != nullptr);
+    rassert(serializer != nullptr);
 }
 
 data_block_manager_t::~data_block_manager_t() {
@@ -409,7 +409,7 @@ void data_block_manager_t::start_reconstruct() {
 void data_block_manager_t::mark_live(int64_t offset, block_size_t ser_block_size) {
     uint64_t extent_id = static_config->extent_index(offset);
 
-    if (entries.get(extent_id) == NULL) {
+    if (entries.get(extent_id) == nullptr) {
         guarantee(state == state_unstarted); // This is called at startup.
 
         gc_entry_t *entry = new gc_entry_t(this, extent_id * extent_manager->extent_size);
@@ -438,13 +438,13 @@ void data_block_manager_t::start_existing(file_t *file,
         /* It is (perhaps) possible to have an active data block extent with no
            actual data blocks in it. In this case we would not have created a
            gc_entry_t for the extent yet. */
-        if (entries.get(offset / extent_manager->extent_size) == NULL) {
+        if (entries.get(offset / extent_manager->extent_size) == nullptr) {
             gc_entry_t *e = new gc_entry_t(this, offset);
             reconstructed_extents.push_back(e);
         }
 
         active_extent = entries.get(offset / extent_manager->extent_size);
-        guarantee(active_extent != NULL);
+        guarantee(active_extent != nullptr);
 
         /* Turn the extent from a reconstructing extent into an active extent */
         guarantee(active_extent->state == gc_entry_t::state_reconstructing);
@@ -452,7 +452,7 @@ void data_block_manager_t::start_existing(file_t *file,
 
         active_extent->make_active();
     } else {
-        active_extent = NULL;
+        active_extent = nullptr;
     }
 
     /* Convert any extents that we found live blocks in, but that are not active
@@ -566,7 +566,7 @@ public:
                                                 int64_t off_in) {
         const gc_entry_t *entry
             = parent->entries.get(off_in / parent->static_config->extent_size());
-        guarantee(entry != NULL);
+        guarantee(entry != nullptr);
 
         return entry->block_boundaries();
     }
@@ -803,7 +803,7 @@ data_block_manager_t::many_writes(const std::vector<buf_write_info_t> &writes,
 }
 
 void data_block_manager_t::destroy_entry(gc_entry_t *entry) {
-    rassert(entry != NULL);
+    rassert(entry != nullptr);
     entry->destroy();
 }
 
@@ -838,10 +838,10 @@ void data_block_manager_t::check_and_handle_empty_extent(uint64_t extent_id) {
             case gc_entry_t::state_in_gc: {
                 int num_matched = 0;
                 for (gc_state_t *gc_state = active_gcs.head();
-                     gc_state != NULL;
+                     gc_state != nullptr;
                      gc_state = active_gcs.next(gc_state)) {
                     if (gc_state->current_entry == entry) {
-                        gc_state->current_entry = NULL;
+                        gc_state->current_entry = nullptr;
                         ++num_matched;
 #ifdef NDEBUG
                         // In release mode, terminate the loop as soon
@@ -940,7 +940,7 @@ void data_block_manager_t::mark_garbage(int64_t offset, extent_transaction_t *tx
 void data_block_manager_t::mark_live_tokenwise_with_offset(int64_t offset) {
     uint64_t extent_id = static_config->extent_index(offset);
     gc_entry_t *entry = entries.get(extent_id);
-    rassert(entry != NULL);
+    rassert(entry != nullptr);
     unsigned int block_index = entry->block_index(offset);
 
     entry->mark_live_tokenwise(block_index);
@@ -950,7 +950,7 @@ void data_block_manager_t::mark_garbage_tokenwise_with_offset(int64_t offset) {
     uint64_t extent_id = static_config->extent_index(offset);
     gc_entry_t *entry = entries.get(extent_id);
 
-    rassert(entry != NULL);
+    rassert(entry != nullptr);
 
     unsigned int block_index = entry->block_index(offset);
 
@@ -1039,9 +1039,9 @@ void data_block_manager_t::gc_one_extent(gc_state_t *gc_state) {
 
         /* grab the entry */
         guarantee (!gc_pq.empty());
-        guarantee(gc_state->current_entry == NULL);
+        guarantee(gc_state->current_entry == nullptr);
         gc_state->current_entry = gc_pq.pop();
-        gc_state->current_entry->our_pq_entry = NULL;
+        gc_state->current_entry->our_pq_entry = nullptr;
 
         guarantee(gc_state->current_entry->state == gc_entry_t::state_old);
         gc_state->current_entry->state = gc_entry_t::state_in_gc;
@@ -1122,7 +1122,7 @@ void data_block_manager_t::gc_one_extent(gc_state_t *gc_state) {
     /* If other forces cause all of the blocks in the extent to become
     garbage before we even finish GCing it, they will set current_entry
     to NULL. */
-    if (gc_state->current_entry == NULL) {
+    if (gc_state->current_entry == nullptr) {
         return;
     }
 
@@ -1162,7 +1162,7 @@ void data_block_manager_t::gc_one_extent(gc_state_t *gc_state) {
     /* Our write should have forced all of the blocks in the extent to
     become garbage, which should have caused the extent to be released
     and gc_state.current_entry to become NULL. */
-    guarantee(gc_state->current_entry == NULL,
+    guarantee(gc_state->current_entry == nullptr,
               "%p: %" PRIu32 " garbage bytes left on the extent, %" PRIu32
               " index-referenced bytes, %" PRIu32
               " token-referenced bytes, at offset %" PRIi64
@@ -1177,7 +1177,7 @@ void data_block_manager_t::gc_one_extent(gc_state_t *gc_state) {
 
 void data_block_manager_t::write_gcs(const std::vector<gc_write_t> &writes,
                                      gc_state_t *gc_state) {
-    guarantee(gc_state->current_entry != NULL);
+    guarantee(gc_state->current_entry != nullptr);
 
     block_write_cond_t block_write_cond;
 
@@ -1219,7 +1219,7 @@ void data_block_manager_t::write_gcs(const std::vector<gc_write_t> &writes,
 
     // We created block tokens for our blocks we're writing, so
     // there's no way the current entry could have become NULL.
-    guarantee(gc_state->current_entry != NULL);
+    guarantee(gc_state->current_entry != nullptr);
 
     std::vector<index_write_op_t> index_write_ops;
 
@@ -1278,7 +1278,7 @@ void data_block_manager_t::write_gcs(const std::vector<gc_write_t> &writes,
 void data_block_manager_t::prepare_metablock(data_block_manager::metablock_mixin_t *metablock) {
     guarantee(state == state_ready || state == state_shutting_down);
 
-    if (active_extent != NULL) {
+    if (active_extent != nullptr) {
         metablock->active_extent = active_extent->extent_ref.offset();
     } else {
         metablock->active_extent = NULL_OFFSET;
@@ -1290,7 +1290,7 @@ void data_block_manager_t::disable_gc() {
 }
 
 bool data_block_manager_t::shutdown(data_block_manager::shutdown_callback_t *cb) {
-    rassert(cb != NULL);
+    rassert(cb != nullptr);
     guarantee(state == state_ready);
     state = state_shutting_down;
 
@@ -1298,7 +1298,7 @@ bool data_block_manager_t::shutdown(data_block_manager::shutdown_callback_t *cb)
         shutdown_callback = cb;
         return false;
     } else {
-        shutdown_callback = NULL;
+        shutdown_callback = nullptr;
         actually_shutdown();
         return true;
     }
@@ -1308,12 +1308,12 @@ void data_block_manager_t::actually_shutdown() {
     guarantee(state == state_shutting_down);
     state = state_shut_down;
 
-    guarantee(reconstructed_extents.head() == NULL);
+    guarantee(reconstructed_extents.head() == nullptr);
 
-    if (active_extent != NULL) {
+    if (active_extent != nullptr) {
         UNUSED int64_t extent = active_extent->extent_ref.release();
         delete active_extent;
-        active_extent = NULL;
+        active_extent = nullptr;
     }
 
     while (gc_entry_t *entry = young_extent_queue.head()) {
@@ -1338,7 +1338,7 @@ data_block_manager_t::gimme_some_new_offsets(const std::vector<buf_write_info_t>
     ASSERT_NO_CORO_WAITING;
 
     // Start a new extent if necessary.
-    if (active_extent == NULL) {
+    if (active_extent == nullptr) {
         active_extent = new gc_entry_t(this);
         ++stats->pm_serializer_data_extents_allocated;
     }

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -101,7 +101,7 @@ private:
         gc_entry_t *current_entry;
 
         gc_state_t()
-            : current_entry(NULL) { }
+            : current_entry(nullptr) { }
     };
 
     struct gc_write_t {

--- a/src/serializer/log/extent_manager.cc
+++ b/src/serializer/log/extent_manager.cc
@@ -221,7 +221,7 @@ void extent_manager_t::prepare_initial_metablock(metablock_mixin_t *mb) {
 void extent_manager_t::start_existing(UNUSED metablock_mixin_t *last_metablock) {
     assert_thread();
     rassert(state == state_reserving_extents);
-    current_transaction = NULL;
+    current_transaction = nullptr;
     zone->reconstruct_free_list();
     state = state_running;
 
@@ -285,7 +285,7 @@ void extent_manager_t::release_extent_preliminaries() {
 void extent_manager_t::end_transaction(extent_transaction_t *t) {
     assert_thread();
     rassert(current_transaction == t);
-    current_transaction = NULL;
+    current_transaction = nullptr;
     t->mark_end();
 }
 

--- a/src/serializer/log/lba/disk_structure.cc
+++ b/src/serializer/log/lba/disk_structure.cc
@@ -5,7 +5,7 @@
 #include "math.hpp"
 
 lba_disk_structure_t::lba_disk_structure_t(extent_manager_t *_em, file_t *_file)
-    : em(_em), file(_file), superblock_extent(NULL), last_extent(NULL)
+    : em(_em), file(_file), superblock_extent(nullptr), last_extent(nullptr)
 {
 }
 
@@ -15,7 +15,7 @@ lba_disk_structure_t::lba_disk_structure_t(extent_manager_t *_em, file_t *_file,
     if (metablock->last_lba_extent_offset != NULL_OFFSET) {
         last_extent = new lba_disk_extent_t(em, file, metablock->last_lba_extent_offset, metablock->last_lba_extent_entries_count);
     } else {
-        last_extent = NULL;
+        last_extent = nullptr;
     }
 
     if (metablock->lba_superblock_offset != NULL_OFFSET) {
@@ -36,7 +36,7 @@ lba_disk_structure_t::lba_disk_structure_t(extent_manager_t *_em, file_t *_file,
             startup_superblock_buffer.get(),
             this);
     } else {
-        superblock_extent = NULL;
+        superblock_extent = nullptr;
     }
 }
 
@@ -71,7 +71,7 @@ void lba_disk_structure_t::add_entry(block_id_t block_id, repli_timestamp_t rece
         /* We have filled up an extent. Transfer it to the superblock. */
 
         extents_in_superblock.push_back(last_extent);
-        last_extent = NULL;
+        last_extent = nullptr;
 
         /* Since there is a new extent on the superblock, we need to rewrite the superblock. */
 
@@ -90,7 +90,7 @@ void lba_disk_structure_t::add_entry(block_id_t block_id, repli_timestamp_t rece
 std::set<lba_disk_extent_t *> lba_disk_structure_t::get_inactive_extents() const {
     std::set<lba_disk_extent_t *> result;
     for (lba_disk_extent_t *e = extents_in_superblock.head();
-         e != NULL; e = extents_in_superblock.next(e)) {
+         e != nullptr; e = extents_in_superblock.next(e)) {
         result.insert(e);
     }
     return result;
@@ -118,7 +118,7 @@ void lba_disk_structure_t::write_superblock(file_account_t *io_account,
     if (superblock_extent
             && superblock_extent->amount_filled + superblock_size > em->extent_size) {
         superblock_extent->destroy(txn);
-        superblock_extent = NULL;
+        superblock_extent = nullptr;
     }
 
     if (!superblock_extent) {
@@ -134,7 +134,7 @@ void lba_disk_structure_t::write_superblock(file_account_t *io_account,
     memcpy(new_superblock->magic, lba_super_magic, LBA_SUPER_MAGIC_SIZE);
     int i = 0;
     for (lba_disk_extent_t *e = extents_in_superblock.head();
-         e != NULL; e = extents_in_superblock.next(e)) {
+         e != nullptr; e = extents_in_superblock.next(e)) {
         new_superblock->entries[i].offset = e->data->extent_ref.offset();
         new_superblock->entries[i].lba_entries_count = e->count;
         i++;
@@ -185,7 +185,7 @@ void lba_disk_structure_t::sync(file_account_t *io_account, sync_callback_t *cb)
         if (last_extent) last_extent->sync(io_account, writer);
         if (superblock_extent) superblock_extent->sync(writer);
         for (lba_disk_extent_t *e = extents_in_superblock.head();
-             e != NULL; e = extents_in_superblock.next(e)) {
+             e != nullptr; e = extents_in_superblock.next(e)) {
             e->sync(io_account, writer);
         }
     }
@@ -264,7 +264,7 @@ struct reader_t
         : ds(_ds), index(_index), rcb(cb)
     {
         for (lba_disk_extent_t *e = ds->extents_in_superblock.head();
-             e != NULL; e = ds->extents_in_superblock.next(e)) {
+             e != nullptr; e = ds->extents_in_superblock.next(e)) {
             new extent_reader_t(this, e);
         }
         if (ds->last_extent) new extent_reader_t(this, ds->last_extent);

--- a/src/serializer/log/lba/extent.cc
+++ b/src/serializer/log/lba/extent.cc
@@ -53,7 +53,7 @@ struct extent_block_t :
         }
         if (is_last_block) {
             rassert(this == parent->last_block);
-            parent->last_block = NULL;
+            parent->last_block = nullptr;
         }
         delete this;
     }
@@ -61,13 +61,13 @@ struct extent_block_t :
 
 extent_t::extent_t(extent_manager_t *_em, file_t *_file)
     : amount_filled(0), em(_em),
-      file(_file), last_block(NULL), current_block(NULL) {
+      file(_file), last_block(nullptr), current_block(nullptr) {
     extent_ref = em->gen_extent();
     ++em->stats->pm_serializer_lba_extents;
 }
 
 extent_t::extent_t(extent_manager_t *_em, file_t *_file, int64_t loc, size_t size)
-    : amount_filled(size), em(_em), file(_file), last_block(NULL), current_block(NULL)
+    : amount_filled(size), em(_em), file(_file), last_block(nullptr), current_block(nullptr)
 {
     extent_ref = em->reserve_extent(loc);
 
@@ -120,7 +120,7 @@ void extent_t::append(void *buffer, size_t length, file_account_t *io_account) {
 
         if (amount_filled % DEVICE_BLOCK_SIZE == 0) {
             extent_block_t *b = current_block;
-            current_block = NULL;
+            current_block = nullptr;
             b->write(io_account);
             em->stats->bytes_written(DEVICE_BLOCK_SIZE);
         }

--- a/src/serializer/log/lba/lba_list.cc
+++ b/src/serializer/log/lba/lba_list.cc
@@ -17,7 +17,7 @@ lba_list_t::lba_list_t(extent_manager_t *em,
 {
     for (int i = 0; i < LBA_SHARD_FACTOR; i++) {
         gc_active[i] = false;
-        disk_structures[i] = NULL;
+        disk_structures[i] = nullptr;
     }
 }
 
@@ -60,7 +60,7 @@ public:
     lba_list_t::ready_callback_t *callback;
 
     lba_start_fsm_t(lba_list_t *l, lba_list_t::metablock_mixin_t *last_metablock)
-        : owner(l), callback(NULL)
+        : owner(l), callback(nullptr)
     {
         rassert(owner->state == lba_list_t::state_unstarted);
         owner->state = lba_list_t::state_starting_up;
@@ -170,7 +170,7 @@ repli_timestamp_t lba_list_t::get_block_recency(block_id_t block) {
 
 segmented_vector_t<repli_timestamp_t> lba_list_t::get_block_recencies(block_id_t first,
                                                                       block_id_t step) {
-    guarantee(coro_t::self() != NULL);
+    guarantee(coro_t::self() != nullptr);
     rassert(state == state_ready);
     segmented_vector_t<repli_timestamp_t> ret;
     // Note that we deliberately don't report recencies for aux blocks.
@@ -270,7 +270,7 @@ public:
     lba_list_t::sync_callback_t *callback;
 
     lba_syncer_t(lba_list_t *_owner, file_account_t *io_account)
-        : owner(_owner), done(false), should_delete_self(false), callback(NULL)
+        : owner(_owner), done(false), should_delete_self(false), callback(nullptr)
     {
         structures_unsynced = LBA_SHARD_FACTOR;
         for (int i = 0; i < LBA_SHARD_FACTOR; i++) {
@@ -442,7 +442,7 @@ bool lba_list_t::we_want_to_gc(int i) {
 
     // Don't count the extent we're currently writing to. If there is no superblock, then that
     // extent is the only one, so we don't want to GC obviously.
-    if (disk_structures[i]->superblock_extent == NULL) {
+    if (disk_structures[i]->superblock_extent == nullptr) {
         return false;
     }
 
@@ -468,7 +468,7 @@ bool lba_list_t::we_want_to_gc(int i) {
 
 void lba_list_t::shutdown_gc() {
     guarantee(state == state_ready);
-    guarantee(coro_t::self() != NULL);
+    guarantee(coro_t::self() != nullptr);
 
     state = state_gc_shutting_down;
 
@@ -482,7 +482,7 @@ void lba_list_t::shutdown() {
 
     for (int i = 0; i < LBA_SHARD_FACTOR; i++) {
         disk_structures[i]->shutdown();   // Also deletes it
-        disk_structures[i] = NULL;
+        disk_structures[i] = nullptr;
     }
 
     gc_io_account.reset();
@@ -492,5 +492,5 @@ void lba_list_t::shutdown() {
 
 lba_list_t::~lba_list_t() {
     rassert(state == state_unstarted || state == state_shut_down);
-    for (int i = 0; i < LBA_SHARD_FACTOR; i++) rassert(disk_structures[i] == NULL);
+    for (int i = 0; i < LBA_SHARD_FACTOR; i++) rassert(disk_structures[i] == nullptr);
 }

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -207,7 +207,7 @@ struct ls_start_existing_fsm_t :
 
         start_existing_state = state_read_static_header;
         // STATE A above implies STATE B here
-        to_signal_when_done = NULL;
+        to_signal_when_done = nullptr;
         if (next_starting_up_step()) {
             return true;
         } else {
@@ -397,15 +397,15 @@ log_serializer_t::log_serializer_t(dynamic_config_t _dynamic_config, serializer_
       expecting_no_more_tokens(false),
 #endif
       dynamic_config(_dynamic_config),
-      shutdown_callback(NULL),
+      shutdown_callback(nullptr),
       shutdown_state(shutdown_not_started),
       state(state_unstarted),
       static_header_needs_migration(false),
-      dbfile(NULL),
-      extent_manager(NULL),
-      metablock_manager(NULL),
-      lba_index(NULL),
-      data_block_manager(NULL),
+      dbfile(nullptr),
+      extent_manager(nullptr),
+      metablock_manager(nullptr),
+      lba_index(nullptr),
+      data_block_manager(nullptr),
       active_write_count(0) {
     // STATE A
     /* This is because the serializer is not completely converted to coroutines yet. */
@@ -756,7 +756,7 @@ max_block_size_t log_serializer_t::max_block_size() const {
 
 bool log_serializer_t::coop_lock_and_check() {
     assert_thread();
-    rassert(dbfile != NULL);
+    rassert(dbfile != nullptr);
     return dbfile->coop_lock_and_check();
 }
 
@@ -878,16 +878,16 @@ void log_serializer_t::next_shutdown_step() {
         extent_manager->shutdown();
 
         delete lba_index;
-        lba_index = NULL;
+        lba_index = nullptr;
 
         delete data_block_manager;
-        data_block_manager = NULL;
+        data_block_manager = nullptr;
 
         delete metablock_manager;
-        metablock_manager = NULL;
+        metablock_manager = nullptr;
 
         delete extent_manager;
-        extent_manager = NULL;
+        extent_manager = nullptr;
 
         shutdown_state = shutdown_waiting_on_dbfile_destruction;
         coro_t::spawn_sometime(std::bind(&log_serializer_t::delete_dbfile_and_continue_shutdown,
@@ -895,7 +895,7 @@ void log_serializer_t::next_shutdown_step() {
         return;
     }
 
-    rassert(dbfile == NULL);
+    rassert(dbfile == nullptr);
 
     if (shutdown_state == shutdown_waiting_on_dbfile_destruction) {
         state = state_shut_down;
@@ -911,9 +911,9 @@ void log_serializer_t::next_shutdown_step() {
 
 void log_serializer_t::delete_dbfile_and_continue_shutdown() {
     index_writes_io_account.reset();
-    rassert(dbfile != NULL);
+    rassert(dbfile != nullptr);
     delete dbfile;
-    dbfile = NULL;
+    dbfile = nullptr;
     next_shutdown_step();
 }
 

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -69,7 +69,7 @@ template<class metablock_t>
 metablock_manager_t<metablock_t>::metablock_manager_t(extent_manager_t *em)
     : head(this), mb_buffer(METABLOCK_SIZE),
       extent_manager(em), metablock_offsets(initial_metablock_offsets(extent_manager->extent_size)),
-      state(state_unstarted), dbfile(NULL) {
+      state(state_unstarted), dbfile(nullptr) {
     rassert(sizeof(crc_metablock_t) <= METABLOCK_SIZE);
     rassert(mb_buffer.get());
     mb_buffer_in_use = false;
@@ -155,7 +155,7 @@ template<class metablock_t>
 void metablock_manager_t<metablock_t>::co_start_existing(file_t *file, bool *mb_found, metablock_t *mb_out) {
     rassert(state == state_unstarted);
     dbfile = file;
-    rassert(dbfile != NULL);
+    rassert(dbfile != nullptr);
 
     rassert(!mb_buffer_in_use);
     mb_buffer_in_use = true;
@@ -198,7 +198,7 @@ void metablock_manager_t<metablock_t>::co_start_existing(file_t *file, bool *mb_
     // about the benefits though, so leaving this alone.
 
     // We've read everything from disk. Now find the last good metablock.
-    crc_metablock_t *last_good_mb = NULL;
+    crc_metablock_t *last_good_mb = nullptr;
     for (unsigned i = 0; i < metablock_offsets.size(); i++) {
         crc_metablock_t *mb_temp = lbm.get_metablock(i);
         if (mb_temp->check_crc()) {

--- a/src/serializer/merger.cc
+++ b/src/serializer/merger.cc
@@ -39,7 +39,7 @@ counted_t<standard_block_token_t> merger_serializer_t::index_read(block_id_t blo
 void merger_serializer_t::index_write(new_mutex_in_line_t *mutex_acq,
                                       const std::function<void()> &on_writes_reflected,
                                       const std::vector<index_write_op_t> &write_ops) {
-    rassert(coro_t::self() != NULL);
+    rassert(coro_t::self() != nullptr);
     assert_thread();
 
     // Apply our set of write ops atomically

--- a/src/serializer/translator.cc
+++ b/src/serializer/translator.cc
@@ -87,7 +87,7 @@ void prep_serializer(
 void serializer_multiplexer_t::create(const std::vector<serializer_t *>& underlying, int n_proxies) {
     /* Choose a more-or-less unique ID so that we can hopefully catch the case where files are
     mixed and mismatched. */
-    creation_timestamp_t creation_timestamp = time(NULL);
+    creation_timestamp_t creation_timestamp = time(nullptr);
 
     /* Write a configuration block for each one */
     pmap(underlying.size(), boost::bind(&prep_serializer,
@@ -226,7 +226,7 @@ block_id_t translator_serializer_t::translate_block_id(block_id_t id) const {
 }
 
 translator_serializer_t::translator_serializer_t(serializer_t *_inner, int _mod_count, int _mod_id, config_block_id_t _cfgid)
-    : inner(_inner), mod_count(_mod_count), mod_id(_mod_id), cfgid(_cfgid), read_ahead_callback(NULL) {
+    : inner(_inner), mod_count(_mod_count), mod_id(_mod_id), cfgid(_cfgid), read_ahead_callback(nullptr) {
     rassert(mod_count > 0);
     rassert(mod_id >= 0);
     rassert(mod_id < mod_count);
@@ -350,10 +350,10 @@ void translator_serializer_t::offer_read_ahead_buf(
     }
 
     // Okay, we take ownership of the buf, it's ours (even if read_ahead_callback is
-    // NULL).
+    // nullptr).
     buf_ptr_t local_buf = std::move(*buf);
 
-    if (read_ahead_callback != NULL) {
+    if (read_ahead_callback != nullptr) {
         const block_id_t inner_block_id = untranslate_block_id_to_id(block_id, mod_count, mod_id, cfgid);
         read_ahead_callback->offer_read_ahead_buf(inner_block_id, &local_buf,
                                                   token);
@@ -370,7 +370,7 @@ void translator_serializer_t::register_read_ahead_cb(serializer_read_ahead_callb
 void translator_serializer_t::unregister_read_ahead_cb(DEBUG_VAR serializer_read_ahead_callback_t *cb) {
     assert_thread();
 
-    rassert(read_ahead_callback == NULL || cb == read_ahead_callback);
+    rassert(read_ahead_callback == nullptr || cb == read_ahead_callback);
     inner->unregister_read_ahead_cb(this);
-    read_ahead_callback = NULL;
+    read_ahead_callback = nullptr;
 }

--- a/src/time.cc
+++ b/src/time.cc
@@ -31,7 +31,7 @@ microtime_t current_microtime() {
 microtime_t current_microtime() {
     // This could be done more efficiently, surely.
     struct timeval t;
-    DEBUG_VAR int res = gettimeofday(&t, NULL);
+    DEBUG_VAR int res = gettimeofday(&t, nullptr);
     rassert(0 == res);
     return uint64_t(t.tv_sec) * MILLION + t.tv_usec;
 }
@@ -84,7 +84,7 @@ timespec clock_monotonic() {
 timespec clock_realtime() {
 #ifdef __MACH__
     struct timeval tv;
-    int res = gettimeofday(&tv, NULL);
+    int res = gettimeofday(&tv, nullptr);
     guarantee_err(res == 0, "gettimeofday failed");
 
     timespec ret;

--- a/src/unittest/barrier_test.cc
+++ b/src/unittest/barrier_test.cc
@@ -44,7 +44,7 @@ void *run_barrier_thread(void *v_arg) {
         arg->error |= (bav->values[indexA] == number);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -59,9 +59,9 @@ TEST(BarrierTest, OneThousandTest) {
     bav1.error = bav2.error = false;
 
     pthread_t th1, th2;
-    int res = pthread_create(&th1, NULL, run_barrier_thread, &bav1);
+    int res = pthread_create(&th1, nullptr, run_barrier_thread, &bav1);
     guarantee_xerr(res == 0, res, "pthread_create (for th1) failed");
-    res = pthread_create(&th2, NULL, run_barrier_thread, &bav2);
+    res = pthread_create(&th2, nullptr, run_barrier_thread, &bav2);
     guarantee_xerr(res == 0, res, "pthread_create (for th2) failed");
 
     void *dummy;

--- a/src/unittest/btree_sindex.cc
+++ b/src/unittest/btree_sindex.cc
@@ -143,7 +143,7 @@ TPTEST(BTreeSindex, BtreeStoreAPI) {
             "unit_test_store",
             true,
             &get_global_perfmon_collection(),
-            NULL,
+            nullptr,
             &io_backender,
             base_path_t("."),
             generate_uuid(),
@@ -265,7 +265,7 @@ TPTEST(BTreeSindex, BtreeStoreAPI) {
             point_read_response_t response;
 
             rdb_get(key, store.get_sindex_slice(sindex_uuid),
-                    sindex_super_block.get(), &response, NULL);
+                    sindex_super_block.get(), &response, nullptr);
 
             ASSERT_EQ(ql::datum_t(1.0), response.data);
         }

--- a/src/unittest/clustering_utils.cc
+++ b/src/unittest/clustering_utils.cc
@@ -6,7 +6,7 @@ peer_address_t get_cluster_local_address(connectivity_cluster_t *cm) {
     auto_drainer_t::lock_t connection_keepalive;
     connectivity_cluster_t::connection_t *loopback =
         cm->get_connection(cm->get_me(), &connection_keepalive);
-    guarantee(loopback != NULL);
+    guarantee(loopback != nullptr);
     return loopback->get_peer_address();
 }
 

--- a/src/unittest/context_switching.cc
+++ b/src/unittest/context_switching.cc
@@ -26,9 +26,9 @@ TEST(ContextSwitchingTest, CreateArtificialStack) {
 `void*` to the test functions... */
 
 static THREAD_LOCAL coro_context_ref_t
-    *original_context = NULL,
-    *artificial_stack_1_context = NULL,
-    *artificial_stack_2_context = NULL;
+    *original_context = nullptr,
+    *artificial_stack_1_context = nullptr,
+    *artificial_stack_2_context = nullptr;
 static THREAD_LOCAL int test_int;
 
 static void switch_context_test(void) {
@@ -61,7 +61,7 @@ TEST(ContextSwitchingTest, SwitchToContextRepeatedly) {
         EXPECT_FALSE(a.context.is_nil());
     }
     EXPECT_EQ(test_int, 11);
-    original_context = NULL;
+    original_context = nullptr;
 }
 
 static void first_switch(void) {
@@ -87,7 +87,7 @@ TEST(ContextSwitchingTest, SwitchBetweenContexts) {
         context_switch(original_context, artificial_stack_1_context);
     }
     EXPECT_EQ(test_int, 101);
-    original_context = NULL;
+    original_context = nullptr;
 }
 
 NORETURN static void throw_an_exception() {

--- a/src/unittest/extproc_test.cc
+++ b/src/unittest/extproc_test.cc
@@ -155,7 +155,7 @@ private:
 
 SPAWNER_TEST(ExtProc, SimpleJob) {
     extproc_pool_t pool(2);
-    fib_job_t job(10, &pool, NULL);
+    fib_job_t job(10, &pool, nullptr);
     uint64_t result = job.run();
     ASSERT_EQ(fib(10), result);
 }
@@ -164,7 +164,7 @@ SPAWNER_TEST(ExtProc, TalkativeJob) {
     extproc_pool_t pool(2);
 
     uint64_t n = 78;
-    collatz_job_t job(n, &pool, NULL); // takes 35 iterations to reach 1
+    collatz_job_t job(n, &pool, nullptr); // takes 35 iterations to reach 1
 
     do {
         n = collatz(n);
@@ -174,7 +174,7 @@ SPAWNER_TEST(ExtProc, TalkativeJob) {
 }
 
 void run_single_job(extproc_pool_t *pool, size_t *counter, cond_t *done) {
-    fib_job_t job(10, pool, NULL);
+    fib_job_t job(10, pool, nullptr);
 
     int result = job.run();
     int expected = fib(10);
@@ -219,7 +219,7 @@ class base_crash_job_t {
 public:
     base_crash_job_t(extproc_pool_t *pool,
                      bool (*worker_fn) (read_stream_t *, write_stream_t *)) :
-        extproc_job(pool, worker_fn, NULL) { }
+        extproc_job(pool, worker_fn, nullptr) { }
 
     void read() {
         int data;
@@ -305,7 +305,7 @@ SPAWNER_TEST(ExtProc, CrashedJob) {
     }
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -319,7 +319,7 @@ SPAWNER_TEST(ExtProc, CrashedJob) {
     }
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -335,7 +335,7 @@ SPAWNER_TEST(ExtProc, CrashedJob) {
     */
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -352,7 +352,7 @@ SPAWNER_TEST(ExtProc, CrashedJob) {
     */
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -383,11 +383,11 @@ SPAWNER_TEST(ExtProc, HangingJob) {
 
     // Run a job that never returns, then make sure it recovers and we can still run more jobs
     {
-        hang_job_t hanger(&pool, NULL);
+        hang_job_t hanger(&pool, nullptr);
     }
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -397,7 +397,7 @@ SPAWNER_TEST(ExtProc, HangingJob) {
 class corrupt_job_t {
 public:
     explicit corrupt_job_t(extproc_pool_t *pool) :
-        extproc_job(pool, &worker_fn, NULL) { }
+        extproc_job(pool, &worker_fn, nullptr) { }
 
     void corrupt(bool direction) {
         write_message_t wm;
@@ -445,7 +445,7 @@ SPAWNER_TEST(ExtProc, CorruptJob) {
     }
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -458,7 +458,7 @@ SPAWNER_TEST(ExtProc, CorruptJob) {
     }
 
     for (size_t i = 0; i < 10; ++i) {
-        fib_job_t job(10, &pool, NULL);
+        fib_job_t job(10, &pool, nullptr);
         uint64_t res = job.run();
         uint64_t expected = fib(10);
         ASSERT_EQ(res, expected);
@@ -486,7 +486,7 @@ SPAWNER_TEST(ExtProc, InterruptJobByPool) {
     pool.create(2);
 
     {
-        fib_job_t job(10, pool.get(), NULL);
+        fib_job_t job(10, pool.get(), nullptr);
 
         coro_t::spawn_now_dangerously(std::bind(&interrupt_job_by_pool_internal,
                                                 &pool, &done));

--- a/src/unittest/geo_indexes.cc
+++ b/src/unittest/geo_indexes.cc
@@ -205,11 +205,11 @@ std::vector<nearest_geo_read_response_t::dist_pair_t> perform_get_nearest(
 
     nearest_geo_read_response_t *geo_response =
         boost::get<nearest_geo_read_response_t>(&response.response);
-    if (geo_response == NULL) {
+    if (geo_response == nullptr) {
         ADD_FAILURE() << "got wrong type of result back";
         return std::vector<nearest_geo_read_response_t::dist_pair_t>();
     }
-    if (boost::get<ql::exc_t>(&geo_response->results_or_error) != NULL) {
+    if (boost::get<ql::exc_t>(&geo_response->results_or_error) != nullptr) {
         ADD_FAILURE() << boost::get<ql::exc_t>(&geo_response->results_or_error)->what();
         return std::vector<nearest_geo_read_response_t::dist_pair_t>();
     }
@@ -336,17 +336,17 @@ std::vector<datum_t> perform_get_intersecting(
 
     rget_read_response_t *geo_response =
         boost::get<rget_read_response_t>(&response.response);
-    if (geo_response == NULL) {
+    if (geo_response == nullptr) {
         ADD_FAILURE() << "got wrong type of result back";
         return std::vector<datum_t>();
     }
-    if (boost::get<ql::exc_t>(&geo_response->result) != NULL) {
+    if (boost::get<ql::exc_t>(&geo_response->result) != nullptr) {
         ADD_FAILURE() << boost::get<ql::exc_t>(&geo_response->result)->what();
         return std::vector<datum_t>();
     }
 
     auto result = boost::get<ql::grouped_t<ql::stream_t> >(&geo_response->result);
-    if (result == NULL) {
+    if (result == nullptr) {
         ADD_FAILURE() << "got wrong type of result back";
         return std::vector<datum_t>();
     }

--- a/src/unittest/internal_node_test.cc
+++ b/src/unittest/internal_node_test.cc
@@ -33,12 +33,12 @@ void verify(block_size_t block_size, const internal_node_t *buf) {
     }
     ASSERT_EQ(block_size.value(), expected);
 
-    const btree_key_t *last_key = NULL;
+    const btree_key_t *last_key = nullptr;
     for (const uint16_t *p = buf->pair_offsets, *e = p + buf->npairs - 1; p < e; ++p) {
         const btree_internal_pair *pair = internal_node::get_pair(buf, *p);
         const btree_key_t *next_key = &pair->key;
 
-        if (last_key != NULL) {
+        if (last_key != nullptr) {
             EXPECT_LT(internal_key_comp::compare(last_key, next_key), 0);
         }
 

--- a/src/unittest/jsproc.cc
+++ b/src/unittest/jsproc.cc
@@ -13,7 +13,7 @@ SPAWNER_TEST(JSProc, EvalTimeout) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string loop_source = "for (var x = 0; x < 4e10; x++) {}";
 
@@ -31,7 +31,7 @@ SPAWNER_TEST(JSProc, CallTimeout) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string loop_source = "(function () { for (var x = 0; x < 4e10; x++) {}})";
 
@@ -41,7 +41,7 @@ SPAWNER_TEST(JSProc, CallTimeout) {
     js_result_t result = js_runner.eval(loop_source, config);
 
     js_id_t *any_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(any_id != NULL);
+    ASSERT_TRUE(any_id != nullptr);
 
     config.timeout_ms = 10;
 
@@ -56,7 +56,7 @@ void run_datum_test(const std::string &source_code, ql::datum_t *res_out) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     js_runner_t::req_config_t config;
     config.timeout_ms = 10000;
@@ -65,7 +65,7 @@ void run_datum_test(const std::string &source_code, ql::datum_t *res_out) {
 
     ql::datum_t *res_datum =
         boost::get<ql::datum_t>(&result);
-    ASSERT_TRUE(res_datum != NULL);
+    ASSERT_TRUE(res_datum != nullptr);
     *res_out = *res_datum;
 }
 
@@ -90,7 +90,7 @@ SPAWNER_TEST(JSProc, EvalAndCall) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string source_code = "(function () { return 10337; })";
 
@@ -101,7 +101,7 @@ SPAWNER_TEST(JSProc, EvalAndCall) {
 
     // Get the id of the function out
     js_id_t *js_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(js_id != NULL);
+    ASSERT_TRUE(js_id != nullptr);
 
     // Call the function
     result = js_runner.call(source_code,
@@ -111,7 +111,7 @@ SPAWNER_TEST(JSProc, EvalAndCall) {
 
     // Check results
     ql::datum_t *res_datum = boost::get<ql::datum_t>(&result);
-    ASSERT_TRUE(res_datum != NULL);
+    ASSERT_TRUE(res_datum != nullptr);
     ASSERT_TRUE(res_datum->has());
     ASSERT_TRUE(res_datum->get_type() == ql::datum_t::R_NUM);
     ASSERT_EQ(res_datum->as_int(), 10337);
@@ -122,7 +122,7 @@ SPAWNER_TEST(JSProc, BrokenFunction) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string source_code = "(function () { return 4 / 0; })";
 
@@ -133,7 +133,7 @@ SPAWNER_TEST(JSProc, BrokenFunction) {
 
     // Get the id of the function out
     js_id_t *js_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(js_id != NULL);
+    ASSERT_TRUE(js_id != nullptr);
 
     // Call the function
     result = js_runner.call(source_code,
@@ -143,7 +143,7 @@ SPAWNER_TEST(JSProc, BrokenFunction) {
 
     // Get the error message
     std::string *error = boost::get<std::string>(&result);
-    ASSERT_TRUE(error != NULL);
+    ASSERT_TRUE(error != nullptr);
 }
 
 SPAWNER_TEST(JSProc, InvalidFunction) {
@@ -151,7 +151,7 @@ SPAWNER_TEST(JSProc, InvalidFunction) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string source_code = "(function() {)";
 
@@ -162,7 +162,7 @@ SPAWNER_TEST(JSProc, InvalidFunction) {
 
     // Get the error message
     std::string *error = boost::get<std::string>(&result);
-    ASSERT_TRUE(error != NULL);
+    ASSERT_TRUE(error != nullptr);
 }
 
 SPAWNER_TEST(JSProc, InfiniteRecursionFunction) {
@@ -170,7 +170,7 @@ SPAWNER_TEST(JSProc, InfiniteRecursionFunction) {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string source_code = "(function f(x) { x = x + f(x); return x; })";
 
@@ -181,7 +181,7 @@ SPAWNER_TEST(JSProc, InfiniteRecursionFunction) {
 
     // Get the id of the function out
     js_id_t *js_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(js_id != NULL);
+    ASSERT_TRUE(js_id != nullptr);
 
     // Call the function
     std::vector<ql::datum_t> args;
@@ -198,7 +198,7 @@ void run_overalloc_function_test() {
     js_runner_t js_runner;
     ql::configured_limits_t limits;
 
-    js_runner.begin(&extproc_pool, NULL, limits);
+    js_runner.begin(&extproc_pool, nullptr, limits);
 
     const std::string source_code = "(function f() {"
                                      "  var res = \"\";"
@@ -215,7 +215,7 @@ void run_overalloc_function_test() {
 
     // Get the id of the function out
     js_id_t *js_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(js_id != NULL);
+    ASSERT_TRUE(js_id != nullptr);
 
     // Call the function
     ASSERT_THROW(js_runner.call(source_code,
@@ -237,7 +237,7 @@ void passthrough_test_internal(extproc_pool_t *pool, const ql::datum_t &arg) {
 
     ql::configured_limits_t limits;
     js_runner_t js_runner;
-    js_runner.begin(pool, NULL, limits);
+    js_runner.begin(pool, nullptr, limits);
 
     const std::string source_code = "(function f(arg) { return arg; })";
 
@@ -248,7 +248,7 @@ void passthrough_test_internal(extproc_pool_t *pool, const ql::datum_t &arg) {
 
     // Get the id of the function out
     js_id_t *js_id = boost::get<js_id_t>(&result);
-    ASSERT_TRUE(js_id != NULL);
+    ASSERT_TRUE(js_id != nullptr);
 
     // Call the function
     js_result_t res = js_runner.call(source_code,
@@ -256,7 +256,7 @@ void passthrough_test_internal(extproc_pool_t *pool, const ql::datum_t &arg) {
                                      config);
 
     ql::datum_t *res_datum = boost::get<ql::datum_t>(&res);
-    ASSERT_TRUE(res_datum != NULL);
+    ASSERT_TRUE(res_datum != nullptr);
     ASSERT_TRUE(res_datum->has());
     ASSERT_EQ(*res_datum, arg);
 }

--- a/src/unittest/leaf_node_test.cc
+++ b/src/unittest/leaf_node_test.cc
@@ -126,7 +126,7 @@ public:
 
         store_key_t replacement;
         bool can_level = leaf::level(&sizer_, nodecmp_value, node(), sibling->node(),
-                                     replacement.btree_key(), NULL);
+                                     replacement.btree_key(), nullptr);
 
         if (can_level) {
             ASSERT_TRUE(!sibling->kv_.empty());

--- a/src/unittest/mock_file.cc
+++ b/src/unittest/mock_file.cc
@@ -12,7 +12,7 @@ namespace unittest {
 
 mock_file_t::mock_file_t(mode_t mode, std::vector<char> *data) : mode_(mode), data_(data) {
     guarantee(mode != 0);
-    guarantee(data_ != NULL);
+    guarantee(data_ != nullptr);
 }
 mock_file_t::~mock_file_t() { }
 

--- a/src/unittest/mock_store.cc
+++ b/src/unittest/mock_store.cc
@@ -26,7 +26,7 @@ read_t mock_read(std::string key) {
 std::string mock_parse_read_response(const read_response_t &rr) {
     const point_read_response_t *prr
         = boost::get<point_read_response_t>(&rr.response);
-    guarantee(prr != NULL);
+    guarantee(prr != nullptr);
     guarantee(prr->data.has());
     if (prr->data.get_type() == ql::datum_t::R_NULL) {
         // Behave like the old dummy_protocol_t.

--- a/src/unittest/page_test.cc
+++ b/src/unittest/page_test.cc
@@ -117,7 +117,7 @@ public:
 test_txn_t::test_txn_t(test_cache_t *cache)
     : page_txn_t(cache,
                  cache->make_throttler_acq(),
-                 NULL) { }
+                 nullptr) { }
 
 
 TPTEST(PageTest, Control, 4) {
@@ -211,7 +211,7 @@ TPTEST(PageTest, OneWriteAcqWait, 4) {
         page_acq.init(page, &page_cache);
         ASSERT_TRUE(page_acq.buf_ready_signal()->is_pulsed());
         void *buf = page_acq.get_buf_write();
-        ASSERT_TRUE(buf != NULL);
+        ASSERT_TRUE(buf != nullptr);
     }
     page_cache.flush(std::move(txn));
 }
@@ -367,7 +367,7 @@ public:
             condZ5.wait();
             t678cond.pulse();
         }
-        c = NULL;
+        c = nullptr;
 
         {
             dummy_cache_balancer_t balancer(memory_limit);
@@ -379,7 +379,7 @@ public:
             coro_t::spawn_later_ordered(std::bind(&bigger_test_t::run_txn15,
                                                   this, drain.lock()));
         }
-        c = NULL;
+        c = nullptr;
 
         {
             dummy_cache_balancer_t balancer(memory_limit);
@@ -407,7 +407,7 @@ public:
 
             cache.flush(std::move(txn));
         }
-        c = NULL;
+        c = nullptr;
     }
 
 private:
@@ -433,14 +433,14 @@ private:
 
             condCR1.pulse();
             condC.wait();
-            txn1_ptr = NULL;
+            txn1_ptr = nullptr;
         }
         c->flush(std::move(txn1));
     }
 
     void run_txn2(auto_drainer_t::lock_t) {
         condA.wait();
-        ASSERT_TRUE(txn1_ptr != NULL);
+        ASSERT_TRUE(txn1_ptr != nullptr);
         auto txn2 = make_scoped<test_txn_t>(c);
         {
             txn2_ptr = txn2.get();
@@ -500,7 +500,7 @@ private:
 
             condCR2.pulse();
 
-            txn2_ptr = NULL;
+            txn2_ptr = nullptr;
         }
         c->flush(std::move(txn2));
     }

--- a/src/unittest/rdb_backfill.cc
+++ b/src/unittest/rdb_backfill.cc
@@ -219,7 +219,7 @@ void run_backfill_test(const backfill_test_config_t &cfg) {
     simple_mailbox_cluster_t cluster;
     io_backender_t io_backender(file_direct_io_mode_t::buffered_desired);
     extproc_pool_t extproc_pool(2);
-    rdb_context_t ctx(&extproc_pool, NULL);
+    rdb_context_t ctx(&extproc_pool, nullptr);
     cond_t non_interruptor;
 
     in_memory_branch_history_manager_t bhm;

--- a/src/unittest/rdb_btree.cc
+++ b/src/unittest/rdb_btree.cc
@@ -66,9 +66,9 @@ void insert_rows(int start, int finish, store_t *store) {
                             &mod_report,
                             txn.get(),
                             &deletion_context,
-                            NULL,
-                            NULL,
-                            NULL);
+                            nullptr,
+                            nullptr,
+                            nullptr);
 
         new_mutex_in_line_t acq = store->get_in_line_for_sindex_queue(&sindex_block);
         store->sindex_queue_push(mod_report, &acq);
@@ -165,7 +165,7 @@ ql::grouped_t<ql::stream_t> read_row_via_sindex(
 
     ql::grouped_t<ql::stream_t> *groups =
         boost::get<ql::grouped_t<ql::stream_t> >(&res.result);
-    guarantee(groups != NULL);
+    guarantee(groups != nullptr);
     return *groups;
 }
 
@@ -178,7 +178,7 @@ void _check_keys_are_present(store_t *store,
         ASSERT_EQ(1, groups.size());
         // The order of `groups` doesn't matter because this is a small unit test.
         ql::stream_t *stream = &groups.begin()->second;
-        ASSERT_TRUE(stream != NULL);
+        ASSERT_TRUE(stream != nullptr);
         ASSERT_EQ(1ul, stream->substreams.size());
         ql::raw_stream_t *raw_stream = &stream->substreams.begin()->second.stream;
         ASSERT_EQ(1ul, raw_stream->size());
@@ -258,7 +258,7 @@ TPTEST(RDBBtree, SindexPostConstruct) {
             "unit_test_store",
             true,
             &get_global_perfmon_collection(),
-            NULL,
+            nullptr,
             &io_backender,
             base_path_t("."),
             generate_uuid(),
@@ -301,7 +301,7 @@ TPTEST(RDBBtree, SindexEraseRange) {
             "unit_test_store",
             true,
             &get_global_perfmon_collection(),
-            NULL,
+            nullptr,
             &io_backender,
             base_path_t("."),
             generate_uuid(),
@@ -382,7 +382,7 @@ TPTEST(RDBBtree, SindexInterruptionViaDrop) {
             "unit_test_store",
             true,
             &get_global_perfmon_collection(),
-            NULL,
+            nullptr,
             &io_backender,
             base_path_t("."),
             generate_uuid(),
@@ -425,7 +425,7 @@ TPTEST(RDBBtree, SindexInterruptionViaStoreDelete) {
             "unit_test_store",
             true,
             &get_global_perfmon_collection(),
-            NULL,
+            nullptr,
             &io_backender,
             base_path_t("."),
             generate_uuid(),

--- a/src/unittest/rdb_env.cc
+++ b/src/unittest/rdb_env.cc
@@ -457,7 +457,7 @@ bool test_rdb_env_t::instance_t::table_find(const name_string_t &name,
         namespace_interface_access_t table_access(
             it->second.get(), &fake_ref_tracker, get_thread_id());
         table_out->reset(new real_table_t(nil_uuid(), table_access,
-                                          it->second->get_primary_key(), NULL));
+                                          it->second->get_primary_key(), nullptr));
         return true;
     }
 }

--- a/src/unittest/rdb_protocol.cc
+++ b/src/unittest/rdb_protocol.cc
@@ -74,7 +74,7 @@ void run_with_namespace_interface(
     }
 
     extproc_pool_t extproc_pool(2);
-    rdb_context_t ctx(&extproc_pool, NULL);
+    rdb_context_t ctx(&extproc_pool, nullptr);
 
     for (int rep = 0; rep < num_restarts; ++rep) {
         const bool do_create = rep == 0;
@@ -297,11 +297,11 @@ void run_create_drop_sindex_test(
         if (rget_read_response_t *rget_resp = boost::get<rget_read_response_t>(&response.response)) {
             auto streams = boost::get<ql::grouped_t<ql::stream_t> >(
                 &rget_resp->result);
-            ASSERT_TRUE(streams != NULL);
+            ASSERT_TRUE(streams != nullptr);
             ASSERT_EQ(1, streams->size());
             // Order doesn't matter because streams->size() is 1.
             auto stream = &streams->begin()->second;
-            ASSERT_TRUE(stream != NULL);
+            ASSERT_TRUE(stream != nullptr);
             ASSERT_EQ(1u, stream->substreams.size());
             ASSERT_EQ(ql::to_datum(data, limits, reql_version_t::LATEST),
                       stream->substreams.begin()->second.stream.at(0).data);
@@ -338,7 +338,7 @@ void run_create_drop_sindex_test(
         if (rget_read_response_t *rget_resp = boost::get<rget_read_response_t>(&response.response)) {
             auto streams = boost::get<ql::grouped_t<ql::stream_t> >(
                 &rget_resp->result);
-            ASSERT_TRUE(streams != NULL);
+            ASSERT_TRUE(streams != nullptr);
             ASSERT_EQ(0, streams->size());
         } else {
             ADD_FAILURE() << "got wrong type of result back";
@@ -562,11 +562,11 @@ void read_sindex(namespace_interface_t *nsi,
     if (rget_read_response_t *rget_resp = boost::get<rget_read_response_t>(&response.response)) {
         auto streams = boost::get<ql::grouped_t<ql::stream_t> >(
             &rget_resp->result);
-        ASSERT_TRUE(streams != NULL);
+        ASSERT_TRUE(streams != nullptr);
         ASSERT_EQ(1, streams->size());
         // Order doesn't matter because streams->size() is 1.
         ql::stream_t *stream = &streams->begin()->second;
-        ASSERT_TRUE(stream != NULL);
+        ASSERT_TRUE(stream != nullptr);
         ASSERT_EQ(1ul, stream->substreams.size());
         ASSERT_EQ(expected_size, stream->substreams.begin()->second.stream.size());
     } else {
@@ -761,11 +761,11 @@ void run_sindex_oversized_keys_test(
                     = boost::get<rget_read_response_t>(&response.response)) {
                     auto streams = boost::get<ql::grouped_t<ql::stream_t> >(
                         &rget_resp->result);
-                    ASSERT_TRUE(streams != NULL);
+                    ASSERT_TRUE(streams != nullptr);
                     ASSERT_EQ(1, streams->size());
                     // Order doesn't matter because streams->size() is 1.
                     auto stream = &streams->begin()->second;
-                    ASSERT_TRUE(stream != NULL);
+                    ASSERT_TRUE(stream != nullptr);
                     // There should be results equal to the number of iterations
                     // performed
                     ASSERT_EQ(1ul, stream->substreams.size());

--- a/src/unittest/rpc_connectivity.cc
+++ b/src/unittest/rpc_connectivity.cc
@@ -176,7 +176,7 @@ TPTEST_MULTITHREAD(RPCConnectivityTest, UnreachablePeer, 3) {
     auto_drainer_t::lock_t connection_keepalive;
     connectivity_cluster_t::connection_t *conn =
         c1.get_connection(c2.get_me(), &connection_keepalive);
-    EXPECT_TRUE(conn == NULL);
+    EXPECT_TRUE(conn == nullptr);
 
     a1.send(888, c2.get_me());
 
@@ -222,7 +222,7 @@ TPTEST_MULTITHREAD(RPCConnectivityTest, LostPeer, 3) {
         let_stuff_happen();
 
         connection = c1.get_connection(c2.get_me(), &connection_keepalive);
-        ASSERT_TRUE(connection != NULL);
+        ASSERT_TRUE(connection != nullptr);
         EXPECT_FALSE(connection_keepalive.get_drain_signal()->is_pulsed());
         EXPECT_TRUE(connection->get_peer_id() == c2.get_me());
 
@@ -473,7 +473,7 @@ public:
         auto_drainer_t::lock_t connection_keepalive;
         connectivity_cluster_t::connection_t *connection =
             get_connectivity_cluster()->get_connection(peer, &connection_keepalive);
-        ASSERT_TRUE(connection != NULL);
+        ASSERT_TRUE(connection != nullptr);
         get_connectivity_cluster()->send_message(connection, connection_keepalive,
                                                  get_message_tag(), &writer);
     }
@@ -829,7 +829,7 @@ TPTEST(RPCConnectivityTest, CanonicalAddress) {
         auto_drainer_t::lock_t connection_keepalive;
         connectivity_cluster_t::connection_t *connection =
             c1.get_connection(c2.get_me(), &connection_keepalive);
-        ASSERT_TRUE(connection != NULL);
+        ASSERT_TRUE(connection != nullptr);
         c2_addr_from_c1 = connection->get_peer_address();
     }
     peer_address_t c3_addr_from_c1;
@@ -837,7 +837,7 @@ TPTEST(RPCConnectivityTest, CanonicalAddress) {
         auto_drainer_t::lock_t connection_keepalive;
         connectivity_cluster_t::connection_t *connection =
             c1.get_connection(c3.get_me(), &connection_keepalive);
-        ASSERT_TRUE(connection != NULL);
+        ASSERT_TRUE(connection != nullptr);
         c3_addr_from_c1 = connection->get_peer_address();
     }
 

--- a/src/unittest/unittest_utils.cc
+++ b/src/unittest/unittest_utils.cc
@@ -108,7 +108,7 @@ temp_directory_t::temp_directory_t() {
     char tmpl[] = "rdb_unittest.";
     char path[MAX_PATH + 1 + sizeof(tmpl) + 6 + 1];
     DWORD res = GetTempPath(sizeof(path), path);
-    guarantee_winerr(res != NULL && res < MAX_PATH + 1, "GetTempPath failed");
+    guarantee_winerr(res != nullptr && res < MAX_PATH + 1, "GetTempPath failed");
     strcpy(path + res, tmpl); // NOLINT
     char *end = path + strlen(path);
     int tries = 0;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -242,20 +242,20 @@ bool parse_time(const std::string &str, local_or_utc_time_t zone,
 }
 
 with_priority_t::with_priority_t(int priority) {
-    rassert(coro_t::self() != NULL);
+    rassert(coro_t::self() != nullptr);
     previous_priority = coro_t::self()->get_priority();
     coro_t::self()->set_priority(priority);
 }
 with_priority_t::~with_priority_t() {
-    rassert(coro_t::self() != NULL);
+    rassert(coro_t::self() != nullptr);
     coro_t::self()->set_priority(previous_priority);
 }
 
 void *raw_malloc_aligned(size_t size, size_t alignment) {
-    void *ptr = NULL;
+    void *ptr = nullptr;
 #ifdef _WIN32
     ptr = _aligned_malloc(size, alignment);
-    if (ptr == NULL) {
+    if (ptr == nullptr) {
         crash_oom();
     }
 #else
@@ -289,7 +289,7 @@ void raw_free_aligned(void *ptr) {
 
 void *rmalloc(size_t size) {
     void *res = malloc(size);  // NOLINT(runtime/rethinkdb_fn)
-    if (res == NULL && size != 0) {
+    if (res == nullptr && size != 0) {
         crash_oom();
     }
     return res;
@@ -297,7 +297,7 @@ void *rmalloc(size_t size) {
 
 void *rrealloc(void *ptr, size_t size) {
     void *res = realloc(ptr, size);  // NOLINT(runtime/rethinkdb_fn)
-    if (res == NULL && size != 0) {
+    if (res == nullptr && size != 0) {
         crash_oom();
     }
     return res;
@@ -362,7 +362,7 @@ TLS_ptr_with_constructor(rng_t, rng)
 void system_random_bytes(void *out, int64_t nbytes) {
 #ifdef _WIN32
     HCRYPTPROV hProv;
-    BOOL res = CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT);
+    BOOL res = CryptAcquireContext(&hProv, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT);
     guarantee_winerr(res, "CryptAcquireContext failed");
     res = CryptGenRandom(hProv, nbytes, static_cast<BYTE*>(out));
     DWORD err = GetLastError();
@@ -505,7 +505,7 @@ char int_to_hex(int x) {
 
 bool blocking_read_file(const char *path, std::string *contents_out) {
 #ifdef _WIN32
-    HANDLE hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL);
+    HANDLE hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_ALWAYS, 0, nullptr);
     if (hFile == INVALID_HANDLE_VALUE) return false;
     LARGE_INTEGER fileSize;
     BOOL res = GetFileSizeEx(hFile, &fileSize);
@@ -519,7 +519,7 @@ bool blocking_read_file(const char *path, std::string *contents_out) {
     size_t index = 0;
     while (remaining > 0) {
         DWORD consumed;
-        res = ReadFile(hFile, &ret[index], remaining, &consumed, NULL);
+        res = ReadFile(hFile, &ret[index], remaining, &consumed, nullptr);
         if (!res) {
             CloseHandle(hFile);
             return false;
@@ -657,7 +657,7 @@ base_path_t::base_path_t(const std::string &path) : path_(path) { }
 void base_path_t::make_absolute() {
 #ifdef _WIN32
     char absolute_path[MAX_PATH];
-    DWORD size = GetFullPathName(path_.c_str(), sizeof(absolute_path), absolute_path, NULL);
+    DWORD size = GetFullPathName(path_.c_str(), sizeof(absolute_path), absolute_path, nullptr);
     guarantee_winerr(size != 0, "GetFullPathName failed");
     if (size < sizeof(absolute_path)) {
       path_.assign(absolute_path);
@@ -665,14 +665,14 @@ void base_path_t::make_absolute() {
     }
     std::string long_absolute_path;
     long_absolute_path.resize(size);
-    DWORD new_size = GetFullPathName(path_.c_str(), size, &long_absolute_path[0], NULL);
+    DWORD new_size = GetFullPathName(path_.c_str(), size, &long_absolute_path[0], nullptr);
     guarantee_winerr(size != 0, "GetFullPathName failed");
     guarantee(new_size < size, "GetFullPathName: name too long");
     path_ = std::move(long_absolute_path);
 #else
     char absolute_path[PATH_MAX];
     char *res = realpath(path_.c_str(), absolute_path);
-    guarantee_err(res != NULL, "Failed to determine absolute path for '%s'", path_.c_str());
+    guarantee_err(res != nullptr, "Failed to determine absolute path for '%s'", path_.c_str());
     path_.assign(absolute_path);
 #endif
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -41,7 +41,7 @@ public:
 struct const_charslice {
     const char *beg, *end;
     const_charslice(const char *_beg, const char *_end) : beg(_beg), end(_end) { }
-    const_charslice() : beg(NULL), end(NULL) { }
+    const_charslice() : beg(nullptr), end(nullptr) { }
 };
 
 void *raw_malloc_aligned(size_t size, size_t alignment);


### PR DESCRIPTION
Done by running: `run-clang-tidy.py src -checks=-*,modernize-use-nullptr
-fix`