### PR TITLE
feat(auto_reconnect): allow runtime configuration of give_up_ms

### DIFF
--- a/src/clustering/administration/main/serve.cc
+++ b/src/clustering/administration/main/serve.cc
@@ -243,7 +243,8 @@ bool do_serve(io_backender_t *io_backender,
             &connectivity_cluster,
             connectivity_cluster_run.get(),
             &server_config_client,
-            serve_info.join_delay_secs);
+            serve_info.join_delay_secs,
+            serve_info.node_reconnect_timeout);
 
         /* `initial_joiner` sets up the initial connections to the peers that were
         specified with the `--join` flag on the command line. */

--- a/src/clustering/administration/main/serve.hpp
+++ b/src/clustering/administration/main/serve.hpp
@@ -120,6 +120,7 @@ public:
                  boost::optional<std::string> _config_file,
                  std::vector<std::string> &&_argv,
                  const int _join_delay_secs,
+                 const int _node_reconnect_timeout,
                  tls_configs_t _tls_configs) :
         joins(std::move(_joins)),
         reql_http_proxy(std::move(_reql_http_proxy)),
@@ -128,7 +129,8 @@ public:
         ports(_ports),
         config_file(_config_file),
         argv(std::move(_argv)),
-        join_delay_secs(_join_delay_secs)
+        join_delay_secs(_join_delay_secs),
+        node_reconnect_timeout(_node_reconnect_timeout)
     {
         tls_configs = _tls_configs;
     }
@@ -148,6 +150,7 @@ public:
     argument parsing has already been completed at this point. */
     std::vector<std::string> argv;
     int join_delay_secs;
+    int node_reconnect_timeout;
     tls_configs_t tls_configs;
 };
 

--- a/src/clustering/administration/servers/auto_reconnect.cc
+++ b/src/clustering/administration/servers/auto_reconnect.cc
@@ -13,11 +13,13 @@ auto_reconnector_t::auto_reconnector_t(
         connectivity_cluster_t *connectivity_cluster_,
         connectivity_cluster_t::run_t *connectivity_cluster_run_,
         server_config_client_t *server_config_client_,
-        const int join_delay_secs_) :
+        const int join_delay_secs_,
+        const int give_up_ms_) :
     connectivity_cluster(connectivity_cluster_),
     connectivity_cluster_run(connectivity_cluster_run_),
     server_config_client(server_config_client_),
     join_delay_secs(join_delay_secs_),
+    give_up_ms(give_up_ms_),
     server_id_subs(
         server_config_client->get_peer_to_server_map(),
         std::bind(&auto_reconnector_t::on_connect_or_disconnect, this, ph::_1),
@@ -60,7 +62,6 @@ void auto_reconnector_t::try_reconnect(const server_id_t &server,
     guarantee(it != addresses.end());
     last_known_address = it->second;
 
-    static const int give_up_ms = 24 * 60 * 60 * 1000;
     signal_timer_t give_up_timer;
     give_up_timer.start(give_up_ms);
 

--- a/src/clustering/administration/servers/auto_reconnect.hpp
+++ b/src/clustering/administration/servers/auto_reconnect.hpp
@@ -22,7 +22,8 @@ public:
         connectivity_cluster_t *connectivity_cluster,
         connectivity_cluster_t::run_t *connectivity_cluster_run,
         server_config_client_t *server_config_client,
-        const int join_delay_secs);
+        const int join_delay_secs,
+        const int give_up_ms);
 
 private:
     void on_connect_or_disconnect(const peer_id_t &peer_id);
@@ -48,6 +49,7 @@ private:
     std::multimap<server_id_t, cond_t *> stop_conds;
 
     int join_delay_secs;
+    int give_up_ms;
 
     auto_drainer_t drainer;
 


### PR DESCRIPTION
Currently the auto_reconnect instance used to reconnect lost nodes is hardcoded to give up reconnecting after 24 hours. This is not ideal in some scenarios where a user may want to remove a node from a cluster, without having to reset all other participating nodes in the cluster. This patch allows the user to change that value.
