### PR TITLE
Java Driver PR: Fixes #5439 and Fixes #5660.

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -118,7 +118,7 @@ public class Connection implements Closeable {
                     if (awaiter != null) {
                         awaiter.complete(response);
                     }
-                } catch (IOException e) {
+                } catch (Exception e) {
                     awaiterException = e;
                     this.close();
                     break;


### PR DESCRIPTION
Hola,

I think this PR will fix #5439 and fix #5660 for the Java driver.

The core of the bug is described here: https://github.com/rethinkdb/rethinkdb/issues/5660#issuecomment-210734741

The crux of the issue is that only `IOException` is being handled. If another exception type was thrown, the `ResponsePump` thread exceptionally exit without clean up and without notifying cursor changefeeds causing what looks like a stalled changefeed upon a server restart.

I'm not sure how I could write a unit test for this particular issue since it would require restarting the RethinkDB server :electric_plug: during a unit test.

All unit tests pass (except a few string tests). Probably because some M$ Windowz string quirks?