### PR TITLE
fix(npm-pkg): support node 5 for build process

### DIFF
--- a/mk/support/pkg/npm-pkg.inc
+++ b/mk/support/pkg/npm-pkg.inc
@@ -49,7 +49,7 @@ pkg_install () {
     mkdir -p "$install_dir/node_modules"
     local pkg
     pkg=$(niceabspath "$src_dir")
-    in_dir "$install_dir" npm --no-registry install "$pkg"
+    in_dir "$install_dir" npm install "$pkg"
 
     local bin_dir="$install_dir/node_modules/$full_npm_package/node_modules/.bin/"
     mkdir -p "$install_dir/bin"


### PR DESCRIPTION
The npm shipped with node 5 (at least this is all I've checked) no
longer supports the `--no-registry` flag. Removing this flag keeps
support for older versions, while also supporting a local node 5
installation

/cc @larkost 
