### PR TITLE
Java: smart type conversion

### DIFF
--- a/drivers/java/build.gradle
+++ b/drivers/java/build.gradle
@@ -51,6 +51,7 @@ signing {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'net.jodah:concurrentunit:0.4.2'
+    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.6.5'
     testRuntime 'ch.qos.logback:logback-classic:1.1.3'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/drivers/java/src/main/java/com/rethinkdb/annotations/IgnoreNullFields.java
+++ b/drivers/java/src/main/java/com/rethinkdb/annotations/IgnoreNullFields.java
@@ -1,0 +1,15 @@
+package com.rethinkdb.annotations;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+/**
+ * When save this data to rethink db, skip null properties.
+ * To recursively skip null properties of children properties,
+ * specify this annotation to the children property's classes.
+ */
+public @interface IgnoreNullFields {
+}

--- a/drivers/java/src/main/java/com/rethinkdb/annotations/IgnoreNullFields.java
+++ b/drivers/java/src/main/java/com/rethinkdb/annotations/IgnoreNullFields.java
@@ -7,7 +7,7 @@ import java.lang.annotation.*;
 @Documented
 @Inherited
 /**
- * When save this data to rethink db, skip null properties.
+ * When saving this data to rethink db, skip null properties.
  * To recursively skip null properties of children properties,
  * specify this annotation to the children property's classes.
  */

--- a/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
@@ -5,9 +5,15 @@ import com.rethinkdb.gen.exc.ReqlDriverError;
 import com.rethinkdb.gen.exc.ReqlRuntimeError;
 import com.rethinkdb.gen.proto.ResponseType;
 
-import java.util.*;
-import java.util.concurrent.ExecutionException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 
@@ -93,12 +99,17 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
         }
     }
 
