### PR TITLE
a trivial improve: limit unnecessary debug log string creation

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Response.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Response.java
@@ -32,7 +32,8 @@ class Response {
     static final Logger logger = LoggerFactory.getLogger(Query.class);
 
     public static Response parseFrom(long token, ByteBuffer buf) {
-        Response.logger.debug("JSON Recv: Token: {} {}", token, Util.bufferToString(buf));
+        if (Response.logger.isDebugEnabled())
+            Response.logger.debug("JSON Recv: Token: {} {}", token, Util.bufferToString(buf));
         InputStreamReader codepointReader =
             new InputStreamReader(new ByteArrayInputStream(buf.array()));
         JSONObject jsonResp = (JSONObject) JSONValue.parse(codepointReader);


### PR DESCRIPTION
`rethinkdb/drivers/java/src/main/java/com/rethinkdb/net/Response.java` output debug log server response, it unconditionally convert ByteBuffer to String, even if debug log is disabled.

```
    public static Response parseFrom(long token, ByteBuffer buf) {
          Response.logger.debug("JSON Recv: Token: {} {}", token, Util.bufferToString(buf));
```

So add a check is better.
```
        if (Response.logger.isDebugEnabled())
          Response.logger.debug("JSON Recv: Token: {} {}", token, Util.bufferToString(buf));
```
