### PR TITLE
intra-cluster handshake improvements

### DIFF
--- a/src/arch/address.cc
+++ b/src/arch/address.cc
@@ -553,6 +553,13 @@ const std::set<ip_and_port_t>& peer_address_t::ips() const {
     return resolved_ips;
 }
 
+void peer_address_t::erase_ip(const ip_and_port_t &ip) {
+    auto it = resolved_ips.find(ip);
+    if (it != resolved_ips.end()) {
+        resolved_ips.erase(it);
+    }
+}
+
 // Two addresses are considered equal if all of their hosts match
 bool peer_address_t::operator == (const peer_address_t &a) const {
     std::set<host_and_port_t>::const_iterator it, jt;

--- a/src/arch/address.hpp
+++ b/src/arch/address.hpp
@@ -184,6 +184,7 @@ public:
     const std::set<ip_and_port_t> &ips() const;
 
     host_and_port_t primary_host() const;
+    void erase_ip(const ip_and_port_t &ip);
 
     // Two addresses are considered equal if all of their hosts match
     bool operator == (const peer_address_t &a) const;

--- a/src/clustering/administration/servers/auto_reconnect.cc
+++ b/src/clustering/administration/servers/auto_reconnect.cc
@@ -97,7 +97,7 @@ void auto_reconnector_t::try_reconnect(const server_id_t &server,
 
                 if (result == join_result_t::PERMANENT_ERROR &&
                     addresses.find(server) != addresses.end()) {
-                    logNTC("Unrecoverable connection error to remote peer: %s\n", server.print().c_str());
+                    logNTC("Unrecoverable connection error to remote server: %s", server.print().c_str());
                     join_failed.pulse_if_not_already_pulsed();
                     addresses.erase(it);
                 }

--- a/src/clustering/administration/servers/auto_reconnect.cc
+++ b/src/clustering/administration/servers/auto_reconnect.cc
@@ -91,9 +91,12 @@ void auto_reconnector_t::try_reconnect(const server_id_t &server,
         // They will be reset to `nullptr` by the assignment_sentry_ts when this function
         // call ends.
         std::shared_ptr<cond_t *> join_failed_out(new cond_t *(nullptr));
-        std::shared_ptr<peer_address_t *> last_known_address_out(new peer_address_t *(nullptr));
-        assignment_sentry_t<cond_t *> join_failed_out_assignment(join_failed_out.get(), &join_failed);
-        assignment_sentry_t<peer_address_t *> last_known_address_out_assignment(last_known_address_out.get(), &last_known_address);
+        std::shared_ptr<peer_address_t *> last_known_address_out(
+            new peer_address_t *(nullptr));
+        assignment_sentry_t<cond_t *> join_failed_out_assignment(
+            join_failed_out.get(), &join_failed);
+        assignment_sentry_t<peer_address_t *> last_known_address_out_assignment(
+            last_known_address_out.get(), &last_known_address);
 
         while (!interruptor.is_pulsed()) {
             // This coroutine can keep running even after this function has returned
@@ -102,11 +105,11 @@ void auto_reconnector_t::try_reconnect(const server_id_t &server,
 
             coro_t::spawn_now_dangerously(
                 [this, last_known_address, server, join_failed_out, last_known_address_out]() {
-                auto &connectivity_cluster_run_local = connectivity_cluster_run;
-                auto &join_delay_secs_local = join_delay_secs;
+                auto connectivity_cluster_run_local = connectivity_cluster_run;
+                auto join_delay_secs_local = join_delay_secs;
 
                 join_results_t results =
-                    connectivity_cluster_run->join_blocking(
+                    connectivity_cluster_run_local->join_blocking(
                         last_known_address, boost::none, server,
                         join_delay_secs_local,
                         auto_drainer_t::lock_t(&connectivity_cluster_run_local->drainer));

--- a/src/clustering/administration/servers/auto_reconnect.hpp
+++ b/src/clustering/administration/servers/auto_reconnect.hpp
@@ -44,10 +44,6 @@ private:
     connected servers we get from the `connectivity_cluster_t`. */
     std::map<peer_id_t, server_id_t> server_ids;
 
-    /* `stop_conds` contains an entry for each running instance of `try_reconnect()`.
-    It's used to interrupt the coroutines if the server reconnects. */
-    std::multimap<server_id_t, cond_t *> stop_conds;
-
     int join_delay_secs;
     int give_up_ms;
 

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -332,6 +332,7 @@ void connectivity_cluster_t::run_t::connect_to_peer(
         boost::optional<peer_id_t> expected_id,
         auto_drainer_t::lock_t drainer_lock,
         bool *successful_join_inout,
+        join_result_t *join_result_inout,
         const int join_delay_secs,
         co_semaphore_t *rate_control) THROWS_NOTHING {
     // Wait to start the connection attempt, max time is one second per address
@@ -363,7 +364,7 @@ void connectivity_cluster_t::run_t::connect_to_peer(
                 tls_ctx, selected_addr->ip(), selected_addr->port().value(),
                 drainer_lock.get_drain_signal(), cluster_client_port);
             if (!*successful_join_inout) {
-                handle(
+                *join_result_inout = handle(
                     &conn, expected_id, boost::optional<peer_address_t>(*address),
                     drainer_lock, successful_join_inout, join_delay_secs);
             }
@@ -380,7 +381,7 @@ void connectivity_cluster_t::run_t::connect_to_peer(
     rate_control->unlock(1);
 }
 
-void connectivity_cluster_t::run_t::join_blocking(
+join_result_t connectivity_cluster_t::run_t::join_blocking(
         const peer_address_t peer,
         boost::optional<peer_id_t> expected_id,
         const int join_delay_secs,
@@ -390,7 +391,7 @@ void connectivity_cluster_t::run_t::join_blocking(
     {
         mutex_assertion_t::acq_t acq(&attempt_table_mutex);
         if (attempt_table.find(peer) != attempt_table.end()) {
-            return;
+            return join_result_t::PERMANENT_ERROR;
         }
         attempt_table.insert(peer);
     }
@@ -400,6 +401,7 @@ void connectivity_cluster_t::run_t::join_blocking(
 
     // Attempt to connect to all known ip addresses of the peer
     bool successful_join = false; // Variable so that handle() can check that only one connection succeeds
+    join_result_t join_result; // Used to determine the joint result for an individual connection attempt
     static_semaphore_t rate_control(peer.ips().size()); // Mutex to control the rate that connection attempts are made
     rate_control.co_lock(peer.ips().size() - 1); // Start with only one coroutine able to run
 
@@ -411,6 +413,7 @@ void connectivity_cluster_t::run_t::join_blocking(
                    expected_id,
                    drainer_lock,
                    &successful_join,
+                   &join_result,
                    join_delay_secs,
                    &rate_control));
 
@@ -419,6 +422,8 @@ void connectivity_cluster_t::run_t::join_blocking(
         mutex_assertion_t::acq_t acq(&attempt_table_mutex);
         attempt_table.erase(peer);
     }
+
+    return join_result;
 }
 
 class cluster_conn_closing_subscription_t : public signal_t::subscription_t {
@@ -841,7 +846,7 @@ void fail_handshake(keepalive_tcp_conn_stream_t *conn,
 // - warning: invalid header
 // - error: id or address don't match expected id or address; deserialization range error; unknown error
 // In all cases we close the connection and quit.
-void connectivity_cluster_t::run_t::handle(
+join_result_t connectivity_cluster_t::run_t::handle(
         /* `conn` should remain valid until `handle()` returns.
          * `handle()` does not take ownership of `conn`. */
         keepalive_tcp_conn_stream_t *conn,
@@ -904,7 +909,7 @@ void connectivity_cluster_t::run_t::handle(
         serialize_universal(&wm, parent->me);
         serialize_universal(&wm, routing_table[parent->me].hosts());
         if (send_write_message(conn, &wm)) {
-            return; // network error.
+            return join_result_t::TEMPORARY_ERROR; // network error.
         }
     }
 
@@ -916,14 +921,14 @@ void connectivity_cluster_t::run_t::handle(
             char buffer;
             int64_t r = conn->read(&buffer, 1);
             if (-1 == r) {
-                return; // network error.
+                return join_result_t::TEMPORARY_ERROR; // network error.
             }
             rassert(r >= 0);
             rassert(r <= 1);
             // If EOF or remote_header does not match header, terminate connection.
             if (0 == r || cluster_proto_header[i] != buffer) {
                 logWRN("Received invalid clustering header from %s, closing connection -- something might be connecting to the wrong port.", peername);
-                return;
+                return join_result_t::PERMANENT_ERROR;
             }
         }
     }
@@ -934,7 +939,7 @@ void connectivity_cluster_t::run_t::handle(
         std::string remote_version_string;
 
         if (!deserialize_compatible_string(conn, &remote_version_string, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         if (!resolve_protocol_version(remote_version_string, &resolved_version)) {
@@ -953,7 +958,7 @@ void connectivity_cluster_t::run_t::handle(
                 }
             }
             fail_handshake(conn, peername, reason, handshake_error_supported);
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         // In the future we'll need to support multiple cluster versions.
@@ -963,14 +968,14 @@ void connectivity_cluster_t::run_t::handle(
     server_id_t remote_server_id;
     {
         if (deserialize_universal_and_check(conn, &remote_server_id, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         if (servers.count(remote_server_id) != 0) {
             // There currently is another connection open to the server
             logINF("Rejected a connection from server %s since one is open already.",
                    remote_server_id.print().c_str());
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
     }
     set_insertion_sentry_t<server_id_t> remote_server_id_sentry(
@@ -981,7 +986,7 @@ void connectivity_cluster_t::run_t::handle(
         std::string remote_arch_bitsize;
 
         if (!deserialize_compatible_string(conn, &remote_arch_bitsize, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         if (remote_arch_bitsize != cluster_arch_bitsize) {
@@ -990,7 +995,7 @@ void connectivity_cluster_t::run_t::handle(
                 strprintf("local: %s, remote: %s",
                           cluster_arch_bitsize.c_str(), remote_arch_bitsize.c_str()));
             fail_handshake(conn, peername, reason);
-            return;
+            return join_result_t::PERMANENT_ERROR;
         }
 
     }
@@ -1000,7 +1005,7 @@ void connectivity_cluster_t::run_t::handle(
         std::string remote_build_mode;
 
         if (!deserialize_compatible_string(conn, &remote_build_mode, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         if (remote_build_mode != cluster_build_mode) {
@@ -1015,7 +1020,7 @@ void connectivity_cluster_t::run_t::handle(
         bool remote_has_admin_password;
 
         if (deserialize_universal_and_check(conn, &remote_has_admin_password, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         // It's enough to do this check on one side. The handshake failure we send
@@ -1028,7 +1033,7 @@ void connectivity_cluster_t::run_t::handle(
                 "server with the `--initial-password auto` option to allow joining "
                 "the password-protected cluster.");
             fail_handshake(conn, peername, reason);
-            return;
+            return join_result_t::PERMANENT_ERROR;
         }
     }
 
@@ -1037,7 +1042,7 @@ void connectivity_cluster_t::run_t::handle(
     std::set<host_and_port_t> other_peer_addr_hosts;
     if (deserialize_universal_and_check(conn, &other_id, peername) ||
         deserialize_universal_and_check(conn, &other_peer_addr_hosts, peername)) {
-        return;
+        return join_result_t::TEMPORARY_ERROR;
     }
 
     {
@@ -1045,19 +1050,19 @@ void connectivity_cluster_t::run_t::handle(
         write_message_t wm;
         serialize_universal(&wm, handshake_result_t::success());
         if (send_write_message(conn, &wm)) {
-            return; // network error.
+            return join_result_t::TEMPORARY_ERROR; // network error.
         }
 
         // Check if there was an issue with the connection initiation
         handshake_result_t handshake_result;
         if (deserialize_universal_and_check(conn, &handshake_result, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
         if (handshake_result.get_code() != handshake_result_code_t::SUCCESS) {
             logWRN("Remote node refused to connect with us, peer: %s, reason: \"%s\"",
                    peername,
                    sanitize_for_logger(handshake_result.get_error_reason()).c_str());
-            return;
+            return join_result_t::PERMANENT_ERROR;
         }
     }
 
@@ -1075,26 +1080,29 @@ void connectivity_cluster_t::run_t::handle(
         logERR("Connected to peer with unresolvable hostname%s: %s, closing "
                "connection.  Consider using the '--canonical-address' launch option.",
                other_peer_addr_hosts.size() > 1 ? "s" : "", hostnames.c_str());
-        return;
+        return join_result_t::TEMPORARY_ERROR;
     }
 
     /* Sanity checks */
     if (other_id == parent->me) {
         // TODO: report this on command-line in some cases. see issue 546 on github.
-        return;
+        return join_result_t::PERMANENT_ERROR;
     }
+
     if (other_id.is_nil()) {
         logERR("Received nil peer id from %s, closing connection.", peername);
-        return;
+        return join_result_t::PERMANENT_ERROR;
     }
+
     if (expected_id && other_id != *expected_id) {
         // This is only a problem if we're not using a loopback address
         if (!peer_addr.ip().is_loopback()) {
             logERR("Received inconsistent routing information (wrong ID) from %s, "
                    "closing connection.", peername);
         }
-        return;
+        return join_result_t::PERMANENT_ERROR;
     }
+
     if (expected_address && !is_similar_peer_address(*other_peer_addr.get(),
                                                      *expected_address)) {
         printf_buffer_t buf;
@@ -1106,7 +1114,7 @@ void connectivity_cluster_t::run_t::handle(
         logERR("Received inconsistent routing information (wrong address) from %s (%s), "
                "closing connection.  Consider using the '--canonical-address' launch "
                "option.", peername, buf.c_str());
-        return;
+        return join_result_t::TEMPORARY_ERROR;
     }
 
     // Just saying that we're still on the rpc listener thread.
@@ -1142,7 +1150,7 @@ void connectivity_cluster_t::run_t::handle(
                                                     *other_peer_addr.get(),
                                                     &routing_table_entry_sentry,
                                                     &routing_table_to_send)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         /* We're good to go! Transmit the routing table to the follower, so it
@@ -1151,14 +1159,14 @@ void connectivity_cluster_t::run_t::handle(
             write_message_t wm;
             serialize_for_version(resolved_version, &wm, routing_table_to_send);
             if (send_write_message(conn, &wm)) {
-                return;         // network error
+                return join_result_t::TEMPORARY_ERROR;         // network error
             }
         }
 
         /* Receive the follower's routing table */
         if (deserialize_and_check(resolved_version, conn,
                                   &other_routing_table, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
     } else {
@@ -1167,7 +1175,7 @@ void connectivity_cluster_t::run_t::handle(
         the routing table. */
         if (deserialize_and_check(resolved_version, conn,
                                   &other_routing_table, peername)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         std::map<peer_id_t, std::set<host_and_port_t> > routing_table_to_send;
@@ -1175,7 +1183,7 @@ void connectivity_cluster_t::run_t::handle(
                                                     *other_peer_addr.get(),
                                                     &routing_table_entry_sentry,
                                                     &routing_table_to_send)) {
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
 
         /* Send our routing table to the leader */
@@ -1183,7 +1191,7 @@ void connectivity_cluster_t::run_t::handle(
             write_message_t wm;
             serialize_for_version(resolved_version, &wm, routing_table_to_send);
             if (send_write_message(conn, &wm)) {
-                return;         // network error
+                return join_result_t::TEMPORARY_ERROR;         // network error
             }
         }
     }
@@ -1196,7 +1204,7 @@ void connectivity_cluster_t::run_t::handle(
     if (successful_join_inout != nullptr) {
         if (*successful_join_inout) {
             logWRN("Somehow ended up with two successful joins to a peer, closing one");
-            return;
+            return join_result_t::TEMPORARY_ERROR;
         }
         *successful_join_inout = true;
     }
@@ -1351,6 +1359,7 @@ void connectivity_cluster_t::run_t::handle(
     `shutdown_write()` which we call above initiates aborting pending writes, but it
     doesn't wait until the process is done. */
     conn->flush_buffer();
+    return join_result_t::SUCCESS;
 }
 
 connectivity_cluster_t::connectivity_cluster_t() THROWS_NOTHING :

--- a/src/rpc/connectivity/cluster.hpp
+++ b/src/rpc/connectivity/cluster.hpp
@@ -248,6 +248,7 @@ public:
         void connect_to_peer(const peer_address_t *addr,
                              int index,
                              boost::optional<peer_id_t> expected_id,
+                             boost::optional<server_id_t> expected_server_id,
                              auto_drainer_t::lock_t drainer_lock,
                              bool *successful_join_inout,
                              join_result_t *join_results_inout,
@@ -259,7 +260,8 @@ public:
         directly by the auto_reconnector_t. For cases where it is used directly, it
         returns a join_result_t, indicating whether the join was successful or not. */
         join_result_t join_blocking(const peer_address_t hosts,
-                           boost::optional<peer_id_t>,
+                           boost::optional<peer_id_t> expected_id,
+                           boost::optional<server_id_t> expected_server_id,
                            const int join_delay_secs,
                            auto_drainer_t::lock_t) THROWS_NOTHING;
 
@@ -280,6 +282,7 @@ public:
         join_result_t handle(keepalive_tcp_conn_stream_t *c,
             boost::optional<peer_id_t> expected_id,
             boost::optional<peer_address_t> expected_address,
+            boost::optional<server_id_t> expected_server_id,
             auto_drainer_t::lock_t,
             bool *successful_join_inout,
             const int join_delay_secs) THROWS_NOTHING;

--- a/src/rpc/connectivity/cluster.hpp
+++ b/src/rpc/connectivity/cluster.hpp
@@ -40,6 +40,8 @@ enum class join_result_t {
     PERMANENT_ERROR = 2
 };
 
+typedef std::map<ip_and_port_t, join_result_t> join_results_t;
+
 /* Uncomment this to enable message profiling. Message profiling will keep track of how
 many messages of each type are sent over the network; it will dump the results to a file
 named `msg_profiler_out_PID.txt` on shutdown. Each line of that file will be of the
@@ -245,13 +247,13 @@ public:
 
         /* `connect_to_peer` is spawned for each known ip address of a peer which we want
         to connect to, all but one should fail */
-        void connect_to_peer(const peer_address_t *addr,
+        join_result_t connect_to_peer(const peer_address_t *address,
+                             ip_and_port_t selected_addr,
                              int index,
                              boost::optional<peer_id_t> expected_id,
                              boost::optional<server_id_t> expected_server_id,
                              auto_drainer_t::lock_t drainer_lock,
                              bool *successful_join_inout,
-                             join_result_t *join_results_inout,
                              const int join_delay_secs,
                              co_semaphore_t *rate_control) THROWS_NOTHING;
 
@@ -259,7 +261,7 @@ public:
         `handle()` when we hear about a new peer from a peer we are connected to, and
         directly by the auto_reconnector_t. For cases where it is used directly, it
         returns a join_result_t, indicating whether the join was successful or not. */
-        join_result_t join_blocking(const peer_address_t hosts,
+        join_results_t join_blocking(const peer_address_t &peer,
                            boost::optional<peer_id_t> expected_id,
                            boost::optional<server_id_t> expected_server_id,
                            const int join_delay_secs,


### PR DESCRIPTION
This is a series of patches that aim to improve intra-cluster connections. This is primarily achieved by the following:

- Introduce a `join_result_t` enum in order to return meaningful results from `connectivity_cluster_t::run_t::join_blocking`. This allows for enabling certain behaviors based on that reuslt.

- One of those aforementioned behaviors is to stop retrying intra-cluster reconnects in the `auto_reconector_t` if a join has failed irrecoverably (a `join_result_t::PERMANENT_ERROR`) 

- Finally, a new `PERMANENT_ERROR` was introduced in the `run_t::handle` method: if an expected server id is provided, and the remote server's id does not equal that value upon initial handshake, then that will prevent further reconnects.

/cc @danielmewes 