### PR TITLE
This fix solves the ambiguous message displayed by the logger

### DIFF
--- a/src/clustering/administration/logs/log_writer.cc
+++ b/src/clustering/administration/logs/log_writer.cc
@@ -455,7 +455,7 @@ bool fallback_log_writer_t::write(const log_message_t &msg, std::string *error_o
     }
 
     if (fd.get() == INVALID_FD) {
-        error_out->assign("cannot open or find log file");
+        error_out->assign("logging module is not yet initialized");
         return false;
     }
 #ifndef _WIN32


### PR DESCRIPTION
- [ ] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
<Please fill in the description of your pull request here. Thank you for your contribution!>

This fixes an ambiguous message on the log_writer module whenever it tries to write a message to a log file , but the log_write module hasn't yet being initialized with a proper  log file.