### PR TITLE
rethinkdb-dump: Add --quiet and dumping to stdout

### DIFF
--- a/drivers/python/rethinkdb/_dump.py
+++ b/drivers/python/rethinkdb/_dump.py
@@ -121,10 +121,9 @@ def do_export(temp_dir, options):
         export_args.extend(["--debug"])
 
     if options["quiet"]:
-        with open(os.devnull, 'w') as devnull:
-            res = subprocess.call(export_args, stdout=devnull)
-    else:
-        res = subprocess.call(export_args)
+        export_args.extend(["--quiet"])
+
+    res = subprocess.call(export_args)
 
     if res != 0:
         raise RuntimeError("Error: rethinkdb-export failed")

--- a/drivers/python/rethinkdb/_restore.py
+++ b/drivers/python/rethinkdb/_restore.py
@@ -216,12 +216,10 @@ def do_import(temp_dir, options):
         import_args.extend(["--debug"])
     if not options["create_sindexes"]:
         import_args.extend(["--no-secondary-indexes"])
-
     if options["quiet"]:
-        with open(os.devnull, 'w') as devnull:
-            res = subprocess.call(import_args, stdout=devnull)
-    else:
-        res = subprocess.call(import_args)
+        import_args.extend(["--quiet"])
+
+    res = subprocess.call(import_args)
 
     if res == 2:
         raise RuntimeError("Warning: rethinkdb-import did not create some secondary indexes.")


### PR DESCRIPTION
This adds two features to `rethinkdb-dump`:

* A `--quiet` flag
* Writing the output archive to stdout

The second feature quite obviously depends on the first one, since we can't print messages and a tar archive to stdout at the same time.

The wording of the help option was inspired by `man tee`.

Example commands you can test:

* `rethinkdb-dump` - should work as before
* `rethinkdb-dump` - should work as before but print no output
* `rethinkdb-dump --file=out.tar.gz` - should work as before
* `rethinkdb-dump --file=-` - should print lots of rubbish into your terminal
* `rethinkdb-dump --file=- | tar tz` should print you the files in the tar file