### PR TITLE
Disable spellcheck on CodeMirror input

### DIFF
--- a/admin/static/js/codemirror/codemirror.js
+++ b/admin/static/js/codemirror/codemirror.js
@@ -97,7 +97,9 @@ window.CodeMirror = (function() {
     else input.setAttribute("wrap", "off");
     // if border: 0; -- iOS fails to open keyboard (issue #1287)
     if (ios) input.style.border = "1px solid black";
-    input.setAttribute("autocorrect", "off"); input.setAttribute("autocapitalize", "off");
+    input.setAttribute("autocorrect", "off"); 
+    input.setAttribute("autocapitalize", "off");
+    input.setAttribute("spellcheck", "off");
 
     // Wraps and hides input textarea
     d.inputDiv = elt("div", [input], null, "overflow: hidden; position: relative; width: 3px; height: 0px;");


### PR DESCRIPTION
Safari on OS X will try to spellcheck if spellcheck is not disabled on the CodeMirror textarea.

Fixes #5777