### PR TITLE
allow tests to be run on ruby 2.3

### DIFF
--- a/test/rql_test/test-runner
+++ b/test/rql_test/test-runner
@@ -550,7 +550,7 @@ class JrbLang(RbLang):
 interpreters = {
     'js':     [JsLang('0.10'), JsLang('0.12'), JsLang('4.0'), JsLang('4.1'), JsLang('4.2'), JsLang('5.0'), JsLang('5.1'), JsLang('5.2'), JsLang('5.3')],
     'py':     [PyLang('2.6'), PyLang('2.7'), PyLang('3.0'), PyLang('3.1'), PyLang('3.2'), PyLang('3.3'), PyLang('3.4'), PyLang('3.5')],
-    'rb':     [RbLang('1.9'), RbLang('2.0'), RbLang('2.1'), JrbLang('9.0')],
+    'rb':     [RbLang('1.9'), RbLang('2.0'), RbLang('2.1'), RbLang('2.3'), JrbLang('9.0')],
     'jrb':    [JrbLang('9.0')],
     
     'js0':    [JsLang('0.10'), JsLang('0.12')],


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
### Description

This change simply adds Ruby 2.3 to the list of supported Ruby versions. Running the test suite has the same result as running it on Ruby 2.1.

The following tests fail (just as they do on 2.1):

```
== Failed 2 tests (of 159) in 260.47 seconds!
        SETUP   connections/r_http.rb2.3
        FAILED  polyglot/meta/table.rb2.3
```

Without this change the tests will not run at all, the runner exits with a message about RUBY_DRIVER being invalid and being unable to find a valid interpreter.
