### PR TITLE
Round the time values to the Rethinkdb precision

### DIFF
--- a/drivers/ruby/lib/shim.rb
+++ b/drivers/ruby/lib/shim.rb
@@ -22,7 +22,7 @@ module RethinkDB
       case x
       when Hash
         if parse_time && x['$reql_type$'] == 'TIME'
-          t = Time.at(x['epoch_time'])
+          t = Time.at(x['epoch_time']).round(3)
           tz = x['timezone']
           return (tz && tz != "" && tz != "Z") ? t.getlocal(tz) : t.utc
         elsif parse_group && x['$reql_type$'] == 'GROUPED_DATA'


### PR DESCRIPTION
- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Ruby seems to add some garbage beyond the provided epoch_time resolution, which makes the read times be slightly after the originally saved times. This is specially evident when running tests.

```
2.2.4 :006 > Time.at(1463567776.592).iso8601(30)
 => "2016-05-18T12:36:16.592000007629394531250000000000+02:00"
2.2.4 :007 > Time.at(1463567776.592).round(3).iso8601(30)
 => "2016-05-18T12:36:16.592000000000000000000000000000+02:00"
```

This PR just rounds the times as shown in the code example above after reading them, removing the bogus microseconds.

PS: I'd love to write some tests, but to run the test suite I need to build the server, which is failing for me with an `npm` error 😢 (Currently it is breaking on `admin-deps_2.0.3` because `npm ERR! registry URL is required`) . Help would be appreciated.