### PR TITLE
Fix the build on case-sensitive macOS file systems

### DIFF
--- a/src/clustering/administration/main/cache_size.cc
+++ b/src/clustering/administration/main/cache_size.cc
@@ -12,7 +12,7 @@
 #include <unistd.h>
 
 #if defined(__MACH__)
-#include <availability.h>
+#include <Availability.h>
 #include <errno.h>
 #include <mach/mach.h>
 #include <sys/sysctl.h>


### PR DESCRIPTION
"Availability.h" not "availability.h" is the correct name of the header
in question. Fixing this spelling is necessary for a successful build
if the file system is case sensitive. With the incorrect spelling the
following build failure occurs on macOS:
  src/clustering/administration/main/cache_size.cc:15:10:
  fatal error: 'availability.h' file not found
  #include <availability.h>"