### PR TITLE
Added `with` support for Cursor in python driver

### DIFF
--- a/drivers/python/rethinkdb/net.py
+++ b/drivers/python/rethinkdb/net.py
@@ -146,6 +146,12 @@ class Cursor(object):
         self._maybe_fetch_batch()
         self._extend_internal(first_response)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def close(self):
         if self.error is None:
             self.error = self._empty_error()


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Added support for `with` statement in the python driver as mentioned in #5768. Now users will be able to run queries like:
```
with r.db('foo').table('bar').run(conn) as table:
     for row in table:
          pass
``` 