### PR TITLE
Making queries involving r.minval and other constants pickleable.

### DIFF
--- a/drivers/python/rethinkdb/query.py
+++ b/drivers/python/rethinkdb/query.py
@@ -266,29 +266,39 @@ class RqlConstant(ast.RqlQuery):
         return 'r.'+self.st
 
 # Time enum values
-monday      = type('monday', (RqlConstant,), {'tt':pTerm.MONDAY, 'st': 'monday'})()
-tuesday     = type('tuesday', (RqlConstant,), {'tt':pTerm.TUESDAY, 'st': 'tuesday'})()
-wednesday   = type('wednesday', (RqlConstant,), {'tt':pTerm.WEDNESDAY, 'st': 'wednesday'})()
-thursday    = type('thursday', (RqlConstant,), {'tt':pTerm.THURSDAY, 'st': 'thursday'})()
-friday      = type('friday', (RqlConstant,), {'tt':pTerm.FRIDAY, 'st': 'friday'})()
-saturday    = type('saturday', (RqlConstant,), {'tt':pTerm.SATURDAY, 'st': 'saturday'})()
-sunday      = type('sunday', (RqlConstant,), {'tt':pTerm.SUNDAY, 'st': 'sunday'})()
+_moduleSelf = globals()
+def _new_const(name, bases, members):
+    """To support the pickle protocol for queries, the types underlying each
+    constant must be available.  This utility function mitigates the creation
+    of a new type so that pickle works.
+    """
+    typName = '_{}Type'.format(name)
+    typ = type(typName, bases, members)
+    _moduleSelf[typName] = typ
+    return typ()
+monday      = _new_const('monday', (RqlConstant,), {'tt':pTerm.MONDAY, 'st': 'monday'})
+tuesday     = _new_const('tuesday', (RqlConstant,), {'tt':pTerm.TUESDAY, 'st': 'tuesday'})
+wednesday   = _new_const('wednesday', (RqlConstant,), {'tt':pTerm.WEDNESDAY, 'st': 'wednesday'})
+thursday    = _new_const('thursday', (RqlConstant,), {'tt':pTerm.THURSDAY, 'st': 'thursday'})
+friday      = _new_const('friday', (RqlConstant,), {'tt':pTerm.FRIDAY, 'st': 'friday'})
+saturday    = _new_const('saturday', (RqlConstant,), {'tt':pTerm.SATURDAY, 'st': 'saturday'})
+sunday      = _new_const('sunday', (RqlConstant,), {'tt':pTerm.SUNDAY, 'st': 'sunday'})
 
-january     = type('january', (RqlConstant,), {'tt':pTerm.JANUARY, 'st': 'january'})()
-february    = type('february', (RqlConstant,), {'tt':pTerm.FEBRUARY, 'st': 'february'})()
-march       = type('march', (RqlConstant,), {'tt': pTerm.MARCH, 'st': 'march'})()
-april       = type('april', (RqlConstant,), {'tt': pTerm.APRIL, 'st': 'april'})()
-may         = type('may', (RqlConstant,), {'tt': pTerm.MAY, 'st': 'may'})()
-june        = type('june', (RqlConstant,), {'tt': pTerm.JUNE, 'st': 'june'})()
-july        = type('july', (RqlConstant,), {'tt': pTerm.JULY, 'st': 'july'})()
-august      = type('august', (RqlConstant,), {'tt': pTerm.AUGUST, 'st': 'august'})()
-september   = type('september', (RqlConstant,), {'tt': pTerm.SEPTEMBER, 'st': 'september'})()
-october     = type('october', (RqlConstant,), {'tt': pTerm.OCTOBER, 'st': 'october'})()
-november    = type('november', (RqlConstant,), {'tt': pTerm.NOVEMBER, 'st': 'november'})()
-december    = type('december', (RqlConstant,), {'tt': pTerm.DECEMBER, 'st': 'december'})()
+january     = _new_const('january', (RqlConstant,), {'tt':pTerm.JANUARY, 'st': 'january'})
+february    = _new_const('february', (RqlConstant,), {'tt':pTerm.FEBRUARY, 'st': 'february'})
+march       = _new_const('march', (RqlConstant,), {'tt': pTerm.MARCH, 'st': 'march'})
+april       = _new_const('april', (RqlConstant,), {'tt': pTerm.APRIL, 'st': 'april'})
+may         = _new_const('may', (RqlConstant,), {'tt': pTerm.MAY, 'st': 'may'})
+june        = _new_const('june', (RqlConstant,), {'tt': pTerm.JUNE, 'st': 'june'})
+july        = _new_const('july', (RqlConstant,), {'tt': pTerm.JULY, 'st': 'july'})
+august      = _new_const('august', (RqlConstant,), {'tt': pTerm.AUGUST, 'st': 'august'})
+september   = _new_const('september', (RqlConstant,), {'tt': pTerm.SEPTEMBER, 'st': 'september'})
+october     = _new_const('october', (RqlConstant,), {'tt': pTerm.OCTOBER, 'st': 'october'})
+november    = _new_const('november', (RqlConstant,), {'tt': pTerm.NOVEMBER, 'st': 'november'})
+december    = _new_const('december', (RqlConstant,), {'tt': pTerm.DECEMBER, 'st': 'december'})
 
-minval      = type('minval', (RqlConstant,), {'tt': pTerm.MINVAL, 'st': 'minval'})()
-maxval      = type('maxval', (RqlConstant,), {'tt': pTerm.MAXVAL, 'st': 'maxval'})()
+minval      = _new_const('minval', (RqlConstant,), {'tt': pTerm.MINVAL, 'st': 'minval'})
+maxval      = _new_const('maxval', (RqlConstant,), {'tt': pTerm.MAXVAL, 'st': 'maxval'})
 
 
 def make_timezone(*args):

--- a/test/rql_test/test-runner
+++ b/test/rql_test/test-runner
@@ -1477,6 +1477,8 @@ def getTestList(rootPath, allowedLanguages, testFilters=None, shards=0):
                         testLanguages = [x for x in interpreters[lang] if x in allowedLanguages] or None
                         if single and testLanguages:
                             testLanguages = [testLanguages[0]]
+                        if testLanguages:
+                            testLanguages = set(testLanguages)
                 langSetsCache[testLangExtensions] = testLanguages
             
             elif extension in ('mocha', 'yaml'):


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
As part of a distributed batch-processing framework in Python, it can be convenient to form "root" queries for an application using RethinkDB and to pass those queries on to other servers that can modify or run them.  This allows the machines working with data from RethinkDB to request the data themselves, while a supervising system can distribute chunks of work that should go together.  For a setup like this to work, queries need to be pickle-able.  This pull request converts the constants in rethinkdb/query.py to a format that works with the pickle module.

Needs tests still, but I need guidance as for where those tests should go.