### PR TITLE
Fixes #5980 - Java Driver: Remove Cursor from cursorCache on close()

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Cursor.java
@@ -47,6 +47,7 @@ public abstract class Cursor<T> implements Iterator<T>, Iterable<T>, Closeable {
     }
 
     public void close() {
+        connection.removeFromCache(this.token);
         if (!error.isPresent()) {
             error = Optional.of(new NoSuchElementException());
             if (connection.isOpen()) {


### PR DESCRIPTION
Compliments of the C# driver. :bow:

To Java driver, From the C# driver, with love. :heart: 

Reference https://github.com/rethinkdb/rethinkdb/issues/5980

----

:sparkles: :point_left: [***"Hey, hey, do that brand new thing... Uh-huh, Uh-huh!"***](https://www.youtube.com/watch?v=AltMeuPkWRs)