### PR TITLE
Changefeeds cursor close cause new cursor cause memory leak

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -344,7 +344,9 @@ public class Connection implements Closeable {
 
 
     void stop(Cursor cursor) {
-        // The server does reply to a stop request, though the response doesn't have a value.
+        // While the server does reply to the stop request, we ignore that reply.
+        // This works because the response pump in `connect` ignores replies for which
+        // no waiter exists.
         runQueryNoreply(Query.stop(cursor.token));
     }
 

--- a/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/Connection.java
@@ -345,7 +345,7 @@ public class Connection implements Closeable {
 
     void stop(Cursor cursor) {
         // The server does reply to a stop request, though the response doesn't have a value.
-        runQuery(Query.stop(cursor.token));
+        runQueryNoreply(Query.stop(cursor.token));
     }
 
     /**

--- a/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
+++ b/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
@@ -412,7 +412,7 @@ public class RethinkDBTest{
     }
 
     @Test
-    public void test() throws Exception {
+    public void test_Changefeeds_Cursor_Close_cause_new_cursor_cause_memory_leak() throws Exception {
         Field f_cursorCache = Connection.class.getDeclaredField("cursorCache");
         f_cursorCache.setAccessible(true);
 

--- a/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
+++ b/drivers/java/src/test/java/com/rethinkdb/RethinkDBTest.java
@@ -10,6 +10,7 @@ import net.jodah.concurrentunit.Waiter;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
+import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -408,6 +409,25 @@ public class RethinkDBTest{
     @Test
     public void testNoreply() throws Exception {
         r.expr(null).runNoReply(conn);
+    }
+
+    @Test
+    public void test() throws Exception {
+        Field f_cursorCache = Connection.class.getDeclaredField("cursorCache");
+        f_cursorCache.setAccessible(true);
+
+        Map<Long, Cursor> cursorCache = (Map<Long, Cursor>) f_cursorCache.get(conn);
+        assertEquals(0, cursorCache.size());
+
+        Cursor c = r.db(dbName).table(tableName).changes().run(conn);
+
+        try {
+            c.next(1000);
+        } catch (TimeoutException ex) {
+        }
+        c.close();
+
+        assertEquals(0, cursorCache.size());
     }
 }
 


### PR DESCRIPTION
fix [hidden memory leak when close Changefeeds cursor · Issue \#6009](https://github.com/rethinkdb/rethinkdb/issues/6009)