### PR TITLE
Fix for #5647

### DIFF
--- a/drivers/python/rethinkdb/_restore.py
+++ b/drivers/python/rethinkdb/_restore.py
@@ -147,7 +147,7 @@ def do_unzip(temp_dir, options):
         path, base = os.path.split(path)
         return (base, db, os.path.splitext(table_file)[0])
 
-    is_fileobj = type(options["in_file"]) is file
+    is_fileobj = type(options["in_file"]) is type(sys.stdin)
 
     # If the in_file is a fileobj (e.g. stdin), stream it to a seekable file
     # first so that the code below can seek in it.

--- a/drivers/python/rethinkdb/_restore.py
+++ b/drivers/python/rethinkdb/_restore.py
@@ -147,12 +147,10 @@ def do_unzip(temp_dir, options):
         path, base = os.path.split(path)
         return (base, db, os.path.splitext(table_file)[0])
 
-    is_fileobj = type(options["in_file"]) is type(sys.stdin)
-
     # If the in_file is a fileobj (e.g. stdin), stream it to a seekable file
     # first so that the code below can seek in it.
     tar_temp_file_path = None
-    if is_fileobj:
+    if options["in_file"] is sys.stdin:
         fileobj = options["in_file"]
         fd, tar_temp_file_path = tempfile.mkstemp(suffix=".tar.gz", dir=options["temp_dir"])
         # Constant memory streaming, buf == "" on EOF


### PR DESCRIPTION
Fixes #5647 

Python 3's sys.stdin is not of type "file" anymore, but rather
_io.TextIOWrapper -- which parses down to just type Class (apparently)

This should fix python3, but also work in python2.

This might be a naive approach, but I don't really see another option. :fearful: 