### PR TITLE
Support for connection pooling in Java driver

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/RethinkDB.java
+++ b/drivers/java/src/main/java/com/rethinkdb/RethinkDB.java
@@ -2,6 +2,7 @@ package com.rethinkdb;
 
 import com.rethinkdb.gen.model.TopLevel;
 import com.rethinkdb.net.Connection;
+import com.rethinkdb.net.ConnectionPool;
 
 public class RethinkDB extends TopLevel {
 
@@ -13,4 +14,14 @@ public class RethinkDB extends TopLevel {
     public Connection.Builder connection() {
         return Connection.build();
     }
+
+	  private static ConnectionPool globalConnectionPool;
+
+	public static ConnectionPool getGlobalConnectionPool() {
+		return globalConnectionPool;
+	}
+
+	public static void setGlobalConnectionPool(ConnectionPool globalConnectionPool) {
+		RethinkDB.globalConnectionPool = globalConnectionPool;
+	}
 }

--- a/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/drivers/java/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -1,10 +1,12 @@
 package com.rethinkdb.ast;
 
+import com.rethinkdb.RethinkDB;
 import com.rethinkdb.gen.exc.ReqlDriverError;
 import com.rethinkdb.gen.proto.TermType;
 import com.rethinkdb.model.Arguments;
 import com.rethinkdb.model.OptArgs;
 import com.rethinkdb.net.Connection;
+import com.rethinkdb.net.ConnectionPool;
 import org.json.simple.JSONArray;
 
 import java.util.HashMap;
@@ -65,6 +67,41 @@ public class ReqlAst {
         return conn.run(this, new OptArgs(), Optional.empty());
     }
 
+	  /**
+	   * Runs this query via connection {@code conn} provided by connection pool, with default options and returns an atom result
+	   * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+	   * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+	   * which may be iterated to get a sequence of atom results
+	   * @param pool The connection pool to provide the connection
+	   * @param <T> The type of result
+	   * @return The result of this query
+	   */
+	  public <T> T run(ConnectionPool pool) {
+		    Connection conn = pool.leaseConnection();
+		    T res = this.run(conn);
+		    pool.returnConnection(conn);
+		    return res;
+	  }
+
+	  /**
+	   * Runs this query via connection {@code conn} provided by the internal global connection pool,
+	   * with default options and returns an atom result
+	   * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+	   * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+	   * which may be iterated to get a sequence of atom results.
+	   * <p/>Global connection pool must be defined prior to using this metod.
+	   * @param <T> The type of result
+	   * @return The result of this query
+	   */
+	  public <T> T run() {
+	  	  ConnectionPool globalPool = RethinkDB.getGlobalConnectionPool();
+		    if (globalPool == null) {
+			    throw new RuntimeException("Global connection pool must be defined via RethinkDB.setGlobalConnectionPool() " +
+			  		  "prior to calling RethinkDB.run()");
+  		  }
+		    return run(globalPool);
+	  }
+
     /**
      * Runs this query via connection {@code conn} with options {@code runOpts} and returns an atom result
      * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
@@ -79,7 +116,44 @@ public class ReqlAst {
         return conn.run(this, runOpts, Optional.empty());
     }
 
+	  /**
+	   * Runs this query via connection {@code conn} provided by connection pool,
+	   * with options {@code runOpts} and returns an atom result
+	   * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+	   * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+	   * which may be iterated to get a sequence of atom results
+	   * @param pool The connection pool to provide connection to run this query
+	   * @param runOpts The options to run this query with
+	   * @param <T> The type of result
+	   * @return The result of this query
+	   */
+	  public <T> T run(ConnectionPool pool, OptArgs runOpts) {
+		    Connection conn = pool.leaseConnection();
+		    T res = this.run(conn, runOpts);
+		    pool.returnConnection(conn);
+		    return res;
+	  }
+
     /**
+     * Runs this query via connection {@code conn} provided by global connection pool,
+     * with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result either has a primitive type (e.g., {@code Integer})
+     * or represents a JSON object as a {@code Map<String, Object>}. The cursor is a {@code com.rethinkdb.net.Cursor}
+     * which may be iterated to get a sequence of atom results
+     * @param runOpts The options to run this query with
+     * @param <T> The type of result
+     * @return The result of this query
+     */
+    public <T> T run(OptArgs runOpts) {
+    	  ConnectionPool globalPool = RethinkDB.getGlobalConnectionPool();
+    	  if (globalPool == null) {
+    	  	throw new RuntimeException("Global connection pool must be defined via RethinkDB.setGlobalConnectionPool() " +
+    	  			"prior to calling RethinkDB.run()");
+    	  }
+    	  return run(globalPool, runOpts);
+    }
+
+  	/**
      * Runs this query via connection {@code conn} with default options and returns an atom result
      * or a sequence result as a cursor. The atom result representing a JSON object is converted
      * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
@@ -93,6 +167,47 @@ public class ReqlAst {
      */
     public <T, P> T run(Connection conn, Class<P> pojoClass) {
         return conn.run(this, new OptArgs(), Optional.of(pojoClass));
+    }
+
+    /**
+     * Runs this query via connection {@code conn} provided by connection pool,
+     * with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result representing a JSON object is converted
+     * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+     * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+     * of type {@code Class<P>}
+     * @param pool The connection pool to provide connection to run this query
+     * @param pojoClass The class of POJO to convert to
+     * @param <T> The type of result
+     * @param <P> The type of POJO to convert to
+     * @return The result of this query (either a {@code P or a Cursor<P>}
+     */
+    public <T, P> T run(ConnectionPool pool, Class<P> pojoClass) {
+    	  Connection conn = pool.leaseConnection();
+    	  T res = this.run(conn, pojoClass);
+    	  pool.returnConnection(conn);
+    	  return res;
+    }
+
+    /**
+     * Runs this query via connection {@code conn} provided by global connection pool,
+     * with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result representing a JSON object is converted
+     * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+     * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+     * of type {@code Class<P>}
+     * @param pojoClass The class of POJO to convert to
+     * @param <T> The type of result
+     * @param <P> The type of POJO to convert to
+     * @return The result of this query (either a {@code P or a Cursor<P>}
+     */
+    public <T, P> T run(Class<P> pojoClass) {
+    	  ConnectionPool globalPool = RethinkDB.getGlobalConnectionPool();
+    	  if (globalPool == null) {
+    		  throw new RuntimeException("Global connection pool must be defined via RethinkDB.setGlobalConnectionPool() " +
+    			  	"prior to calling RethinkDB.run()");
+    	  }
+    	  return run(globalPool, pojoClass);
     }
 
     /**
@@ -111,6 +226,49 @@ public class ReqlAst {
     public <T, P> T run(Connection conn, OptArgs runOpts, Class<P> pojoClass) {
         return conn.run(this, runOpts, Optional.of(pojoClass));
     }
+
+    /**
+     * Runs this query via connection {@code conn} provided by connection pool,
+     * with options {@code runOpts} and returns an atom result
+     * or a sequence result as a cursor. The atom result representing a JSON object is converted
+     * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+     * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+     * of type {@code Class<P>}
+     * @param pool The connection pool to provide connection to run this query
+     * @param runOpts The options to run this query with
+     * @param pojoClass The class of POJO to convert to
+     * @param <T> The type of result
+     * @param <P> The type of POJO to convert to
+     * @return The result of this query (either a {@code P or a Cursor<P>}
+     */
+    public <T, P> T run(ConnectionPool pool, OptArgs runOpts, Class<P> pojoClass) {
+	      Connection conn = pool.leaseConnection();
+	      T res = this.run(conn, runOpts, pojoClass);
+	      pool.returnConnection(conn);
+	      return res;
+    }
+
+  	/**
+	   * Runs this query via connection {@code conn} provided by global connection pool,
+	   * with options {@code runOpts} and returns an atom result
+	   * or a sequence result as a cursor. The atom result representing a JSON object is converted
+	   * to an object of type {@code Class<P>} specified with {@code pojoClass}. The cursor
+	   * is a {@code com.rethinkdb.net.Cursor} which may be iterated to get a sequence of atom results
+	   * of type {@code Class<P>}
+	   * @param runOpts The options to run this query with
+	   * @param pojoClass The class of POJO to convert to
+	   * @param <T> The type of result
+	   * @param <P> The type of POJO to convert to
+	   * @return The result of this query (either a {@code P or a Cursor<P>}
+	   */
+	  public <T, P> T run(OptArgs runOpts, Class<P> pojoClass) {
+	  	  ConnectionPool globalPool = RethinkDB.getGlobalConnectionPool();
+		    if (globalPool == null) {
+			      throw new RuntimeException("Global connection pool must be defined via RethinkDB.setGlobalConnectionPool() " +
+		  		  	"prior to calling RethinkDB.run()");
+	  	  }
+		    return run(globalPool, runOpts, pojoClass);
+	  }
 
     public void runNoReply(Connection conn){
         conn.runNoReply(this, new OptArgs());

--- a/drivers/java/src/main/java/com/rethinkdb/net/ConnectionPool.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/ConnectionPool.java
@@ -1,0 +1,144 @@
+package com.rethinkdb.net;
+
+import com.rethinkdb.RethinkDB;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public interface ConnectionPool {
+
+	/**
+	 * Provides a Connausted.ection by taking it from a connection pool or creates a new Connection of pool is exh
+	 * @return
+	 */
+	Connection leaseConnection();
+
+	/**
+	 * To be called by application code to return Connection to the connection pool.
+	 * At this point the connection pool is free to provide this Connection to any caller of leaseConnection().
+	 * App code must not use the Connection after it called this method.
+	 * @param conn
+	 */
+	void returnConnection(Connection conn);
+
+	/**
+	 * Pool size.
+	 * @return
+	 */
+	int size();
+
+	/**
+	 * Close all connections and clear the pool
+	 */
+	void close();
+
+	public default List<Connection.Builder> queryCluster(Connection.Builder initialConnectionBuilder) {
+
+		List<Connection.Builder> discoveredNodes = new ArrayList<>();
+		Connection conn = initialConnectionBuilder.connect();
+		Cursor serverConfig = RethinkDB.r.db("rethinkdb").table("server_status").run(conn);
+
+		for (Object obj : serverConfig.toList()) {
+			Map map = (Map) obj;
+
+			System.out.println("_______________\nname:" + map.get("name") + " id:" + map.get("id"));
+			Map network = (Map) map.get("network");
+			String hostname = (String) network.get("hostname");
+			long reqlPort = (long) network.get("reql_port");
+			List addresses = (List) network.get("canonical_addresses");
+			List<InetAddress> foundAddresses = new ArrayList<>(10);
+			for (Object addressObj : addresses) {
+				Map address = (Map) addressObj;
+				String host = (String) address.get("host");
+				long port = (long) address.get("port");
+				try {
+					InetAddress inetAddress = InetAddress.getByName(host);
+					foundAddresses.add(inetAddress);
+					String type = inetAddress instanceof Inet4Address ? "IPv4" : (inetAddress instanceof Inet6Address ? "IPv6" : "unknown");
+					System.out.println(host + ":" + port + " type:" + type
+							+ " loopback:" + inetAddress.isLoopbackAddress()
+							+ " anyLocal:" + inetAddress.isAnyLocalAddress()
+							+ " siteLocal:" + inetAddress.isSiteLocalAddress()
+							+ " linkLocal:" + inetAddress.isLinkLocalAddress());
+					//+ " isReachable:" + inetAddress.isReachable(2000));
+
+				} catch (UnknownHostException e) {
+					// quietly drop this IP address
+				}
+			}
+
+			// find most appropriate address in this order:
+			// 1. public IPv4
+			// 2. public IPv6
+			List<InetAddress> publicIPv4 = filterInetAddresses(foundAddresses, true, true);
+			List<InetAddress> publicIPv6 = filterInetAddresses(foundAddresses, false, true);
+			if (!publicIPv4.isEmpty()) {
+
+				for (InetAddress inetAddress : publicIPv4) {
+					Connection.Builder copy = cloneConnection(initialConnectionBuilder, inetAddress.getHostAddress(), (int) reqlPort);
+					if (copy != null) {
+						discoveredNodes.add(copy);
+					}
+				}
+			} else if (!publicIPv6.isEmpty()) {
+
+				for (InetAddress inetAddress : publicIPv4) {
+					Connection.Builder copy = cloneConnection(initialConnectionBuilder, inetAddress.getHostAddress(), (int) reqlPort);
+					if (copy != null) {
+						discoveredNodes.add(copy);
+					}
+				}
+			}
+		}
+
+		return discoveredNodes;
+	}
+
+	public default Connection.Builder cloneConnection(Connection.Builder original, String hostAddress, int port) {
+		Connection.Builder copy = null;
+		try {
+			copy = original.clone();
+		} catch (CloneNotSupportedException e) {
+			e.printStackTrace();  // should not happen - Connection.Builder implements Cloneable
+			return null;
+		}
+		copy.hostname(hostAddress);
+		copy.port(port);
+		return copy;
+	}
+
+
+	/**
+	 * Filters a list InetAddress addresses according to given criteria
+	 *
+	 * @param addresses       An input list of InetAddress addresses.
+	 * @param ipType          true if IPv4, false if IPv6
+	 * @param publicOrPrivate true if only public addresses, false if only private or loopback
+	 * @return A list of public IPv4 addresses matching the criteria.
+	 */
+	default List<InetAddress> filterInetAddresses(List<InetAddress> addresses, boolean ipType, boolean publicOrPrivate) {
+		List<InetAddress> found = new ArrayList<>();
+		for (InetAddress address : addresses) {
+			boolean isPublic = !address.isLoopbackAddress() && !address.isLinkLocalAddress() && !address.isSiteLocalAddress();
+			boolean properInetClass = ipType ? address instanceof Inet4Address : address instanceof Inet6Address;
+			if (properInetClass && (publicOrPrivate && isPublic || !publicOrPrivate && !isPublic)) {
+				found.add(address);
+			}
+		}
+		return found;
+	}
+
+	default String printList(List<InetAddress> list) {
+		StringBuilder out = new StringBuilder();
+		for (InetAddress ia : list) {
+			out.append(ia.getHostAddress()).append(" ,");
+		}
+		return out.toString();
+	}
+
+}

--- a/drivers/java/src/main/java/com/rethinkdb/net/FixedConnectionPool.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/FixedConnectionPool.java
@@ -1,0 +1,103 @@
+package com.rethinkdb.net;
+
+import com.rethinkdb.gen.exc.ReqlDriverError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * A {@link ConnectionPool} that manages {@link Connection}s to a set of predefined cluster nodes.
+ * This {@link ConnectionPool} implementation does not auto-discover cluster nodes,
+ * nor does it dynamically handle adding or removing cluster nodes.
+ */
+public class FixedConnectionPool implements ConnectionPool {
+
+	private static final Logger log = LoggerFactory.getLogger(FixedConnectionPool.class);
+
+	private final Connection.Builder[] initialConnectionBuilders;
+
+	private ConcurrentLinkedDeque<Connection> connDequeue = new ConcurrentLinkedDeque<>();
+
+	// for sync purposes this field should only be changed in method getNewConnectionIndex()
+	private int lastCreatedConnIndex = -1;
+
+	/**
+	 * Constructs a {@link ConnectionPool} with connections to the provided set of nodes.
+	 * {@link Connection.Builder} must be provided for every cluster node that this ConnectionPool manages Connection for.
+	 *
+	 * @param connectionBuilders An array of one Connection.Builder for each cluster node.
+	 */
+	public FixedConnectionPool(Connection.Builder... connectionBuilders) {
+		this.initialConnectionBuilders = connectionBuilders;
+	}
+
+	@Override
+	public Connection leaseConnection() {
+
+		// get from the front of the queue
+		Connection leasedConn = connDequeue.pollFirst();
+
+		// out of connections?
+		if (leasedConn == null) {
+			int i = 0;
+			while (i < initialConnectionBuilders.length && leasedConn == null) {
+				try {
+					int pickedIndex = pickNextConnectionIndex();
+					log.debug("Creating new connection. Picked conn builder " + pickedIndex + "/" + initialConnectionBuilders.length);
+					Connection.Builder connBuilder = initialConnectionBuilders[pickedIndex];
+					leasedConn = connBuilder.connect();
+				} catch (ReqlDriverError rde) {
+					log.warn("ReqlDriverError: " + rde.getMessage() + (rde.getBacktrace().isPresent() ? " backtrace:" + rde.getBacktrace().get().toString() : ""));
+				}
+				i++;
+			}
+			if (leasedConn == null) {
+				throw new RuntimeException("Error: could not create a connection with any of the provided connection builders.");
+			}
+		}
+
+		// check if connection is not open anymore and then try leasing another connection
+		// this purges closed connections and consequently shrinks the pool if unused (closed) connections start piling up
+		if (!leasedConn.isOpen()) {
+			leasedConn = leaseConnection();
+		}
+
+		return leasedConn;
+	}
+
+	@Override
+	public void returnConnection(Connection conn) {
+		if (conn != null) {
+			// return to the back of the queue
+			connDequeue.addLast(conn);
+		}
+	}
+
+	@Override
+	public int size() {
+		return connDequeue.size();
+	}
+
+	@Override
+	public synchronized void close() {
+		for (Connection connection : connDequeue) {
+			connection.close();
+		}
+		connDequeue.clear();
+	}
+
+	/**
+	 * Loops through initialConnectionBuilders indexes in a round-robin fashion.
+	 * @return
+	 */
+	private synchronized int pickNextConnectionIndex() {
+		// increment index
+		lastCreatedConnIndex++;
+		// reset if overflows
+		if (lastCreatedConnIndex >= initialConnectionBuilders.length) {
+			lastCreatedConnIndex = 0;
+		}
+		return lastCreatedConnIndex;
+	}
+}

--- a/drivers/java/src/test/java/com/rethinkdb/FixedConnectionPoolTest.java
+++ b/drivers/java/src/test/java/com/rethinkdb/FixedConnectionPoolTest.java
@@ -1,0 +1,85 @@
+package com.rethinkdb;
+
+import com.rethinkdb.net.Connection;
+import com.rethinkdb.net.FixedConnectionPool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FixedConnectionPoolTest {
+
+	private FixedConnectionPool pool;
+
+	@Before
+	public void before() {
+
+		Connection.Builder connBuilder1 = Connection.build().hostname("localhost").port(28015);
+		Connection.Builder connBuilder2 = Connection.build().hostname("localhost").port(28016);
+		Connection.Builder connBuilder3 = Connection.build().hostname("localhost").port(28017);
+		Connection.Builder connBuilder4 = Connection.build().hostname("localhost").port(28018); // this one should not exist
+
+		pool = new FixedConnectionPool(connBuilder1, connBuilder2, connBuilder3, connBuilder4);
+		RethinkDB.r.db("test").tableCreate("pooltest").run(pool);
+	}
+
+	@After
+	public void after() {
+		RethinkDB.r.db("test").tableDrop("pooltest").run(pool);
+		pool.close();
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void noGlobalPoolTest() {
+
+		RethinkDB.r.db("test").table("pooltest").run();  // throws RuntimeException
+	}
+
+	@Test
+	public void globalPoolTest() {
+
+		RethinkDB.setGlobalConnectionPool(pool);
+
+		RethinkDB.r.db("test").table("pooltest").run();  // uses global conneciton pool
+	}
+
+	@Test
+	public void oneLeaseTest() {
+
+		// connection is leased and immediately returned, so only one connection is created
+		Connection conn1 = pool.leaseConnection();
+		pool.returnConnection(conn1);
+		Connection conn2 = pool.leaseConnection();
+		pool.returnConnection(conn2);
+		Connection conn3 = pool.leaseConnection();
+		pool.returnConnection(conn3);
+
+		// it's all the same connection
+		Assert.assertEquals(conn1, conn2);
+		Assert.assertEquals(conn2, conn3);
+
+		// one connection was created
+		Assert.assertEquals(1, pool.size());
+	}
+
+	@Test
+	public void multiLeaseTest() {
+
+		// three connections are leased and then  returned, so three connections are created
+		Connection conn1 = pool.leaseConnection();
+		Connection conn2 = pool.leaseConnection();
+		Connection conn3 = pool.leaseConnection();
+		Connection conn4 = pool.leaseConnection();
+		pool.returnConnection(conn1);
+		pool.returnConnection(conn2);
+		pool.returnConnection(conn3);
+		pool.returnConnection(conn4);
+
+		Assert.assertNotEquals(conn1, conn2);
+		Assert.assertNotEquals(conn2, conn3);
+		Assert.assertNotEquals(conn3, conn4);
+
+		// four connections were created
+		Assert.assertEquals(4, pool.size());
+	}
+}


### PR DESCRIPTION
Adds support for an extensible connection pool implementations via a ConnectionPool interface. 

Provides a FixedConnectionPool implementation, which creates connections on-demand to a pre-defined set of cluster nodes. Connections are selected in a round-robin fashion and after use returned to the pool. Pool grows on-demand by creating new connections when existing pool is exhausted. 

Typical use:
```
// define conneciton builders 
Connection.Builder connBuilder1 = Connection.build().hostname("localhost").port(28015);
Connection.Builder connBuilder2 = Connection.build().hostname("localhost").port(28016);

// create a conneciton pool
ConnectionPool pool = new FixedConnectionPool(connBuilder1, connBuilder2);

// use it
RethinkDB.r.db("test").table("pooltest").run(pool);  // provide ConnectionPool instead of Connection

//  optionally register a global connection pool 
RethinkDB.setGlobalConnectionPool(pool);  
RethinkDB.r.db("test").table("pooltest").run();    // no need to pass pool or conn