### PR TITLE
Cache compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Environment
 language: cpp
+ccache: ccache
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Since travis added caching for all types of machines, using ccache might speed up the build a lot.
I'm guessing that clang won't agree with me so hang in there for a moment.