### PR TITLE
chore(packaging): speed up debian packaging by parallel builds

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -14,11 +14,11 @@ clean:
 install: build
 	dh_clean
 	dh_installdirs
-	$(MAKE) DEBUG=$(DEBUG) DESTDIR=$(CURDIR)/debian/$(package) PVERSION=$(PVERSION) STRIP_ON_INSTALL=0 install
+	$(MAKE) DEBUG=$(DEBUG) DESTDIR=$(CURDIR)/debian/$(package) PVERSION=$(PVERSION) STRIP_ON_INSTALL=0 -j`nproc` install
 
 build:
 	./configure
-	$(MAKE) DEBUG=$(DEBUG) PVERSION=$(PVERSION) VERBOSE=1 SYMBOLS=1
+	$(MAKE) DEBUG=$(DEBUG) PVERSION=$(PVERSION) VERBOSE=1 SYMBOLS=1 -j`nproc`
 	touch build
 
 binary-indep: install


### PR DESCRIPTION
- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
### Description

This speeds up debian packaging by adding j flags to the make steps
