### PR TITLE
Fix issue #5846

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1629,7 +1629,7 @@ module.exports.connect = varar 0, 2, (hostOrCallback, callback) ->
         # Otherwise, the `callback` variable is already correctly
         # holding the callback, and the host variable is the first
         # argument
-        host = hostOrCallback
+        host = hostOrCallback || {}
 
     # `r.connect` returns a Promise which does the following:
     #


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Documented as `r.connect([options]) → promise`, but `options` is not optional, see #5846.