-    protected void waitOnCursorItems(){
+    protected void waitOnCursorItems(Optional<Long> timeout) throws TimeoutException {
         Response res = null;
         try {
-            res = this.awatingContinue.get();
-        }
-        catch(Exception e){
+            if(timeout.isPresent()){
+                res = this.awatingContinue.get(timeout.get(), TimeUnit.MILLISECONDS);
+            } else {
+                res = this.awatingContinue.get();
+            }
+        }catch(TimeoutException exc){
+            throw exc;
+        }catch(Exception e){
             throw new ReqlDriverError(e);
         }
         this.extend(res);
@@ -162,20 +173,24 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
         /* This isn't great, but the Java iterator protocol relies on hasNext,
          so it must be implemented in a reasonable way */
         public boolean hasNext(){
-            if(items.size() > 0){
-                return true;
-            }
-            if(error.isPresent()){
-                return false;
-            }
-            if(_isFeed){
-                return true;
-            }
+            try {
+                if(items.size() > 0){
+                    return true;
+                }
+                if(error.isPresent()){
+                    return false;
+                }
+                if(_isFeed){
+                    return true;
+                }
 
-            maybeSendContinue();
-            waitOnCursorItems();
+                maybeSendContinue();
+                waitOnCursorItems(Optional.empty());
 
-            return items.size() > 0;
+                return items.size() > 0;
+            }catch(TimeoutException toe) {
+                throw new RuntimeException("Timeout can't happen here");
+            }
         }
 
         @SuppressWarnings("unchecked")
@@ -183,7 +198,7 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
 
             while( items.size() == 0){
                 maybeSendContinue();
-                waitOnCursorItems();
+                waitOnCursorItems(timeout);
 
                 if( items.size() != 0){
                     break;

--- a/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
@@ -33,7 +33,7 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
     protected int threshold = 1;
     protected Optional<RuntimeException> error = Optional.empty();
 
-    protected Future<Response> awatingContinue = null;
+    protected Future<Response> awaitingContinue = null;
 
     public Cursor(Connection connection, Query query, Response firstResponse) {
         this.connection = connection;
@@ -95,7 +95,7 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
                 && items.size() < threshold
                 && outstandingRequests == 0 ) {
             outstandingRequests += 1;
-            this.awatingContinue = connection.continue_(this);
+            this.awaitingContinue = connection.continue_(this);
         }
     }
 
@@ -103,9 +103,9 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T> {
         Response res = null;
         try {
             if(timeout.isPresent()){
-                res = this.awatingContinue.get(timeout.get(), TimeUnit.MILLISECONDS);
+                res = this.awaitingContinue.get(timeout.get(), TimeUnit.MILLISECONDS);
             } else {
-                res = this.awatingContinue.get();
+                res = this.awaitingContinue.get();
             }
         }catch(TimeoutException exc){
             throw exc;

--- a/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
+++ b/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
@@ -1,5 +1,7 @@
 package com.rethinkdb;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rethinkdb.annotations.IgnoreNullFields;
 import com.rethinkdb.gen.exc.ReqlError;
 import com.rethinkdb.gen.exc.ReqlQueryLogicError;
 import com.rethinkdb.model.MapObject;
@@ -10,15 +12,20 @@ import net.jodah.concurrentunit.Waiter;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.rethinkdb.TestingCommon.smartDeepEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RethinkDBTest{
 
@@ -48,7 +55,6 @@ public class RethinkDBTest{
     public static void oneTimeTearDown() throws Exception {
         Connection conn = TestingFramework.createConnection();
         try {
-            r.db(dbName).tableDrop(tableName).run(conn);
             r.dbDrop(dbName).run(conn);
         } catch(ReqlError e){}
         conn.close();
@@ -210,7 +216,16 @@ public class RethinkDBTest{
         try {
             r.dbCreate("test").run(conn);
         } catch (Exception e) {}
+        try{
+            r.db("test").tableDrop(tblName).run(conn);
+        } catch (Exception e) {}
 
+        try {
+            r.dbDrop("optargs").run(conn);
+        } catch (Exception e) {}
+        try {
+            r.dbDrop("conn_default").run(conn);
+        } catch (Exception e) {}
         r.expr(r.array("optargs", "conn_default")).forEach(r::dbCreate).run(conn);
         r.expr(r.array("test", "optargs", "conn_default")).forEach(dbName ->
                         r.db(dbName).tableCreate(tblName).do_((unused) ->
@@ -311,6 +326,336 @@ public class RethinkDBTest{
         assertEquals(false, pojoTwoSelected.getPojoProperty().getBooleanProperty());
     }
 
+    @Test
+    public void testTableSelectOfPojoCursor_ManyTypeMappings() {
+        TestPojo pojoOne = new TestPojo("foo", new TestPojoInner(42L, true));
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(pojoOne).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+
+        Cursor<TestPojo> cursor = r.db(dbName).table(tableName).run(conn, TestPojo.class);
+        List<TestPojo> result = cursor.toList();
+
+        TestPojo pojoOneSelected = result.get(0);
+
+        compareMostPropertiesOfPojo(pojoOneSelected, pojoOne);
+
+        assertTrue( smartDeepEquals(pojoOneSelected.getPojoListProperty(), pojoOne.getPojoListProperty()));
+    }
+
+    @Test
+    public void testTableSelectOfPojoCursor_ConvertStringToOtherTypes() {
+        TestPojo pojoOne = new TestPojo("foo", new TestPojoInner(42L, true));
+        //pojoOne.getEnumProperty().toString() lowercase output.
+        //pojoOne.getEnumProperty().Name() will output uppercase,
+        //uppercase is more easy to be converted back because auto-generated Enum use such convention.
+        //By default, when storing enum to db, we store the .Name()
+        MapObject map = r.hashMap("stringProperty",pojoOne.getStringProperty().toString())
+                .with("enumProperty", pojoOne.getEnumProperty().toString())
+                .with("enumInnerLowerCaseProperty", pojoOne.getEnumInnerLowerCaseProperty().toString()) //store "xxx"
+                .with("enumInnerUpperCaseProperty", pojoOne.getEnumInnerUpperCaseProperty().toString()) //store "XXX"
+                .with("offsetDateTimeProperty", pojoOne.getOffsetDateTimeProperty().toString())
+                .with("localDateTimeProperty", pojoOne.getLocalDateTimeProperty().toString())
+                .with("zonedDateTimeProperty", pojoOne.getZonedDateTimeProperty().toString())
+                .with("localDateProperty", pojoOne.getLocalDateProperty().toString())
+                .with("localTimeProperty", pojoOne.getLocalTimeProperty().toString())
+                .with("dateProperty", pojoOne.getDateProperty().toString())
+                .with("doubleProperty", pojoOne.getDoubleProperty().toString())
+                .with("primitiveDoubleProperty", String.valueOf(pojoOne.getPrimitiveDoubleProperty()))
+                .with("floatProperty", pojoOne.getFloatProperty().toString())
+                .with("primitiveFloatProperty", String.valueOf(pojoOne.getPrimitiveFloatProperty()))
+                .with("integerProperty", pojoOne.getIntegerProperty().toString())
+                .with("primitiveIntegerProperty", String.valueOf(pojoOne.getPrimitiveIntegerProperty()))
+                .with("longProperty", pojoOne.getLongProperty().toString())
+                .with("primitiveLongProperty", String.valueOf(pojoOne.getPrimitiveLongProperty()))
+                .with("shortProperty", pojoOne.getShortProperty().toString())
+                .with("primitiveShortProperty", String.valueOf(pojoOne.getPrimitiveShortProperty()))
+                .with("byteProperty", pojoOne.getByteProperty().toString())
+                .with("primitiveByteProperty", String.valueOf(pojoOne.getPrimitiveByteProperty()))
+                .with("booleanProperty", pojoOne.getBooleanProperty().toString())
+                .with("primitiveBooleanProperty", String.valueOf(pojoOne.getPrimitiveBooleanProperty()))
+                .with("bigDecimalProperty", pojoOne.getBigDecimalProperty().toString())
+                .with("bigIntegerProperty", pojoOne.getBigIntegerProperty().toString())
+                ;
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(map).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+
+        Cursor<TestPojo> cursor = r.db(dbName).table(tableName).run(conn, TestPojo.class);
+        List<TestPojo> result = cursor.toList();
+        assertEquals(1, result.size());
+
+        TestPojo pojoOneSelected = result.get(0);
+
+        compareMostPropertiesOfPojo(pojoOneSelected, pojoOne);
+    }
+
+    @Test
+    public void testSaveBeanAsMapThenSelectAsBean() {
+        TestPojo pojoOne = new TestPojo("foo", new TestPojoInner(42L, true));
+        ObjectMapper m = new ObjectMapper();
+
+        Map<String, Object> map = m.convertValue(pojoOne, Map.class);
+
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(map).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+
+        Cursor<TestPojo> cursor = r.db(dbName).table(tableName).run(conn, TestPojo.class);
+        List<TestPojo> result = cursor.toList();
+        assertEquals(1, result.size());
+
+        TestPojo pojoOneSelected = result.get(0);
+
+        compareMostPropertiesOfPojo(pojoOneSelected, pojoOne);
+
+        assertTrue( smartDeepEquals(pojoOneSelected.getPojoListProperty(), pojoOne.getPojoListProperty()));
+    }
+
+    private void compareMostPropertiesOfPojo(TestPojo pojoOneSelected, TestPojo pojoOne) {
+        assertEquals(pojoOneSelected.getEnumProperty(), pojoOne.getEnumProperty());
+        assertEquals(pojoOneSelected.getEnumInnerLowerCaseProperty(), pojoOne.getEnumInnerLowerCaseProperty());
+        assertEquals(pojoOneSelected.getEnumInnerUpperCaseProperty(), pojoOne.getEnumInnerUpperCaseProperty());
+
+        assertEquals(pojoOneSelected.getOffsetDateTimeProperty(), pojoOne.getOffsetDateTimeProperty());
+        assertEquals(pojoOneSelected.getLocalDateTimeProperty(), pojoOne.getLocalDateTimeProperty());
+        assertEquals(pojoOneSelected.getLocalDateProperty(), pojoOne.getLocalDateProperty());
+        assertEquals(pojoOneSelected.getLocalTimeProperty(), pojoOne.getLocalTimeProperty());
+        assertEquals(pojoOneSelected.getZonedDateTimeProperty().toInstant(), pojoOne.getZonedDateTimeProperty().toInstant());
+        assertEquals(pojoOneSelected.getDateProperty().toString(), pojoOne.getDateProperty().toString());
+
+        assertEquals(pojoOneSelected.getDoubleProperty(), pojoOne.getDoubleProperty());
+        assertTrue(pojoOneSelected.getPrimitiveDoubleProperty() == pojoOne.getPrimitiveDoubleProperty());
+        assertEquals(pojoOneSelected.getFloatProperty(), pojoOne.getFloatProperty());
+        assertTrue(pojoOneSelected.getPrimitiveFloatProperty() == pojoOne.getPrimitiveFloatProperty());
+        assertEquals(pojoOneSelected.getIntegerProperty(), pojoOne.getIntegerProperty());
+        assertTrue(pojoOneSelected.getPrimitiveIntegerProperty() == pojoOne.getPrimitiveIntegerProperty());
+        assertEquals(pojoOneSelected.getLongProperty(), pojoOne.getLongProperty());
+        assertTrue(pojoOneSelected.getPrimitiveLongProperty() == pojoOne.getPrimitiveLongProperty());
+        assertEquals(pojoOneSelected.getShortProperty(), pojoOne.getShortProperty());
+        assertTrue(pojoOneSelected.getPrimitiveShortProperty() == pojoOne.getPrimitiveShortProperty());
+        assertEquals(pojoOneSelected.getByteProperty(), pojoOne.getByteProperty());
+        assertTrue(pojoOneSelected.getPrimitiveByteProperty() == pojoOne.getPrimitiveByteProperty());
+        assertEquals(pojoOneSelected.getBooleanProperty(), pojoOne.getBooleanProperty());
+        assertTrue(pojoOneSelected.getPrimitiveBooleanProperty() == pojoOne.getPrimitiveBooleanProperty());
+
+        int scale = pojoOneSelected.getBigDecimalProperty().scale();
+        java.math.BigDecimal sampleBigDecimal = pojoOne.getBigDecimalProperty().setScale(scale, java.math.BigDecimal.ROUND_HALF_UP);
+        assertEquals(pojoOneSelected.getBigDecimalProperty(), sampleBigDecimal);
+
+        assertEquals(pojoOneSelected.getBigIntegerProperty(), pojoOne.getBigIntegerProperty());
+    }
+
+    @Test
+    public void testDeepCompare() {
+        assertEquals(false, smartDeepEquals("hihihih", "xx"));
+        assertEquals(true, smartDeepEquals("hihihih", "hihihih"));
+        assertEquals(true, smartDeepEquals(Long.valueOf(123456789), 123456789L));
+
+        TestPojo pojo1 = new TestPojo("s1", null);
+        TestPojo pojo2 = new TestPojo("s1", null);
+
+        assertEquals(false, pojo1.equals(pojo2));
+        assertEquals(true, smartDeepEquals(pojo1, pojo2));
+
+        pojo1 = new TestPojo("s1", new TestPojoInner(11L, true));
+        pojo2 = new TestPojo("s1", new TestPojoInner(11L, true));
+
+        assertEquals(false, pojo1.equals(pojo2));
+        assertEquals(true, smartDeepEquals(pojo1, pojo2));
+
+        pojo1.getPojoListProperty().set(0, new TestPojoInner(99L, true));
+        assertEquals(false, smartDeepEquals(pojo1.getPojoListProperty(), pojo2.getPojoListProperty()));
+        assertEquals(false, smartDeepEquals(pojo1, pojo2));
+
+        List<TestPojo> list1 = Arrays.asList(new TestPojo("s1", new TestPojoInner(11L, true)), new TestPojo("s2", new TestPojoInner(22L, true)));
+        List<TestPojo> list2 = Arrays.asList(new TestPojo("s1", new TestPojoInner(11L, true)), new TestPojo("s2", new TestPojoInner(22L, true)));
+
+        ArrayList list3 = new ArrayList();
+        ArrayList<TestPojo> list4 = new ArrayList<>();
+        list3.add(new TestPojo("s1", new TestPojoInner(11L, true)));
+        list4.add(new TestPojo("s1", new TestPojoInner(11L, true)));
+        list3.add(new TestPojo("s2", new TestPojoInner(22L, true)));
+        list4.add(new TestPojo("s2", new TestPojoInner(22L, true)));
+
+        assertEquals(false, list1.equals(list2));
+        assertEquals(true, smartDeepEquals(list1, list2));
+
+        assertEquals(false, list1.equals(list3));
+        assertEquals(true, smartDeepEquals(list1, list3));
+
+        assertEquals(false, list1.equals(list4));
+        assertEquals(true, smartDeepEquals(list1, list4));
+
+        assertEquals(false, list3.equals(list4));
+        assertEquals(true, smartDeepEquals(list3, list4));
+
+        TestPojo[] ary1 = new TestPojo[]{new TestPojo("s1", new TestPojoInner(11L, true)), new TestPojo("s2", new TestPojoInner(22L, true))};
+        TestPojo[] ary2 = new TestPojo[]{new TestPojo("s1", new TestPojoInner(11L, true)), new TestPojo("s2", new TestPojoInner(22L, true))};
+        Object[] ary3 = new Object[]{new TestPojo("s1", new TestPojoInner(11L, true)), new TestPojo("s2", new TestPojoInner(22L, true))};
+
+        assertEquals(false, ary1.equals(ary2));
+        assertEquals(true, smartDeepEquals(ary1, ary2));
+
+        assertEquals(false, ary1.equals(ary3));
+        assertEquals(true, smartDeepEquals(ary1, ary3));
+    }
+
+    @IgnoreNullFields
+    public static class TestPojoIgnoreNull {
+        private Object notNullProperty;
+        private Object nullProperty;
+
+        public TestPojoIgnoreNull() {
+        }
+
+        public TestPojoIgnoreNull(Object notNullProperty, Object nullProperty) {
+            this.notNullProperty = notNullProperty;
+            this.nullProperty = nullProperty;
+        }
+
+        public Object getNotNullProperty() {
+            return notNullProperty;
+        }
+
+        public void setNotNullProperty(Object notNullProperty) {
+            this.notNullProperty = notNullProperty;
+        }
+
+        public Object getNullProperty() {
+            return nullProperty;
+        }
+
+        public void setNullProperty(Object nullProperty) {
+            this.nullProperty = nullProperty;
+        }
+    }
+
+    @Test
+    public void testSaveObjectIgnoreNullProperties() {
+        TestPojoIgnoreNull pojoOne = new TestPojoIgnoreNull("foo", null);
+
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(pojoOne).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+
+        Cursor cursor = r.db(dbName).table(tableName).run(conn);
+        List result = cursor.toList();
+        assertEquals(1, result.size());
+
+        Object _pojoOneSelected = result.get(0);
+        assertTrue(_pojoOneSelected instanceof Map);
+
+        Map<String, Object> pojoOneSelected = (Map<String, Object>)_pojoOneSelected;
+
+        assertTrue(!pojoOneSelected.containsKey("nullProperty"));
+        assertEquals(pojoOneSelected.get("notNullProperty"), pojoOne.getNotNullProperty());
+    }
+
+    @Test
+    public void testSaveObjectIgnoreNullPropertiesNested() {
+        TestPojoIgnoreNull pojoOne = new TestPojoIgnoreNull("foo", null);
+        TestPojoIgnoreNull pojoOneInner = new TestPojoIgnoreNull("foo inner", null);
+        pojoOne.setNotNullProperty(pojoOneInner);
+
+        Map<String, Object> pojoOneResult = r.db(dbName).table(tableName).insert(pojoOne).run(conn);
+        assertEquals(1L, pojoOneResult.get("inserted"));
+
+        Cursor cursor = r.db(dbName).table(tableName).run(conn);
+        List result = cursor.toList();
+        assertEquals(1, result.size());
+
+        Object _pojoOneSelected = result.get(0);
+        assertTrue(_pojoOneSelected instanceof Map);
+
+        Map<String, Object> pojoOneSelected = (Map<String, Object>)_pojoOneSelected;
+
+        assertTrue(!pojoOneSelected.containsKey("nullProperty"));
+
+        Object _pojoOneInnerSelected = pojoOneSelected.get("notNullProperty");
+        assertTrue(_pojoOneInnerSelected instanceof Map);
+
+        Map<String, Object> pojoOneInnerSelected = (Map<String, Object>)_pojoOneInnerSelected;
+
+        assertTrue(!pojoOneInnerSelected.containsKey("nullProperty"));
+        assertEquals(pojoOneInnerSelected.get("notNullProperty"), pojoOneInner.getNotNullProperty());
+    }
+
+    @Test
+    public void testTableSelect_convertStringToDate() {
+        Locale.setDefault(Locale.JAPAN);
+        _convertStringToDate("2016-03-16", new String[]{
+                "Wed Mar 16 00:00:00 JST 2016"
+                ,"2016-03-16T00:00+09:00"
+                ,"2016-03-16T00:00"
+                ,"2016-03-16"
+                ,"2016-03-16T00:00+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("2016-03-16T22:43:05", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05+09:00"
+                ,"2016-03-16T22:43:05"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("2016-03-16T22:43:05.002", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05.002+09:00"
+                ,"2016-03-16T22:43:05.002"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05.002+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("2016-03-16T22:43:05+09:00", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05+09:00"
+                ,"2016-03-16T22:43:05"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("2016-03-16T22:43:05.002+09:00", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05.002+09:00"
+                ,"2016-03-16T22:43:05.002"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05.002+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("2016-03-16T22:43:05.002+09:00[Asia/Tokyo]", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05.002+09:00"
+                ,"2016-03-16T22:43:05.002"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05.002+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate(1458135785002L, new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05.002+09:00"
+                ,"2016-03-16T22:43:05.002"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05.002+09:00[Asia/Tokyo]"
+        });
+        _convertStringToDate("Wed Mar 16 22:43:05 JST 2016", new String[]{
+                "Wed Mar 16 22:43:05 JST 2016"
+                ,"2016-03-16T22:43:05+09:00"
+                ,"2016-03-16T22:43:05"
+                ,"2016-03-16"
+                ,"2016-03-16T22:43:05+09:00[Asia/Tokyo]"
+        });
+    }
+
+    void _convertStringToDate(Object value, String[] expects) {
+        r.db(dbName).table(tableName).delete().run(conn);
+        r.db(dbName).table(tableName).insert(r.hashMap()
+                .with("dateProperty", value)
+                .with("offsetDateTimeProperty", value)
+                .with("localDateTimeProperty", value)
+                .with("localDateProperty", value)
+                .with("zonedDateTimeProperty", value)
+        ).run(conn);
+        TestPojo pojoSelected = ((Cursor<TestPojo>)r.db(dbName).table(tableName).run(conn, TestPojo.class)).next();
+
+        assertEquals(expects[0], pojoSelected.getDateProperty().toString());
+        assertEquals(expects[1], pojoSelected.getOffsetDateTimeProperty().toString());
+        assertEquals(expects[2], pojoSelected.getLocalDateTimeProperty().toString());
+        assertEquals(expects[3], pojoSelected.getLocalDateProperty().toString());
+        assertEquals(expects[4], pojoSelected.getZonedDateTimeProperty().toString());
+    }
+
     @Test(expected = ClassCastException.class)
     public void testTableSelectOfPojoCursor_withNoPojoClass_throwsException() {
         TestPojo pojoOne = new TestPojo("foo", new TestPojoInner(42L, true));
@@ -340,7 +685,7 @@ public class RethinkDBTest{
                 waiter.resume();
             }).start();
 
-        waiter.await(2500, total);
+        waiter.await(5000, total);
 
         assertEquals(total, writeCounter.get());
     }
@@ -393,6 +738,17 @@ public class RethinkDBTest{
 
         final Cursor<TestPojo> all = r.db(dbName).table(tableName).run(conn);
         assertEquals(total, all.toList().size());
+    }
+
+    @Test
+    public void testQueryTimeout() {
+        Cursor c = r.db(dbName).table(tableName).changes().run(conn);
+        try {
+            c.next(10*1000);
+            fail();
+        } catch (TimeoutException e) {
+            e = e;
+        }
     }
 }
 

--- a/drivers/java/src/test/java/com/rethinkdb/TestPojo.java
+++ b/drivers/java/src/test/java/com/rethinkdb/TestPojo.java
@@ -1,17 +1,115 @@
 package com.rethinkdb;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
 /**
  * Has both public parameterless constructor and public parametrized constructor
  */
 public class TestPojo {
+
+    public enum PojoEnum {
+        AAA("aaa"),
+        xxx("xxx"),
+        XXX("XXX"),
+        ;
+
+        private String value;
+
+        PojoEnum(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     private String stringProperty;
     private TestPojoInner pojoProperty;
+    private PojoEnum enumProperty;
+    private PojoEnum enumInnerLowerCaseProperty;
+    private PojoEnum enumInnerUpperCaseProperty;
+    private OffsetDateTime offsetDateTimeProperty;
+    private LocalDateTime localDateTimeProperty;
+    private ZonedDateTime zonedDateTimeProperty;
+    private LocalDate localDateProperty;
+    private LocalTime localTimeProperty;
+    private Date dateProperty;
+    private Double doubleProperty;
+    private double primitiveDoubleProperty;
+    private Float floatProperty;
+    private float primitiveFloatProperty;
+    private Integer integerProperty;
+    private int primitiveIntegerProperty;
+    private Long longProperty;
+    private long primitiveLongProperty;
+    private Short shortProperty;
+    private short primitiveShortProperty;
+    private Byte byteProperty;
+    private byte primitiveByteProperty;
+    private Boolean booleanProperty;
+    private boolean primitiveBooleanProperty;
+    private BigDecimal bigDecimalProperty;
+    private BigInteger bigIntegerProperty;
+
+    private List<TestPojoInner> pojoListProperty;
+
+    private TestPojoInner[] pojoArrayProperty;
+
+    private int[] primitiveIntegerArrayProperty;
+
+    private static final OffsetDateTime sample_offsetDateTimeProperty = OffsetDateTime.now();
+    private static final LocalDateTime sample_localDateTimeProperty = LocalDateTime.now();
+    private static final ZonedDateTime sample_zonedDateTimeProperty = ZonedDateTime.now();
+    private static final LocalDate sample_localDateProperty = LocalDate.now();
+    private static final LocalTime sample_localTimeProperty = LocalTime.now();
+    private static final Date sample_dateProperty = new Date();
 
     public TestPojo() {}
 
     public TestPojo(String stringProperty, TestPojoInner pojoProperty) {
         this.stringProperty = stringProperty;
         this.pojoProperty = pojoProperty;
+
+        enumProperty = PojoEnum.AAA;
+        enumInnerLowerCaseProperty = PojoEnum.xxx;
+        enumInnerUpperCaseProperty = PojoEnum.XXX;
+        offsetDateTimeProperty = sample_offsetDateTimeProperty;
+        localDateTimeProperty = sample_localDateTimeProperty;
+        zonedDateTimeProperty = sample_zonedDateTimeProperty;
+        localDateProperty = sample_localDateProperty;
+        localTimeProperty = sample_localTimeProperty;
+        dateProperty = sample_dateProperty;
+        doubleProperty = Double.MAX_VALUE;
+        primitiveDoubleProperty = Double.MAX_VALUE;
+        floatProperty = Float.MAX_VALUE;
+        primitiveFloatProperty = Float.MAX_VALUE;
+        integerProperty = Integer.MAX_VALUE;
+        primitiveIntegerProperty = Integer.MAX_VALUE;
+        longProperty = Long.MAX_VALUE;
+        primitiveLongProperty = Long.MAX_VALUE;
+        shortProperty = Short.MAX_VALUE;
+        primitiveShortProperty = Short.MAX_VALUE;
+        byteProperty = Byte.MAX_VALUE;
+        primitiveByteProperty = Byte.MAX_VALUE;
+        booleanProperty = true;
+        primitiveBooleanProperty = true;
+        bigDecimalProperty = new BigDecimal("123456789012345678901234567");
+        bigIntegerProperty = new BigInteger("123456789012345");
+
+        pojoListProperty = Arrays.asList(new TestPojoInner(111L, true), new TestPojoInner(222L, false));
+        pojoArrayProperty = new TestPojoInner[] {new TestPojoInner(111L, true), new TestPojoInner(222L, false)};
+//        primitiveIntegerArrayProperty = new int[] {991, 992};
     }
 
     public String getStringProperty() { return this.stringProperty; }
@@ -19,4 +117,229 @@ public class TestPojo {
 
     public void setStringProperty(String stringProperty) { this.stringProperty = stringProperty; }
     public void setPojoProperty(TestPojoInner pojoProperty) { this.pojoProperty = pojoProperty; }
+
+    public PojoEnum getEnumProperty() {
+        return enumProperty;
+    }
+
+    public void setEnumProperty(PojoEnum enumProperty) {
+        this.enumProperty = enumProperty;
+    }
+
+    public PojoEnum getEnumInnerLowerCaseProperty() {
+        return enumInnerLowerCaseProperty;
+    }
+
+    public void setEnumInnerLowerCaseProperty(PojoEnum enumInnerLowerCaseProperty) {
+        this.enumInnerLowerCaseProperty = enumInnerLowerCaseProperty;
+    }
+
+    public PojoEnum getEnumInnerUpperCaseProperty() {
+        return enumInnerUpperCaseProperty;
+    }
+
+    public void setEnumInnerUpperCaseProperty(PojoEnum enumInnerUpperCaseProperty) {
+        this.enumInnerUpperCaseProperty = enumInnerUpperCaseProperty;
+    }
+
+    public OffsetDateTime getOffsetDateTimeProperty() {
+        return offsetDateTimeProperty;
+    }
+
+    public void setOffsetDateTimeProperty(OffsetDateTime offsetDateTimeProperty) {
+        this.offsetDateTimeProperty = offsetDateTimeProperty;
+    }
+
+    public LocalDateTime getLocalDateTimeProperty() {
+        return localDateTimeProperty;
+    }
+
+    public void setLocalDateTimeProperty(LocalDateTime localDateTimeProperty) {
+        this.localDateTimeProperty = localDateTimeProperty;
+    }
+
+    public ZonedDateTime getZonedDateTimeProperty() {
+        return zonedDateTimeProperty;
+    }
+
+    public void setZonedDateTimeProperty(ZonedDateTime zonedDateTimeProperty) {
+        this.zonedDateTimeProperty = zonedDateTimeProperty;
+    }
+
+    public LocalDate getLocalDateProperty() {
+        return localDateProperty;
+    }
+
+    public void setLocalDateProperty(LocalDate localDateProperty) {
+        this.localDateProperty = localDateProperty;
+    }
+
+    public LocalTime getLocalTimeProperty() {
+        return localTimeProperty;
+    }
+
+    public void setLocalTimeProperty(LocalTime localTimeProperty) {
+        this.localTimeProperty = localTimeProperty;
+    }
+
+    public Date getDateProperty() {
+        return dateProperty;
+    }
+
+    public void setDateProperty(Date dateProperty) {
+        this.dateProperty = dateProperty;
+    }
+
+    public Double getDoubleProperty() {
+        return doubleProperty;
+    }
+
+    public void setDoubleProperty(Double doubleProperty) {
+        this.doubleProperty = doubleProperty;
+    }
+
+    public double getPrimitiveDoubleProperty() {
+        return primitiveDoubleProperty;
+    }
+
+    public void setPrimitiveDoubleProperty(double primitiveDoubleProperty) {
+        this.primitiveDoubleProperty = primitiveDoubleProperty;
+    }
+
+    public Float getFloatProperty() {
+        return floatProperty;
+    }
+
+    public void setFloatProperty(Float floatProperty) {
+        this.floatProperty = floatProperty;
+    }
+
+    public float getPrimitiveFloatProperty() {
+        return primitiveFloatProperty;
+    }
+
+    public void setPrimitiveFloatProperty(float primitiveFloatProperty) {
+        this.primitiveFloatProperty = primitiveFloatProperty;
+    }
+
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    public int getPrimitiveIntegerProperty() {
+        return primitiveIntegerProperty;
+    }
+
+    public void setPrimitiveIntegerProperty(int primitiveIntegerProperty) {
+        this.primitiveIntegerProperty = primitiveIntegerProperty;
+    }
+
+    public Long getLongProperty() {
+        return longProperty;
+    }
+
+    public void setLongProperty(Long longProperty) {
+        this.longProperty = longProperty;
+    }
+
+    public long getPrimitiveLongProperty() {
+        return primitiveLongProperty;
+    }
+
+    public void setPrimitiveLongProperty(long primitiveLongProperty) {
+        this.primitiveLongProperty = primitiveLongProperty;
+    }
+
+    public Short getShortProperty() {
+        return shortProperty;
+    }
+
+    public void setShortProperty(Short shortProperty) {
+        this.shortProperty = shortProperty;
+    }
+
+    public short getPrimitiveShortProperty() {
+        return primitiveShortProperty;
+    }
+
+    public void setPrimitiveShortProperty(short primitiveShortProperty) {
+        this.primitiveShortProperty = primitiveShortProperty;
+    }
+
+    public Byte getByteProperty() {
+        return byteProperty;
+    }
+
+    public void setByteProperty(Byte byteProperty) {
+        this.byteProperty = byteProperty;
+    }
+
+    public byte getPrimitiveByteProperty() {
+        return primitiveByteProperty;
+    }
+
+    public void setPrimitiveByteProperty(byte primitiveByteProperty) {
+        this.primitiveByteProperty = primitiveByteProperty;
+    }
+
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    public boolean getPrimitiveBooleanProperty() {
+        return primitiveBooleanProperty;
+    }
+
+    public void setPrimitiveBooleanProperty(boolean primitiveBooleanProperty) {
+        this.primitiveBooleanProperty = primitiveBooleanProperty;
+    }
+
+    public BigDecimal getBigDecimalProperty() {
+        return bigDecimalProperty;
+    }
+
+    public void setBigDecimalProperty(BigDecimal bigDecimalProperty) {
+        this.bigDecimalProperty = bigDecimalProperty;
+    }
+
+    public BigInteger getBigIntegerProperty() {
+        return bigIntegerProperty;
+    }
+
+    public void setBigIntegerProperty(BigInteger bigIntegerProperty) {
+        this.bigIntegerProperty = bigIntegerProperty;
+    }
+
+
+    public List<TestPojoInner> getPojoListProperty() {
+        return pojoListProperty;
+    }
+
+    public void setPojoListProperty(List<TestPojoInner> pojoListProperty) {
+        this.pojoListProperty = pojoListProperty;
+    }
+
+    public TestPojoInner[] getPojoArrayProperty() {
+        return pojoArrayProperty;
+    }
+
+    public void setPojoArrayProperty(TestPojoInner[] pojoArrayProperty) {
+        this.pojoArrayProperty = pojoArrayProperty;
+    }
+
+    public int[] getPrimitiveIntegerArrayProperty() {
+        return primitiveIntegerArrayProperty;
+    }
+
+    public void setPrimitiveIntegerArrayProperty(int[] primitiveIntegerArrayProperty) {
+        this.primitiveIntegerArrayProperty = primitiveIntegerArrayProperty;
+    }
 }

--- a/drivers/java/src/test/java/com/rethinkdb/TestPojoInner.java
+++ b/drivers/java/src/test/java/com/rethinkdb/TestPojoInner.java
@@ -1,11 +1,44 @@
 package com.rethinkdb;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+
 /**
  * Has only public parametrized constructor and no public parameterless constructor
  */
 public class TestPojoInner {
+    public static class TestPojoInnerInner {
+        private String stringProperty;
+
+        public TestPojoInnerInner() {
+        }
+
+        public TestPojoInnerInner(String stringProperty) {
+            this.stringProperty = stringProperty;
+        }
+
+        public String getStringProperty() {
+            return stringProperty;
+        }
+
+        public void setStringProperty(String stringProperty) {
+            this.stringProperty = stringProperty;
+        }
+    }
+
     private Long longProperty;
     private Boolean booleanProperty;
+
+    public ArrayList<TestPojoInnerInner> getInnerInnerPojoArrayListProperty() {
+        return innerInnerPojoArrayListProperty;
+    }
+
+    public void setInnerInnerPojoArrayListProperty(ArrayList<TestPojoInnerInner> innerInnerPojoArrayListProperty) {
+        this.innerInnerPojoArrayListProperty = innerInnerPojoArrayListProperty;
+    }
+
+    private ArrayList<TestPojoInnerInner> innerInnerPojoArrayListProperty;
 
     public TestPojoInner() {
     }
@@ -13,6 +46,9 @@ public class TestPojoInner {
     public TestPojoInner(Long longProperty, Boolean booleanProperty) {
         this.longProperty = longProperty;
         this.booleanProperty = booleanProperty;
+        this.innerInnerPojoArrayListProperty = new ArrayList<>();
+        this.innerInnerPojoArrayListProperty.add(new TestPojoInnerInner("innerInner111" + ";" + longProperty + ";" + booleanProperty));
+        this.innerInnerPojoArrayListProperty.add(new TestPojoInnerInner("innerInner112" + ";" + longProperty + ";" + booleanProperty));
     }
 
     public Long getLongProperty() { return this.longProperty; }

--- a/src/build.mk
+++ b/src/build.mk
@@ -122,7 +122,7 @@ else ifeq ($(COMPILER), GCC)
   ifeq ($(LEGACY_GCC), 1)
     RT_CXXFLAGS += -Wformat=2 -Wswitch-enum -Wswitch-default
   else
-    RT_CXXFLAGS += -Wformat=2 -Wswitch-enum -Wswitch-default -Wno-array-bounds
+    RT_CXXFLAGS += -Wformat=2 -Wswitch-enum -Wswitch-default -Wno-array-bounds -Wno-maybe-uninitialized
   endif
 endif
 

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -3963,11 +3963,17 @@ counted_t<datum_stream_t> artificial_t::subscribe(
     // threads, make sure that the `subscription_t` and `stream_t` are allocated
     // on the thread you want to use them on.
     guarantee(feed.has());
-    r_sanity_check(ss.squash == datum_t::boolean(false));
-    scoped_ptr_t<subscription_t> sub = new_sub(env, feed.get(), ss);
+    const streamspec_t *unsquashed_ss = &ss;
+    scoped_ptr_t<streamspec_t> dup;
+    if (ss.squash != datum_t::boolean(false)) {
+        dup = make_scoped<streamspec_t>(ss);
+        dup->squash = datum_t::boolean(false);
+        unsquashed_ss = &*dup;
+    }
+    scoped_ptr_t<subscription_t> sub = new_sub(env, feed.get(), *unsquashed_ss);
     return sub->to_artificial_stream(
         uuid, primary_key_name, initial_values,
-        ss.maybe_src.has(), std::move(sub), bt);
+        unsquashed_ss->maybe_src.has(), std::move(sub), bt);
 }
 
 void artificial_t::send_all(const msg_t &msg) {

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -1064,12 +1064,11 @@ void connectivity_cluster_t::run_t::handle(
 
     try {
         other_peer_addr.create(other_peer_addr_hosts);
-    } catch (host_lookup_exc_t) {
+    } catch (const host_lookup_exc_t &) {
         printf_buffer_t hostnames;
-        for (auto it = other_peer_addr_hosts.begin();
-             it != other_peer_addr_hosts.end(); ++it) {
-            hostnames.appendf("%s%s", it != other_peer_addr_hosts.begin() ? ", " : "",
-                              it->host().c_str());
+        for (auto const &host_and_port : other_peer_addr_hosts) {
+            hostnames.appendf("%s%s", hostnames.size() > 0 ? ", " : "",
+                              host_and_port.host().c_str());
         }
         logERR("Connected to peer with unresolvable hostname%s: %s, closing "
                "connection.  Consider using the '--canonical-address' launch option.",
@@ -1206,14 +1205,29 @@ void connectivity_cluster_t::run_t::handle(
     if (!drainer_lock.get_drain_signal()->is_pulsed()) {
         for (auto it = other_routing_table.begin(); it != other_routing_table.end(); ++it) {
             if (routing_table.find(it->first) == routing_table.end()) {
-                // `it->first` is the ID of a peer that our peer is connected
-                //  to, but we aren't connected to.
-                coro_t::spawn_now_dangerously(std::bind(
-                    &connectivity_cluster_t::run_t::join_blocking, this,
-                    peer_address_t(it->second), // This is where we resolve the peer's ip addresses
-                    boost::optional<peer_id_t>(it->first),
-                    join_delay_secs,
-                    drainer_lock));
+                try {
+                    // This is where we resolve the peer's ip addresses
+                    peer_address_t other_peer_addr(it->second);
+
+                    // `it->first` is the ID of a peer that our peer is connected
+                    //  to, but we aren't connected to.
+                    coro_t::spawn_now_dangerously(std::bind(
+                        &connectivity_cluster_t::run_t::join_blocking, this,
+                        other_peer_addr,
+                        boost::optional<peer_id_t>(it->first),
+                        join_delay_secs,
+                        drainer_lock));
+                } catch (const host_lookup_exc_t &ex) {
+                    printf_buffer_t hostnames;
+                    for (auto const &host_and_port : it->second) {
+                        hostnames.appendf("%s%s", hostnames.size() > 0 ? ", " : "",
+                                          host_and_port.host().c_str());
+                    }
+                    logERR("Informed of peer with unresolvable hostname%s: %s. We will not be "
+                           "able to connect to this peer, which could result in diminished "
+                           "availability.  Consider using the '--canonical-address' launch option.",
+                           it->second.size() > 1 ? "s" : "", hostnames.c_str());
+                }
             }
         }
     }

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -1207,13 +1207,13 @@ void connectivity_cluster_t::run_t::handle(
             if (routing_table.find(it->first) == routing_table.end()) {
                 try {
                     // This is where we resolve the peer's ip addresses
-                    peer_address_t other_peer_addr(it->second);
+                    peer_address_t next_peer_addr(it->second);
 
                     // `it->first` is the ID of a peer that our peer is connected
                     //  to, but we aren't connected to.
                     coro_t::spawn_now_dangerously(std::bind(
                         &connectivity_cluster_t::run_t::join_blocking, this,
-                        other_peer_addr,
+                        next_peer_addr,
                         boost::optional<peer_id_t>(it->first),
                         join_delay_secs,
                         drainer_lock));


### PR DESCRIPTION
This is almost same as https://github.com/rethinkdb/rethinkdb/pull/5484, but resolved conflict.

Hope this easy to review and merge.

There are still something TODO as following, i will modify in this branch later
    Better conversion(db -> java):
       Support generic hash map, generic array, generic primitive array
       Better conversion for number type xxx by ((Number)value).xxxValue(), instead of xxx.parse(value.toString())
    Support save primitive array to db.
...