### PR TITLE
Issue#5742: Bug: rethinkdb.errors.ReqlDriverError: Could not connect …

### DIFF
--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -332,7 +332,7 @@ class SocketWrapper(object):
         except Exception as ex:
             self.close()
             raise ReqlDriverError("Could not connect to %s:%s. Error: %s" %
-                                  (self.host, self.port, ex))
+                                  (self.host, self.port, str(ex)))
 
     def is_open(self):
         return self._socket is not None


### PR DESCRIPTION
…to localhost:28015. Error: can't concat bytes to str

Hi,
I have fixed 5742 issue which was of string concatenation when connecting to redis with python driver.
Kindly review the change and merge PR.
