### PR TITLE
Add missing return keyword in TermBase constructor

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -57,7 +57,7 @@ class TermBase
             self.__proto__ = @.__proto__
             return self
         else
-            @
+            return @
 
     run: (connection, options, callback) ->
         # Valid syntaxes are


### PR DESCRIPTION
See https://github.com/rethinkdb/rethinkdb/issues/162 and https://github.com/rethinkdb/rethinkdb/pull/5067 for context.