### PR TITLE
Expunge evil boost::shared stuff.

### DIFF
--- a/src/client_protocol/server.hpp
+++ b/src/client_protocol/server.hpp
@@ -4,14 +4,11 @@
 
 #include <set>
 #include <map>
+#include <memory>
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include "arch/address.hpp"
 #include "arch/io/openssl.hpp"

--- a/src/clustering/administration/artificial_reql_cluster_interface.cc
+++ b/src/clustering/administration/artificial_reql_cluster_interface.cc
@@ -512,11 +512,11 @@ bool artificial_reql_cluster_interface_t::sindex_list(
 
 admin_artificial_tables_t::admin_artificial_tables_t(
         real_reql_cluster_interface_t *_next_reql_cluster_interface,
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t> >
             auth_semilattice_view,
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > _semilattice_view,
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             heartbeat_semilattice_metadata_t> > _heartbeat_view,
         clone_ptr_t< watchable_t< change_tracking_map_t<peer_id_t,
             cluster_directory_metadata_t> > > _directory_view,

--- a/src/clustering/administration/artificial_reql_cluster_interface.hpp
+++ b/src/clustering/administration/artificial_reql_cluster_interface.hpp
@@ -253,11 +253,11 @@ class admin_artificial_tables_t {
 public:
     admin_artificial_tables_t(
             real_reql_cluster_interface_t *_next_reql_cluster_interface,
-            boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t> >
+            std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t> >
                 auth_semilattice_view,
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 heartbeat_semilattice_metadata_t> > _heartbeat_view,
             clone_ptr_t< watchable_t< change_tracking_map_t<peer_id_t,
                 cluster_directory_metadata_t> > > _directory_view,

--- a/src/clustering/administration/auth/base_artificial_table_backend.hpp
+++ b/src/clustering/administration/auth/base_artificial_table_backend.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_AUTH_BASE_ARTIFICIAL_TABLE_BACKEND_HPP
 #define CLUSTERING_ADMINISTRATION_AUTH_BASE_ARTIFICIAL_TABLE_BACKEND_HPP
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/metadata.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
@@ -19,9 +17,9 @@ class base_artificial_table_backend_t :
 {
 public:
     base_artificial_table_backend_t(
-            boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+            std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
                 auth_semilattice_view,
-            boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+            std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
                 cluster_semilattice_view)
         : m_auth_semilattice_view(std::move(auth_semilattice_view)),
           m_auth_subscription([this](){ notify_all(); }, m_auth_semilattice_view),
@@ -37,11 +35,11 @@ public:
     }
 
 protected:
-    boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+    std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
         m_auth_semilattice_view;
     semilattice_read_view_t<auth_semilattice_metadata_t>::subscription_t
         m_auth_subscription;
-    boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+    std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
         m_cluster_semilattice_view;
 };
 

--- a/src/clustering/administration/auth/permissions_artificial_table_backend.cc
+++ b/src/clustering/administration/auth/permissions_artificial_table_backend.cc
@@ -9,9 +9,9 @@
 namespace auth {
 
 permissions_artificial_table_backend_t::permissions_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
             cluster_semilattice_view,
         table_meta_client_t *table_meta_client,
         admin_identifier_format_t identifier_format)

--- a/src/clustering/administration/auth/permissions_artificial_table_backend.hpp
+++ b/src/clustering/administration/auth/permissions_artificial_table_backend.hpp
@@ -11,9 +11,9 @@ class permissions_artificial_table_backend_t :
 {
 public:
     permissions_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
             cluster_semilattice_view,
         table_meta_client_t *table_meta_client,
         admin_identifier_format_t identifier_format);

--- a/src/clustering/administration/auth/users_artificial_table_backend.cc
+++ b/src/clustering/administration/auth/users_artificial_table_backend.cc
@@ -4,9 +4,9 @@
 namespace auth {
 
 users_artificial_table_backend_t::users_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
             cluster_semilattice_view)
     : base_artificial_table_backend_t(
         auth_semilattice_view,

--- a/src/clustering/administration/auth/users_artificial_table_backend.hpp
+++ b/src/clustering/administration/auth/users_artificial_table_backend.hpp
@@ -11,9 +11,9 @@ class users_artificial_table_backend_t :
 {
 public:
     users_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t>>
             cluster_semilattice_view);
 
     bool read_all_rows_as_vector(

--- a/src/clustering/administration/cluster_config.cc
+++ b/src/clustering/administration/cluster_config.cc
@@ -5,7 +5,7 @@
 #include "clustering/administration/datum_adapter.hpp"
 
 cluster_config_artificial_table_backend_t::cluster_config_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             heartbeat_semilattice_metadata_t> > _heartbeat_sl_view) :
     heartbeat_doc(_heartbeat_sl_view) {
     docs["heartbeat"] = &heartbeat_doc;

--- a/src/clustering/administration/cluster_config.hpp
+++ b/src/clustering/administration/cluster_config.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_CLUSTER_CONFIG_HPP_
 #define CLUSTERING_ADMINISTRATION_CLUSTER_CONFIG_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/metadata.hpp"
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
@@ -24,7 +22,7 @@ class cluster_config_artificial_table_backend_t :
 {
 public:
     cluster_config_artificial_table_backend_t(
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 heartbeat_semilattice_metadata_t> > _heartbeat_sl_view);
     ~cluster_config_artificial_table_backend_t();
 
@@ -75,7 +73,7 @@ private:
 
     class heartbeat_doc_t : public doc_t {
     public:
-        explicit heartbeat_doc_t(boost::shared_ptr<semilattice_readwrite_view_t<
+        explicit heartbeat_doc_t(std::shared_ptr<semilattice_readwrite_view_t<
             heartbeat_semilattice_metadata_t> > _sl_view) : sl_view(_sl_view) { }
         bool read(
                 signal_t *interruptor,
@@ -87,7 +85,7 @@ private:
                 admin_err_t *error_out);
         void set_notification_callback(const std::function<void()> &fun);
     private:
-        boost::shared_ptr<
+        std::shared_ptr<
             semilattice_readwrite_view_t<heartbeat_semilattice_metadata_t> > sl_view;
         scoped_ptr_t<
                 semilattice_read_view_t<heartbeat_semilattice_metadata_t>::subscription_t

--- a/src/clustering/administration/issues/issues_backend.cc
+++ b/src/clustering/administration/issues/issues_backend.cc
@@ -8,7 +8,7 @@
 
 issues_artificial_table_backend_t::issues_artificial_table_backend_t(
         mailbox_manager_t *mailbox_manager,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
             _cluster_sl_view,
         watchable_map_t<peer_id_t, cluster_directory_metadata_t> *directory_view,
         server_config_client_t *_server_config_client,

--- a/src/clustering/administration/issues/issues_backend.hpp
+++ b/src/clustering/administration/issues/issues_backend.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_ISSUES_ISSUES_BACKEND_HPP_
 #define CLUSTERING_ADMINISTRATION_ISSUES_ISSUES_BACKEND_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
 #include "clustering/administration/metadata.hpp"
@@ -25,7 +23,7 @@ class issues_artificial_table_backend_t :
 public:
     issues_artificial_table_backend_t(
         mailbox_manager_t *mailbox_manager,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
             _cluster_sl_view,
         watchable_map_t<peer_id_t, cluster_directory_metadata_t> *directory_view,
         server_config_client_t *server_config_client,
@@ -56,7 +54,7 @@ private:
 
     admin_identifier_format_t identifier_format;
 
-    boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+    std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
         cluster_sl_view;
 
     server_config_client_t *server_config_client;

--- a/src/clustering/administration/issues/name_collision.cc
+++ b/src/clustering/administration/issues/name_collision.cc
@@ -228,7 +228,7 @@ bool table_name_collision_issue_t::build_info_and_description(
 
 name_collision_issue_tracker_t::name_collision_issue_tracker_t(
             server_config_client_t *_server_config_client,
-            boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+            std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
                 _cluster_sl_view,
             table_meta_client_t *_table_meta_client) :
     server_config_client(_server_config_client),

--- a/src/clustering/administration/issues/name_collision.hpp
+++ b/src/clustering/administration/issues/name_collision.hpp
@@ -15,7 +15,7 @@ class name_collision_issue_tracker_t : public issue_tracker_t {
 public:
     name_collision_issue_tracker_t(
         server_config_client_t *_server_config_client,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
             _cluster_sl_view,
         table_meta_client_t *_table_meta_client);
 
@@ -25,7 +25,7 @@ public:
 
 private:
     server_config_client_t *server_config_client;
-    boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+    std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
         cluster_sl_view;
     table_meta_client_t *table_meta_client;
 

--- a/src/clustering/administration/jobs/backend.cc
+++ b/src/clustering/administration/jobs/backend.cc
@@ -12,7 +12,7 @@
 
 jobs_artificial_table_backend_t::jobs_artificial_table_backend_t(
         mailbox_manager_t *_mailbox_manager,
-        boost::shared_ptr< semilattice_readwrite_view_t<
+        std::shared_ptr< semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > _semilattice_view,
         const clone_ptr_t<watchable_t<change_tracking_map_t<
             peer_id_t, cluster_directory_metadata_t> > > &_directory_view,

--- a/src/clustering/administration/jobs/backend.hpp
+++ b/src/clustering/administration/jobs/backend.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_JOBS_BACKEND_HPP_
 #define CLUSTERING_ADMINISTRATION_JOBS_BACKEND_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
 #include "clustering/administration/metadata.hpp"
@@ -20,7 +18,7 @@ class jobs_artificial_table_backend_t :
 public:
     jobs_artificial_table_backend_t(
         mailbox_manager_t *_mailbox_manager,
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > _semilattice_view,
         const clone_ptr_t<watchable_t<change_tracking_map_t<
             peer_id_t, cluster_directory_metadata_t> > > &_directory_view,
@@ -53,7 +51,7 @@ private:
 
     mailbox_manager_t *mailbox_manager;
 
-    boost::shared_ptr< semilattice_readwrite_view_t<
+    std::shared_ptr< semilattice_readwrite_view_t<
         cluster_semilattice_metadata_t> > semilattice_view;
 
     clone_ptr_t<watchable_t<change_tracking_map_t<peer_id_t,

--- a/src/clustering/administration/main/memory_checker.hpp
+++ b/src/clustering/administration/main/memory_checker.hpp
@@ -4,9 +4,6 @@
 
 #include <functional>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "arch/runtime/coroutines.hpp"
 #include "arch/timing.hpp"
 #include "clustering/administration/issues/memory.hpp"

--- a/src/clustering/administration/main/version_check.hpp
+++ b/src/clustering/administration/main/version_check.hpp
@@ -4,9 +4,6 @@
 
 #include <functional>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "arch/runtime/coroutines.hpp"
 #include "arch/timing.hpp"
 #include "concurrency/auto_drainer.hpp"

--- a/src/clustering/administration/persist/semilattice.cc
+++ b/src/clustering/administration/persist/semilattice.cc
@@ -8,7 +8,7 @@ template <class metadata_t>
 semilattice_persister_t<metadata_t>::semilattice_persister_t(
         metadata_file_t *f,
         const metadata_file_t::key_t<metadata_t> &k,
-        boost::shared_ptr<semilattice_read_view_t<metadata_t> > v) :
+        std::shared_ptr<semilattice_read_view_t<metadata_t> > v) :
     file(f), key(k), view(v),
     persist_pumper(std::bind(&semilattice_persister_t::persist, this, ph::_1)),
     subs(std::bind(&pump_coro_t::notify, &persist_pumper), v)

--- a/src/clustering/administration/persist/semilattice.hpp
+++ b/src/clustering/administration/persist/semilattice.hpp
@@ -12,7 +12,7 @@ public:
     semilattice_persister_t(
         metadata_file_t *file,
         const metadata_file_t::key_t<metadata_t> &key,
-        boost::shared_ptr<semilattice_read_view_t<metadata_t> > view);
+        std::shared_ptr<semilattice_read_view_t<metadata_t> > view);
 
     /* `stop_and_flush()` finishes flushing the current value to disk but stops
     responding to future changes. It's usually called right before the
@@ -27,7 +27,7 @@ private:
 
     metadata_file_t * const file;
     metadata_file_t::key_t<metadata_t> const key;
-    boost::shared_ptr<semilattice_read_view_t<metadata_t> > const view;
+    std::shared_ptr<semilattice_read_view_t<metadata_t> > const view;
 
     pump_coro_t persist_pumper;
 

--- a/src/clustering/administration/real_reql_cluster_interface.cc
+++ b/src/clustering/administration/real_reql_cluster_interface.cc
@@ -22,9 +22,9 @@
 
 real_reql_cluster_interface_t::real_reql_cluster_interface_t(
         mailbox_manager_t *mailbox_manager,
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             auth_semilattice_metadata_t> > auth_semilattice_view,
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > cluster_semilattice_view,
         rdb_context_t *rdb_context,
         server_config_client_t *server_config_client,
@@ -1060,7 +1060,7 @@ bool is_joined(const T &multiple, const T &divisor) {
 
 template <typename T>
 bool grant_internal(
-        boost::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_readwrite_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
         rdb_context_t *rdb_context,
         auth::user_context_t const &user_context,

--- a/src/clustering/administration/real_reql_cluster_interface.hpp
+++ b/src/clustering/administration/real_reql_cluster_interface.hpp
@@ -30,9 +30,9 @@ class real_reql_cluster_interface_t :
 public:
     real_reql_cluster_interface_t(
             mailbox_manager_t *mailbox_manager,
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 auth_semilattice_metadata_t> > auth_semilattice_view,
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > cluster_semilattice_view,
             rdb_context_t *rdb_context,
             server_config_client_t *server_config_client,
@@ -256,9 +256,9 @@ public:
 
 private:
     mailbox_manager_t *m_mailbox_manager;
-    boost::shared_ptr<semilattice_readwrite_view_t<
+    std::shared_ptr<semilattice_readwrite_view_t<
         auth_semilattice_metadata_t> > m_auth_semilattice_view;
-    boost::shared_ptr<semilattice_readwrite_view_t<
+    std::shared_ptr<semilattice_readwrite_view_t<
         cluster_semilattice_metadata_t> > m_cluster_semilattice_view;
     table_meta_client_t *m_table_meta_client;
     scoped_array_t< scoped_ptr_t< cross_thread_watchable_variable_t<

--- a/src/clustering/administration/servers/auto_reconnect.hpp
+++ b/src/clustering/administration/servers/auto_reconnect.hpp
@@ -5,9 +5,6 @@
 #include <map>
 #include <utility>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "clustering/administration/servers/server_metadata.hpp"
 #include "concurrency/watchable.hpp"
 #include "containers/incremental_lenses.hpp"

--- a/src/clustering/administration/servers/server_common.hpp
+++ b/src/clustering/administration/servers/server_common.hpp
@@ -5,9 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "clustering/administration/tables/database_metadata.hpp"
 #include "clustering/administration/tables/table_metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"

--- a/src/clustering/administration/servers/server_config.hpp
+++ b/src/clustering/administration/servers/server_config.hpp
@@ -5,9 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "clustering/administration/servers/server_common.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"
 #include "rdb_protocol/artificial_table/backend.hpp"

--- a/src/clustering/administration/servers/server_status.hpp
+++ b/src/clustering/administration/servers/server_status.hpp
@@ -5,9 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/server_common.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"

--- a/src/clustering/administration/stats/debug_stats_backend.hpp
+++ b/src/clustering/administration/stats/debug_stats_backend.hpp
@@ -5,9 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
-
 #include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/server_common.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"

--- a/src/clustering/administration/stats/stats_backend.cc
+++ b/src/clustering/administration/stats/stats_backend.cc
@@ -9,7 +9,7 @@ stats_artificial_table_backend_t::stats_artificial_table_backend_t(
         const clone_ptr_t<watchable_t<change_tracking_map_t<peer_id_t,
             cluster_directory_metadata_t> > >
                 &_directory_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
             _cluster_sl_view,
         server_config_client_t *_server_config_client,
         table_meta_client_t *_table_meta_client,

--- a/src/clustering/administration/stats/stats_backend.hpp
+++ b/src/clustering/administration/stats/stats_backend.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_STATS_STATS_BACKEND_HPP_
 #define CLUSTERING_ADMINISTRATION_STATS_STATS_BACKEND_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
 #include "clustering/administration/metadata.hpp"
@@ -21,7 +19,7 @@ public:
         const clone_ptr_t<watchable_t<change_tracking_map_t<peer_id_t,
             cluster_directory_metadata_t> > >
                 &_directory_view,
-        boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
             _cluster_sl_view,
         server_config_client_t *_server_config_client,
         table_meta_client_t *_table_meta_client,
@@ -59,7 +57,7 @@ private:
 
     clone_ptr_t<watchable_t<change_tracking_map_t<peer_id_t,
         cluster_directory_metadata_t> > > directory_view;
-    boost::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
+    std::shared_ptr<semilattice_read_view_t<cluster_semilattice_metadata_t> >
         cluster_sl_view;
     server_config_client_t *server_config_client;
     table_meta_client_t *table_meta_client;

--- a/src/clustering/administration/tables/db_config.cc
+++ b/src/clustering/administration/tables/db_config.cc
@@ -55,7 +55,7 @@ bool convert_db_config_and_name_from_datum(
 }
 
 db_config_artificial_table_backend_t::db_config_artificial_table_backend_t(
-        boost::shared_ptr< semilattice_readwrite_view_t<
+        std::shared_ptr< semilattice_readwrite_view_t<
         databases_semilattice_metadata_t> > _database_sl_view,
         real_reql_cluster_interface_t *_reql_cluster_interface) :
     database_sl_view(_database_sl_view),

--- a/src/clustering/administration/tables/db_config.hpp
+++ b/src/clustering/administration/tables/db_config.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_DB_CONFIG_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_DB_CONFIG_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/tables/database_metadata.hpp"
 #include "containers/uuid.hpp"
@@ -27,7 +25,7 @@ class db_config_artificial_table_backend_t :
 {
 public:
     db_config_artificial_table_backend_t(
-            boost::shared_ptr< semilattice_readwrite_view_t<
+            std::shared_ptr< semilattice_readwrite_view_t<
             databases_semilattice_metadata_t> > _database_sl_view,
             real_reql_cluster_interface_t *_reql_cluster_interface);
     ~db_config_artificial_table_backend_t();
@@ -53,7 +51,7 @@ public:
             admin_err_t *error_out);
 
 private:
-    boost::shared_ptr< semilattice_readwrite_view_t<
+    std::shared_ptr< semilattice_readwrite_view_t<
         databases_semilattice_metadata_t> > database_sl_view;
     semilattice_read_view_t<databases_semilattice_metadata_t>::subscription_t subs;
     real_reql_cluster_interface_t *reql_cluster_interface;

--- a/src/clustering/administration/tables/debug_table_status.cc
+++ b/src/clustering/administration/tables/debug_table_status.cc
@@ -18,7 +18,7 @@ ql::datum_t sindex_status_to_datum(
 
 debug_table_status_artificial_table_backend_t::
                 debug_table_status_artificial_table_backend_t(
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
             table_meta_client_t *_table_meta_client) :
         common_table_artificial_table_backend_t(

--- a/src/clustering/administration/tables/debug_table_status.hpp
+++ b/src/clustering/administration/tables/debug_table_status.hpp
@@ -2,10 +2,8 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_DEBUG_TABLE_STATUS_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_DEBUG_TABLE_STATUS_HPP_
 
+#include <memory>
 #include <string>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/tables/table_common.hpp"
 
@@ -16,7 +14,7 @@ class debug_table_status_artificial_table_backend_t :
 {
 public:
     debug_table_status_artificial_table_backend_t(
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
             table_meta_client_t *_table_meta_client);
     ~debug_table_status_artificial_table_backend_t();

--- a/src/clustering/administration/tables/table_common.cc
+++ b/src/clustering/administration/tables/table_common.cc
@@ -7,7 +7,7 @@
 #include "concurrency/cross_thread_signal.hpp"
 
 common_table_artificial_table_backend_t::common_table_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > _semilattice_view,
         table_meta_client_t *_table_meta_client,
         admin_identifier_format_t _identifier_format) :

--- a/src/clustering/administration/tables/table_common.hpp
+++ b/src/clustering/administration/tables/table_common.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_TABLE_COMMON_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_TABLE_COMMON_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/admin_op_exc.hpp"
 #include "clustering/administration/metadata.hpp"
@@ -21,7 +19,7 @@ class common_table_artificial_table_backend_t :
 {
 public:
     common_table_artificial_table_backend_t(
-            boost::shared_ptr< semilattice_readwrite_view_t<
+            std::shared_ptr< semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
             table_meta_client_t *_table_meta_client,
             admin_identifier_format_t _identifier_format);
@@ -62,7 +60,7 @@ protected:
             const name_string_t &table_name,
             ql::datum_t *row_out);
 
-    boost::shared_ptr< semilattice_readwrite_view_t<
+    std::shared_ptr< semilattice_readwrite_view_t<
         cluster_semilattice_metadata_t> > semilattice_view;
     table_meta_client_t *table_meta_client;
     admin_identifier_format_t identifier_format;

--- a/src/clustering/administration/tables/table_config.hpp
+++ b/src/clustering/administration/tables/table_config.hpp
@@ -2,11 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_TABLE_CONFIG_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_TABLE_CONFIG_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/servers/config_client.hpp"
 #include "clustering/administration/tables/table_common.hpp"
@@ -30,7 +28,7 @@ class table_config_artificial_table_backend_t :
 {
 public:
     table_config_artificial_table_backend_t(
-            boost::shared_ptr< semilattice_readwrite_view_t<
+            std::shared_ptr< semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
             real_reql_cluster_interface_t *_reql_cluster_interface,
             admin_identifier_format_t _identifier_format,

--- a/src/clustering/administration/tables/table_status.cc
+++ b/src/clustering/administration/tables/table_status.cc
@@ -9,7 +9,7 @@
 #include "clustering/table_manager/table_meta_client.hpp"
 
 table_status_artificial_table_backend_t::table_status_artificial_table_backend_t(
-        boost::shared_ptr<semilattice_readwrite_view_t<
+        std::shared_ptr<semilattice_readwrite_view_t<
             cluster_semilattice_metadata_t> > _semilattice_view,
         server_config_client_t *_server_config_client,
         table_meta_client_t *_table_meta_client,

--- a/src/clustering/administration/tables/table_status.hpp
+++ b/src/clustering/administration/tables/table_status.hpp
@@ -2,10 +2,8 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_TABLE_STATUS_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_TABLE_STATUS_HPP_
 
+#include <memory>
 #include <string>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 
 #include "clustering/administration/tables/calculate_status.hpp"
 #include "clustering/administration/tables/table_common.hpp"
@@ -22,7 +20,7 @@ class table_status_artificial_table_backend_t :
 {
 public:
     table_status_artificial_table_backend_t(
-            boost::shared_ptr<semilattice_readwrite_view_t<
+            std::shared_ptr<semilattice_readwrite_view_t<
                 cluster_semilattice_metadata_t> > _semilattice_view,
             server_config_client_t *server_config_client,
             table_meta_client_t *_table_meta_client,

--- a/src/concurrency/watchable.tcc
+++ b/src/concurrency/watchable.tcc
@@ -2,9 +2,7 @@
 #include "concurrency/watchable.hpp"
 
 #include <functional>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "arch/timing.hpp"
 #include "concurrency/cond_var.hpp"
@@ -111,14 +109,14 @@ private:
         typename watchable_t<outer_type>::subscription_t parent_subscription;
     };
 
-    explicit subview_watchable_t(const boost::shared_ptr<lensed_value_cache_t> &_cache) :
+    explicit subview_watchable_t(const std::shared_ptr<lensed_value_cache_t> &_cache) :
         cache(_cache) { }
 
     // If you clone a subview_watchable_t, all clones share the same cache.
     // As a consequence, the lens is only applied once for the whole family
     // of clones, not once per instance of subview_watchable_t. This should save
     // some CPU and memory as well.
-    boost::shared_ptr<lensed_value_cache_t> cache;
+    std::shared_ptr<lensed_value_cache_t> cache;
 };
 
 /* Given a non-incremental lens with the type signature

--- a/src/containers/archive/boost_types.hpp
+++ b/src/containers/archive/boost_types.hpp
@@ -4,7 +4,6 @@
 
 #include "errors.hpp"
 #include <boost/logic/tribool.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 

--- a/src/extproc/js_job.cc
+++ b/src/extproc/js_job.cc
@@ -130,10 +130,10 @@ public:
 
 private:
     js_id_t remember_value(const v8::Handle<v8::Value> &value);
-    const boost::shared_ptr<persistent_value_t> find_value(js_id_t id);
+    const std::shared_ptr<persistent_value_t> find_value(js_id_t id);
 
     js_id_t next_id;
-    std::map<js_id_t, boost::shared_ptr<persistent_value_t> > values;
+    std::map<js_id_t, std::shared_ptr<persistent_value_t> > values;
 };
 
 // Cleans the worker process's environment when instantiated
@@ -474,15 +474,15 @@ js_id_t js_env_t::remember_value(const v8::Handle<v8::Value> &value) {
     // Save this value in a persistent handle so it isn't deallocated when
     // its scope is destructed.
 
-    boost::shared_ptr<persistent_value_t> persistent_handle(new persistent_value_t());
+    std::shared_ptr<persistent_value_t> persistent_handle(new persistent_value_t());
     persistent_handle->value.Reset(js_instance_t::isolate(), value);
 
     values.insert(std::make_pair(id, persistent_handle));
     return id;
 }
 
-const boost::shared_ptr<persistent_value_t> js_env_t::find_value(js_id_t id) {
-    std::map<js_id_t, boost::shared_ptr<persistent_value_t> >::iterator it = values.find(id);
+const std::shared_ptr<persistent_value_t> js_env_t::find_value(js_id_t id) {
+    std::map<js_id_t, std::shared_ptr<persistent_value_t> >::iterator it = values.find(id);
     guarantee(it != values.end());
     return it->second;
 }
@@ -523,7 +523,7 @@ js_result_t js_env_t::call(js_id_t id,
     js_result_t result("");
     std::string *err_out = boost::get<std::string>(&result);
 
-    const boost::shared_ptr<persistent_value_t> found_value = find_value(id);
+    const std::shared_ptr<persistent_value_t> found_value = find_value(id);
     guarantee(!found_value->value.IsEmpty());
 
     v8::Isolate *isolate = js_instance_t::isolate();

--- a/src/extproc/js_job.hpp
+++ b/src/extproc/js_job.hpp
@@ -2,11 +2,8 @@
 #ifndef EXTPROC_JS_JOB_HPP_
 #define EXTPROC_JS_JOB_HPP_
 
-#include <vector>
 #include <string>
-
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
+#include <vector>
 
 #include "utils.hpp"
 #include "containers/archive/archive.hpp"

--- a/src/extproc/js_runner.hpp
+++ b/src/extproc/js_runner.hpp
@@ -7,7 +7,6 @@
 #include <set>
 
 #include "errors.hpp"
-#include <boost/make_shared.hpp>
 #include <boost/variant.hpp>
 
 #include "containers/scoped.hpp"

--- a/src/http/http.cc
+++ b/src/http/http.cc
@@ -26,11 +26,15 @@ http_req_t::resource_t::resource_t(const http_req_t::resource_t &from, const htt
 }
 
 http_req_t::resource_t::resource_t(const std::string &_val) {
-    if (!assign(_val)) throw std::invalid_argument(_val);
+    if (!assign(_val)) {
+        throw std::invalid_argument(_val);
+    }
 }
 
 http_req_t::resource_t::resource_t(const char * _val, size_t size) {
-    if (!assign(_val, size)) throw std::invalid_argument(_val);
+    if (!assign(_val, size)) {
+        throw std::invalid_argument(_val);
+    }
 }
 
 // Returns false if the assignment fails.
@@ -40,7 +44,9 @@ MUST_USE bool http_req_t::resource_t::assign(const std::string &_val) {
 
 // Returns false if the assignment fails.
 MUST_USE bool http_req_t::resource_t::assign(const char * _val, size_t size) {
-    if (!(size > 0 && _val[0] == resource_parts_sep_char[0])) return false;
+    if (!(size > 0 && _val[0] == resource_parts_sep_char[0])) {
+        return false;
+    }
     val.reset(new char[size]);
     memcpy(val.get(), _val, size);
     val_size = size;

--- a/src/http/http.cc
+++ b/src/http/http.cc
@@ -22,7 +22,7 @@ http_req_t::resource_t::resource_t() {
 }
 
 http_req_t::resource_t::resource_t(const http_req_t::resource_t &from, const http_req_t::resource_t::iterator& resource_start)
-    : val(from.val), val_size(from.val_size), b(resource_start), e(from.e) {
+    : val(from.val), b(resource_start), e(from.e) {
 }
 
 http_req_t::resource_t::resource_t(const std::string &_val) {
@@ -47,12 +47,12 @@ MUST_USE bool http_req_t::resource_t::assign(const char * _val, size_t size) {
     if (!(size > 0 && _val[0] == resource_parts_sep_char[0])) {
         return false;
     }
-    val.reset(new char[size]);
-    memcpy(val.get(), _val, size);
-    val_size = size;
+    counted_t<shared_buf_t> buf = shared_buf_t::create(size);
+    memcpy(buf->data(), _val, size);
+    val = std::move(buf);
 
     // We skip the first '/' when we initialize tokenizer, otherwise we'll get an empty token out of it first.
-    tokenizer t(val.get() + 1, val.get() + size, resource_parts_sep);
+    tokenizer t(val->data() + 1, val->data() + size, resource_parts_sep);
     b = t.begin();
     e = t.end();
     return true;
@@ -72,9 +72,9 @@ std::string http_req_t::resource_t::as_string(const http_req_t::resource_t::iter
     } else {
         // -1 for the '/' before the token start
         const char* sub_resource = token_start_position(it) - 1;
-        guarantee(sub_resource >= val.get() && sub_resource < val.get() + val_size);
+        guarantee(sub_resource >= val->data() && sub_resource < val->data() + val->size());
 
-        size_t sub_resource_len = val_size - (sub_resource - val.get());
+        size_t sub_resource_len = val->size() - (sub_resource - val->data());
         return std::string(sub_resource, sub_resource_len);
     }
 }
@@ -85,7 +85,7 @@ std::string http_req_t::resource_t::as_string() const {
 
 const char* http_req_t::resource_t::token_start_position(const http_req_t::resource_t::iterator& it) const {
     if (it == e) {
-        return val.get() + val_size;
+        return val->data() + val->size();
     } else {
         // Ugh, this is quite awful, but boost tokenizer iterator can't give us the pointer to the beginning of the data.
         //

--- a/src/http/http.hpp
+++ b/src/http/http.hpp
@@ -10,14 +10,13 @@
 
 #include "errors.hpp"
 #include <boost/tokenizer.hpp>
-#include <boost/shared_array.hpp>
 #include <boost/optional.hpp>
 
 #include "arch/address.hpp"
 #include "arch/io/openssl.hpp"
 #include "arch/types.hpp"
 #include "concurrency/auto_drainer.hpp"
-#include "containers/scoped.hpp"
+#include "containers/shared_buffer.hpp"
 #include "parsing/util.hpp"
 
 enum class http_method_t {
@@ -35,7 +34,7 @@ enum class http_method_t {
 struct http_req_t {
     class resource_t {
     public:
-        typedef boost::tokenizer<boost::char_separator<char>, char *> tokenizer;
+        typedef boost::tokenizer<boost::char_separator<char>, const char *> tokenizer;
         typedef tokenizer::iterator iterator;
 
         resource_t();
@@ -55,8 +54,7 @@ struct http_req_t {
         // This function returns a pointer to the beginning of the token (without the leading '/')
         const char* token_start_position(const iterator& it) const;
 
-        boost::shared_array<char> val;
-        size_t val_size;
+        counted_t<const shared_buf_t> val;
         iterator b;
         iterator e;
     } resource;

--- a/src/rdb_protocol/context.cc
+++ b/src/rdb_protocol/context.cc
@@ -64,7 +64,7 @@ rdb_context_t::rdb_context_t()
 rdb_context_t::rdb_context_t(
         extproc_pool_t *_extproc_pool,
         reql_cluster_interface_t *_cluster_interface,
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view)
     : extproc_pool(_extproc_pool),
       cluster_interface(_cluster_interface),
@@ -78,7 +78,7 @@ rdb_context_t::rdb_context_t(
         extproc_pool_t *_extproc_pool,
         mailbox_manager_t *_mailbox_manager,
         reql_cluster_interface_t *_cluster_interface,
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
         perfmon_collection_t *global_stats,
         const std::string &_reql_http_proxy)
@@ -91,7 +91,7 @@ rdb_context_t::rdb_context_t(
 }
 
 void rdb_context_t::init_auth_watchables(
-    boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+    std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
         auth_semilattice_view) {
     for (int thread = 0; thread < get_num_threads(); ++thread) {
         m_cross_thread_auth_watchables.emplace_back(

--- a/src/rdb_protocol/context.hpp
+++ b/src/rdb_protocol/context.hpp
@@ -3,13 +3,13 @@
 #define RDB_PROTOCOL_CONTEXT_HPP_
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
 #include "errors.hpp"
 #include <boost/optional.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include "concurrency/one_per_thread.hpp"
 #include "concurrency/promise.hpp"
@@ -424,7 +424,7 @@ public:
     // Also used by unit tests.
     rdb_context_t(extproc_pool_t *_extproc_pool,
                   reql_cluster_interface_t *_cluster_interface,
-                  boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+                  std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
                       auth_semilattice_view);
 
     // The "real" constructor used outside of unit tests.
@@ -432,7 +432,7 @@ public:
         extproc_pool_t *_extproc_pool,
         mailbox_manager_t *_mailbox_manager,
         reql_cluster_interface_t *_cluster_interface,
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view,
         perfmon_collection_t *global_stats,
         const std::string &_reql_http_proxy);
@@ -470,7 +470,7 @@ public:
 
 private:
     void init_auth_watchables(
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t>>
             auth_semilattice_view);
 
     std::vector<std::unique_ptr<cross_thread_watchable_variable_t<

--- a/src/rdb_protocol/protocol.hpp
+++ b/src/rdb_protocol/protocol.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "errors.hpp"
-#include <boost/shared_ptr.hpp>
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -220,9 +220,9 @@ connectivity_cluster_t::run_t::run_t(
         const int join_delay_secs,
         int port,
         int client_port,
-        boost::shared_ptr<semilattice_read_view_t<heartbeat_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<heartbeat_semilattice_metadata_t> >
             _heartbeat_sl_view,
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t> >
             _auth_sl_view,
         tls_ctx_t *_tls_ctx)
         THROWS_ONLY(address_in_use_exc_t, tcp_socket_exc_t) :

--- a/src/rpc/connectivity/cluster.hpp
+++ b/src/rpc/connectivity/cluster.hpp
@@ -190,9 +190,9 @@ public:
               const int join_delay_secs,
               int port,
               int client_port,
-              boost::shared_ptr<semilattice_read_view_t<
+              std::shared_ptr<semilattice_read_view_t<
                   heartbeat_semilattice_metadata_t> > heartbeat_sl_view,
-              boost::shared_ptr<semilattice_read_view_t<
+              std::shared_ptr<semilattice_read_view_t<
                   auth_semilattice_metadata_t> > auth_sl_view,
               tls_ctx_t *tls_ctx)
             THROWS_ONLY(address_in_use_exc_t, tcp_socket_exc_t);
@@ -312,10 +312,10 @@ public:
         /* For picking random threads */
         rng_t rng;
 
-        boost::shared_ptr<semilattice_read_view_t<heartbeat_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<heartbeat_semilattice_metadata_t> >
             heartbeat_sl_view;
 
-        boost::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t> >
+        std::shared_ptr<semilattice_read_view_t<auth_semilattice_metadata_t> >
             auth_sl_view;
 
         auto_drainer_t drainer;

--- a/src/rpc/directory/read_manager.hpp
+++ b/src/rpc/directory/read_manager.hpp
@@ -3,9 +3,7 @@
 #define RPC_DIRECTORY_READ_MANAGER_HPP_
 
 #include <map>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "concurrency/auto_drainer.hpp"
 #include "concurrency/fifo_enforcer.hpp"
@@ -54,11 +52,11 @@ private:
 
     They assume ownership of `new_value`. Semantically, the argument here is `metadata_t
     &&new_value` but we cannot easily pass that through to the coroutine call, which is
-    why we use `boost::shared_ptr` instead. */
+    why we use `std::shared_ptr` instead. */
     void handle_connection(
             connectivity_cluster_t::connection_t *connection,
             auto_drainer_t::lock_t connection_keepalive,
-            const boost::shared_ptr<metadata_t> &new_value,
+            const std::shared_ptr<metadata_t> &new_value,
             fifo_enforcer_state_t metadata_fifo_state,
             auto_drainer_t::lock_t per_thread_keepalive)
             THROWS_NOTHING;
@@ -66,7 +64,7 @@ private:
     void propagate_update(
             connectivity_cluster_t::connection_t *connection,
             auto_drainer_t::lock_t connection_keepalive,
-            const boost::shared_ptr<metadata_t> &new_value,
+            const std::shared_ptr<metadata_t> &new_value,
             fifo_enforcer_write_token_t metadata_fifo_token,
             auto_drainer_t::lock_t per_thread_keepalive)
             THROWS_NOTHING;

--- a/src/rpc/directory/read_manager.tcc
+++ b/src/rpc/directory/read_manager.tcc
@@ -50,7 +50,7 @@ void directory_read_manager_t<metadata_t>::on_message(
     switch (code) {
         case 'I': {
             /* Initial message from another peer */
-            boost::shared_ptr<metadata_t> initial_value(new metadata_t());
+            std::shared_ptr<metadata_t> initial_value(new metadata_t());
             fifo_enforcer_state_t metadata_fifo_state;
             {
                 archive_result_t res =
@@ -73,7 +73,7 @@ void directory_read_manager_t<metadata_t>::on_message(
 
         case 'U': {
             /* Update from another peer */
-            boost::shared_ptr<metadata_t> new_value(new metadata_t());
+            std::shared_ptr<metadata_t> new_value(new metadata_t());
             fifo_enforcer_write_token_t metadata_fifo_token;
             {
                 archive_result_t res =
@@ -102,7 +102,7 @@ template<class metadata_t>
 void directory_read_manager_t<metadata_t>::handle_connection(
         connectivity_cluster_t::connection_t *connection,
         auto_drainer_t::lock_t connection_keepalive,
-        const boost::shared_ptr<metadata_t> &new_value,
+        const std::shared_ptr<metadata_t> &new_value,
         fifo_enforcer_state_t metadata_fifo_state,
         auto_drainer_t::lock_t per_thread_keepalive)
         THROWS_NOTHING
@@ -176,7 +176,7 @@ template<class metadata_t>
 void directory_read_manager_t<metadata_t>::propagate_update(
         connectivity_cluster_t::connection_t *connection,
         auto_drainer_t::lock_t connection_keepalive,
-        const boost::shared_ptr<metadata_t> &new_value,
+        const std::shared_ptr<metadata_t> &new_value,
         fifo_enforcer_write_token_t metadata_fifo_token,
         auto_drainer_t::lock_t per_thread_keepalive)
         THROWS_NOTHING

--- a/src/rpc/directory/write_manager.hpp
+++ b/src/rpc/directory/write_manager.hpp
@@ -3,9 +3,7 @@
 #define RPC_DIRECTORY_WRITE_MANAGER_HPP_
 
 #include <map>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "concurrency/auto_drainer.hpp"
 #include "concurrency/fifo_enforcer.hpp"

--- a/src/rpc/semilattice/semilattice_manager.hpp
+++ b/src/rpc/semilattice/semilattice_manager.hpp
@@ -43,7 +43,7 @@ public:
                           const metadata_t &initial_metadata);
     ~semilattice_manager_t() THROWS_NOTHING;
 
-    boost::shared_ptr<semilattice_readwrite_view_t<metadata_t> > get_root_view();
+    std::shared_ptr<semilattice_readwrite_view_t<metadata_t> > get_root_view();
 
 private:
     typedef uint64_t metadata_version_t, sync_from_query_id_t, sync_to_query_id_t;
@@ -77,7 +77,7 @@ private:
     void join_metadata_locally(metadata_t);
     void wait_for_version_from_peer(peer_id_t peer, metadata_version_t version, signal_t *interruptor) THROWS_ONLY(interrupted_exc_t, sync_failed_exc_t);
 
-    const boost::shared_ptr<root_view_t> root_view;
+    const std::shared_ptr<root_view_t> root_view;
 
     metadata_version_t metadata_version;
     metadata_t metadata;

--- a/src/rpc/semilattice/semilattice_manager.tcc
+++ b/src/rpc/semilattice/semilattice_manager.tcc
@@ -3,11 +3,9 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <set>
 #include <utility>
-
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
 
 #include "concurrency/cross_thread_signal.hpp"
 #include "concurrency/pmap.hpp"
@@ -24,7 +22,7 @@ semilattice_manager_t<metadata_t>::semilattice_manager_t(
         connectivity_cluster_t::message_tag_t message_tag,
         const metadata_t &initial_metadata) :
     cluster_message_handler_t(_connectivity_cluster, message_tag),
-    root_view(boost::make_shared<root_view_t>(this)),
+    root_view(std::make_shared<root_view_t>(this)),
     metadata_version(0),
     metadata(initial_metadata),
     next_sync_from_query_id(0), next_sync_to_query_id(0),
@@ -44,7 +42,7 @@ semilattice_manager_t<metadata_t>::~semilattice_manager_t() THROWS_NOTHING {
 }
 
 template<class metadata_t>
-boost::shared_ptr<semilattice_readwrite_view_t<metadata_t> > semilattice_manager_t<metadata_t>::get_root_view() {
+std::shared_ptr<semilattice_readwrite_view_t<metadata_t> > semilattice_manager_t<metadata_t>::get_root_view() {
     assert_thread();
     return root_view;
 }

--- a/src/rpc/semilattice/view.hpp
+++ b/src/rpc/semilattice/view.hpp
@@ -2,8 +2,7 @@
 #ifndef RPC_SEMILATTICE_VIEW_HPP_
 #define RPC_SEMILATTICE_VIEW_HPP_
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "concurrency/interruptor.hpp"
 #include "concurrency/pubsub.hpp"
@@ -41,10 +40,10 @@ public:
     class subscription_t {
     public:
         explicit subscription_t(std::function<void()> cb) : subs(cb) { }
-        subscription_t(std::function<void()> cb, boost::shared_ptr<semilattice_read_view_t> v) : subs(cb) {
+        subscription_t(std::function<void()> cb, std::shared_ptr<semilattice_read_view_t> v) : subs(cb) {
             reset(v);
         }
-        void reset(boost::shared_ptr<semilattice_read_view_t> v) {
+        void reset(std::shared_ptr<semilattice_read_view_t> v) {
             subs.reset(v->get_publisher());
             view = v;
         }
@@ -55,7 +54,7 @@ public:
     private:
         /* Hold a pointer to the `semilattice_read_view_t` so it doesn't die while
         we are subscribed to it */
-        boost::shared_ptr<semilattice_read_view_t> view;
+        std::shared_ptr<semilattice_read_view_t> view;
         publisher_t<std::function<void()> >::subscription_t subs;
     };
 

--- a/src/rpc/semilattice/view/field.hpp
+++ b/src/rpc/semilattice/view/field.hpp
@@ -2,8 +2,7 @@
 #ifndef RPC_SEMILATTICE_VIEW_FIELD_HPP_
 #define RPC_SEMILATTICE_VIEW_FIELD_HPP_
 
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "rpc/semilattice/view.hpp"
 
@@ -15,21 +14,21 @@ field on another metadata view. Example:
         double x, y;
     };
 
-    boost::shared_ptr<semilattice_readwrite_view_t<point_t> > point_view =
+    std::shared_ptr<semilattice_readwrite_view_t<point_t> > point_view =
         get_a_view_from_somewhere();
-    boost::shared_ptr<semilattice_readwrite_view_t<double> > x_view =
+    std::shared_ptr<semilattice_readwrite_view_t<double> > x_view =
         metadata_field(&point_t::x, point_view);
 */
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_read_view_t<inner_t> > metadata_field(
+std::shared_ptr<semilattice_read_view_t<inner_t> > metadata_field(
         inner_t outer_t::*field,
-        boost::shared_ptr<semilattice_read_view_t<outer_t> > outer);
+        std::shared_ptr<semilattice_read_view_t<outer_t> > outer);
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_field(
+std::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_field(
         inner_t outer_t::*field,
-        boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer);
+        std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer);
 
 #include "rpc/semilattice/view/field.tcc"
 

--- a/src/rpc/semilattice/view/field.tcc
+++ b/src/rpc/semilattice/view/field.tcc
@@ -1,8 +1,7 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "rpc/semilattice/view/field.hpp"
 
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
+#include <memory>
 
 /* `semilattice_field_read_view_t` is a `semilattice_read_view_t` that corresponds to
 some sub-field of another `semilattice_read_view_t`. Pass the field to the
@@ -12,7 +11,7 @@ template<class outer_t, class inner_t>
 class semilattice_field_read_view_t : public semilattice_read_view_t<inner_t> {
 
 public:
-    semilattice_field_read_view_t(inner_t outer_t::*f, boost::shared_ptr<semilattice_read_view_t<outer_t> > o) :
+    semilattice_field_read_view_t(inner_t outer_t::*f, std::shared_ptr<semilattice_read_view_t<outer_t> > o) :
         field(f), outer(o) { }
 
     inner_t get() {
@@ -39,7 +38,7 @@ public:
 
 private:
     inner_t outer_t::*field;
-    boost::shared_ptr<semilattice_read_view_t<outer_t> > outer;
+    std::shared_ptr<semilattice_read_view_t<outer_t> > outer;
 };
 
 /* A `semilattice_field_readwrite_view_t` is like a `semilattice_field_read_view_t`
@@ -49,7 +48,7 @@ template<class outer_t, class inner_t>
 class semilattice_field_readwrite_view_t : public semilattice_readwrite_view_t<inner_t> {
 
 public:
-    semilattice_field_readwrite_view_t(inner_t outer_t::*f, boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > o) :
+    semilattice_field_readwrite_view_t(inner_t outer_t::*f, std::shared_ptr<semilattice_readwrite_view_t<outer_t> > o) :
         field(f), outer(o) { }
 
     inner_t get() {
@@ -77,25 +76,25 @@ public:
 
 private:
     inner_t outer_t::*field;
-    boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer;
+    std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer;
 };
 
 /* Convenient wrappers around `semilattice_field_read[write]_view_t` */
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_read_view_t<inner_t> > metadata_field(
+std::shared_ptr<semilattice_read_view_t<inner_t> > metadata_field(
         inner_t outer_t::*field,
-        boost::shared_ptr<semilattice_read_view_t<outer_t> > outer)
+        std::shared_ptr<semilattice_read_view_t<outer_t> > outer)
 {
-    return boost::make_shared<semilattice_field_read_view_t<outer_t, inner_t> >(
+    return std::make_shared<semilattice_field_read_view_t<outer_t, inner_t> >(
         field, outer);
 }
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_field(
+std::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_field(
         inner_t outer_t::*field,
-        boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer)
+        std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer)
 {
-    return boost::make_shared<semilattice_field_readwrite_view_t<outer_t, inner_t> >(
+    return std::make_shared<semilattice_field_readwrite_view_t<outer_t, inner_t> >(
         field, outer);
 }

--- a/src/rpc/semilattice/view/function.hpp
+++ b/src/rpc/semilattice/view/function.hpp
@@ -1,9 +1,12 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #ifndef RPC_SEMILATTICE_VIEW_FUNCTION_HPP_
 #define RPC_SEMILATTICE_VIEW_FUNCTION_HPP_
+
+#include <memory>
+
 #include "errors.hpp"
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+
 
 #include "rpc/semilattice/view.hpp"
 
@@ -11,15 +14,15 @@
 //this is convenient of the value you want to extract is contained within a few
 //layers of member classes
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_read_view_t<inner_t> > metadata_function(
+std::shared_ptr<semilattice_read_view_t<inner_t> > metadata_function(
         boost::function<inner_t &(outer_t &)>,
-        boost::shared_ptr<semilattice_read_view_t<outer_t> > outer);
+        std::shared_ptr<semilattice_read_view_t<outer_t> > outer);
 
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_function(
+std::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_function(
         boost::function<inner_t &(outer_t &)>,
-        boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer);
+        std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer);
 
 #include "rpc/semilattice/view/function.tcc"
 

--- a/src/rpc/semilattice/view/function.tcc
+++ b/src/rpc/semilattice/view/function.tcc
@@ -4,15 +4,16 @@
 
 #include "rpc/semilattice/view/function.hpp"
 
+#include <memory>
+
 #include "errors.hpp"
-#include <boost/make_shared.hpp>
 #include <boost/function.hpp>
 
 template<class outer_t, class inner_t>
 class metadata_function_read_view_t : public semilattice_read_view_t<inner_t> {
 
 public:
-    metadata_function_read_view_t(boost::function<inner_t &(outer_t &)> _extractor, boost::shared_ptr<semilattice_read_view_t<outer_t> > o) :
+    metadata_function_read_view_t(boost::function<inner_t &(outer_t &)> _extractor, std::shared_ptr<semilattice_read_view_t<outer_t> > o) :
         extractor(_extractor), outer(o) { }
 
     inner_t get() {
@@ -30,14 +31,14 @@ public:
 
 private:
     boost::function<inner_t &(outer_t &)> extractor;
-    boost::shared_ptr<semilattice_read_view_t<outer_t> > outer;
+    std::shared_ptr<semilattice_read_view_t<outer_t> > outer;
 };
 
 template<class outer_t, class inner_t>
 class metadata_function_readwrite_view_t : public semilattice_readwrite_view_t<inner_t> {
 
 public:
-    metadata_function_readwrite_view_t(boost::function<inner_t &(outer_t &)> _extractor, boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > o) :
+    metadata_function_readwrite_view_t(boost::function<inner_t &(outer_t &)> _extractor, std::shared_ptr<semilattice_readwrite_view_t<outer_t> > o) :
         extractor(_extractor), outer(o) { }
 
     inner_t get() {
@@ -74,23 +75,23 @@ public:
 
 private:
     boost::function<inner_t &(outer_t &)> extractor;
-    boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer;
+    std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer;
 };
 
 //some convenient wrappers
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_read_view_t<inner_t> > metadata_function(
+std::shared_ptr<semilattice_read_view_t<inner_t> > metadata_function(
         boost::function<inner_t &(outer_t &)> extractor,
-        boost::shared_ptr<semilattice_read_view_t<outer_t> > outer)
+        std::shared_ptr<semilattice_read_view_t<outer_t> > outer)
 {
     return boost::make_shared<metadata_function_read_view_t<outer_t, inner_t> >(
         extractor, outer);
 }
 
 template<class outer_t, class inner_t>
-boost::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_function(
+std::shared_ptr<semilattice_readwrite_view_t<inner_t> > metadata_function(
         boost::function<inner_t &(outer_t &)> extractor,
-        boost::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer)
+        std::shared_ptr<semilattice_readwrite_view_t<outer_t> > outer)
 {
     return boost::make_shared<metadata_function_readwrite_view_t<outer_t, inner_t> >(
         extractor, outer);

--- a/src/rpc/semilattice/view/member.hpp
+++ b/src/rpc/semilattice/view/member.hpp
@@ -3,9 +3,7 @@
 #define RPC_SEMILATTICE_VIEW_MEMBER_HPP_
 
 #include <map>
-
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "rpc/semilattice/view.hpp"
 
@@ -15,23 +13,23 @@
 member of a `std::map` in another metadata view. */
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_read_view_t<value_t> > metadata_member(
+std::shared_ptr<semilattice_read_view_t<value_t> > metadata_member(
     key_t,
-    boost::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > >);
+    std::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > >);
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_member(
+std::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_member(
     key_t,
-    boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > >);
+    std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > >);
 
 /* `metadata_new_member` inserts a new default-constructed `value_t` into the
 given view under the given key, and returns a view pointing to the newly-
 inserted object. */
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_new_member(
+std::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_new_member(
     key_t,
-    boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > >);
+    std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > >);
 
 #include "rpc/semilattice/view/member.tcc"
 

--- a/src/rpc/semilattice/view/member.tcc
+++ b/src/rpc/semilattice/view/member.tcc
@@ -2,10 +2,8 @@
 #include "rpc/semilattice/view/member.hpp"
 
 #include <map>
+#include <memory>
 #include <utility>
-
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
 
 /* `semilattice_member_read_view_t` and `semilattice_member_readwrite_view_t`
 correspond to some values of a `std::map` contained in another metadata view. */
@@ -14,7 +12,7 @@ template<class key_t, class value_t>
 class semilattice_member_read_view_t : public semilattice_read_view_t<value_t> {
 
 public:
-    semilattice_member_read_view_t(key_t k, boost::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > sv) :
+    semilattice_member_read_view_t(key_t k, std::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > sv) :
         key(k), superview(sv)
     {
         rassert(superview->get().count(key) != 0);
@@ -34,7 +32,7 @@ public:
 
 private:
     key_t key;
-    boost::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > superview;
+    std::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > superview;
     DISABLE_COPYING(semilattice_member_read_view_t);
 };
 
@@ -42,7 +40,7 @@ template<class key_t, class value_t>
 class semilattice_member_readwrite_view_t : public semilattice_readwrite_view_t<value_t> {
 
 public:
-    semilattice_member_readwrite_view_t(key_t k, boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > sv) :
+    semilattice_member_readwrite_view_t(key_t k, std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > sv) :
         key(k), superview(sv)
     {
         rassert(superview->get().count(key) != 0);
@@ -72,32 +70,32 @@ public:
 
 private:
     key_t key;
-    boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > superview;
+    std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > superview;
     DISABLE_COPYING(semilattice_member_readwrite_view_t);
 };
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_read_view_t<value_t> > metadata_member(
+std::shared_ptr<semilattice_read_view_t<value_t> > metadata_member(
     key_t key,
-    boost::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > outer)
+    std::shared_ptr<semilattice_read_view_t<std::map<key_t, value_t> > > outer)
 {
-    return boost::make_shared<semilattice_member_read_view_t<key_t, value_t> >(
+    return std::make_shared<semilattice_member_read_view_t<key_t, value_t> >(
         key, outer);
 }
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_member(
+std::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_member(
     key_t key,
-    boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > outer)
+    std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > outer)
 {
-    return boost::make_shared<semilattice_member_readwrite_view_t<key_t, value_t> >(
+    return std::make_shared<semilattice_member_readwrite_view_t<key_t, value_t> >(
         key, outer);
 }
 
 template<class key_t, class value_t>
-boost::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_new_member(
+std::shared_ptr<semilattice_readwrite_view_t<value_t> > metadata_new_member(
     key_t key,
-    boost::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > outer)
+    std::shared_ptr<semilattice_readwrite_view_t<std::map<key_t, value_t> > > outer)
 {
     rassert(outer->get().count(key) == 0);
     std::map<key_t, value_t> new_value;

--- a/src/rpc/semilattice/watchable.hpp
+++ b/src/rpc/semilattice/watchable.hpp
@@ -8,7 +8,7 @@ template <class T>
 class semilattice_watchable_t : public watchable_t<T> {
 public:
     semilattice_watchable_t() { }
-    explicit semilattice_watchable_t(const boost::shared_ptr<semilattice_read_view_t<T> > &_view)
+    explicit semilattice_watchable_t(const std::shared_ptr<semilattice_read_view_t<T> > &_view)
         : view(_view) { }
 
     semilattice_watchable_t *clone() const {
@@ -35,14 +35,14 @@ public:
     }
 
 private:
-    boost::shared_ptr<semilattice_read_view_t<T> > view;
+    std::shared_ptr<semilattice_read_view_t<T> > view;
     rwi_lock_assertion_t rwi_lock_assertion;
 
     DISABLE_COPYING(semilattice_watchable_t);
 };
 
 template<class T>
-cross_thread_watchable_variable_t<T> cross_thread_watchable_from_semilattice(boost::shared_ptr<semilattice_read_view_t<T> > view,
+cross_thread_watchable_variable_t<T> cross_thread_watchable_from_semilattice(std::shared_ptr<semilattice_read_view_t<T> > view,
                                                                              threadnum_t dest_thread) {
     return cross_thread_watchable_variable_t<T>(new semilattice_watchable_t<T>(view), dest_thread);
 }

--- a/src/unittest/dummy_metadata_controller.hpp
+++ b/src/unittest/dummy_metadata_controller.hpp
@@ -2,8 +2,7 @@
 #ifndef UNITTEST_DUMMY_METADATA_CONTROLLER_HPP_
 #define UNITTEST_DUMMY_METADATA_CONTROLLER_HPP_
 
-#include "errors.hpp"
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include "arch/timing.hpp"
 #include "rpc/semilattice/view.hpp"
@@ -19,16 +18,16 @@ class dummy_semilattice_controller_t {
 
 public:
     dummy_semilattice_controller_t() :
-        view(boost::make_shared<view_t>(this)) { }
+        view(std::make_shared<view_t>(this)) { }
     explicit dummy_semilattice_controller_t(const metadata_t &m) :
-        view(boost::make_shared<view_t>(this)),
+        view(std::make_shared<view_t>(this)),
         metadata(m) { }
 
     ~dummy_semilattice_controller_t() {
         view->controller = NULL;
     }
 
-    boost::shared_ptr<semilattice_readwrite_view_t<metadata_t> > get_view() {
+    std::shared_ptr<semilattice_readwrite_view_t<metadata_t> > get_view() {
         return view;
     }
 
@@ -65,7 +64,7 @@ private:
         dummy_semilattice_controller_t *controller;
         rng_t rng;
     };
-    boost::shared_ptr<view_t> view;
+    std::shared_ptr<view_t> view;
 
     metadata_t metadata;
 

--- a/src/unittest/rdb_protocol.cc
+++ b/src/unittest/rdb_protocol.cc
@@ -5,7 +5,6 @@
 
 #include "errors.hpp"
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include "arch/io/disk.hpp"
 #include "buffer_cache/cache_balancer.hpp"

--- a/src/unittest/rpc_semilattice.cc
+++ b/src/unittest/rpc_semilattice.cc
@@ -1,6 +1,5 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
-#include "errors.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "clustering/administration/metadata.hpp"
 #include "containers/archive/archive.hpp"
@@ -173,7 +172,7 @@ TPTEST_MULTITHREAD(RPCSemilatticeTest, FieldView, 3) {
     dummy_semilattice_controller_t<sl_pair_t> controller(
         sl_pair_t(sl_int_t(8), sl_int_t(4)));
 
-    boost::shared_ptr<semilattice_read_view_t<sl_int_t> > x_view =
+    std::shared_ptr<semilattice_read_view_t<sl_int_t> > x_view =
         metadata_field(&sl_pair_t::x, controller.get_view());
 
     EXPECT_EQ(8u, x_view->get().i);
@@ -198,7 +197,7 @@ TPTEST_MULTITHREAD(RPCSemilatticeTest, MemberView, 3) {
     dummy_semilattice_controller_t<std::map<std::string, sl_int_t> > controller(
         initial_value);
 
-    boost::shared_ptr<semilattice_read_view_t<sl_int_t> > foo_view =
+    std::shared_ptr<semilattice_read_view_t<sl_int_t> > foo_view =
         metadata_member(std::string("foo"), controller.get_view());
 
     EXPECT_EQ(8u, foo_view->get().i);


### PR DESCRIPTION
- Replaces `boost::shared_ptr` with `std::shared_ptr`.
- Replaces `boost::shared_array` with `counted_t<const shared_buf_t>`.

I feel like I've picked a scab.