### PR TITLE
fix for rounding error with ruby times

### DIFF
--- a/drivers/ruby/lib/shim.rb
+++ b/drivers/ruby/lib/shim.rb
@@ -135,7 +135,7 @@ module RethinkDB
       when TrueClass then RQL.new(x)
       when NilClass then RQL.new(x)
       when Time then
-        epoch_time = x.to_f
+        epoch_time = (x.to_r * 1000).to_i / 1000.0
         offset = x.utc_offset
         raw_offset = offset.abs
         raw_hours = raw_offset / 3600

--- a/drivers/ruby/lib/shim.rb
+++ b/drivers/ruby/lib/shim.rb
@@ -22,7 +22,7 @@ module RethinkDB
       case x
       when Hash
         if parse_time && x['$reql_type$'] == 'TIME'
-          t = Time.at(x['epoch_time']).round(3)
+          t = Time.at((x['epoch_time'] * 1000).to_i / 1000.0)
           tz = x['timezone']
           return (tz && tz != "" && tz != "Z") ? t.getlocal(tz) : t.utc
         elsif parse_group && x['$reql_type$'] == 'GROUPED_DATA'


### PR DESCRIPTION
- [X ] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
In ruby/rails -- storing a `Time.now.end_of_day` in rethink, always returns the next day
```
> d = Date.today
> d.to_time
=> 2016-06-03 00:00 +0000
> d.to_time.end_of_day
=> 2016-06-03 23:59 +0000
> d.to_time.end_of_day.to_i
=> 1464998399
> d.to_time.end_of_day.to_r
=> (1464998399999999999/1000000000)

> d.to_time.end_of_day.to_f
=> 1464998400.0     <--- The Problem
> ((d.to_time.end_of_day.to_r  * 1000).to_i / 1000.0)  <--- The Fix
=> 1464998399.999
```
Due to a rounding error with `.to_f`  

The fix ensures that the Time is truncated to milliseconds with no rounding error.