### PR TITLE
Avoid side effects on 'hostOrCallback'

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1634,7 +1634,7 @@ module.exports.connect = varar 0, 2, (hostOrCallback, callback) ->
         # Otherwise, the `callback` variable is already correctly
         # holding the callback, and the host variable is the first
         # argument
-        host = hostOrCallback || {}
+        host = Object.assign {}, hostOrCallback
 
     # `r.connect` returns a Promise which does the following:
     #


### PR DESCRIPTION
It's better to clone 'hostOrCallback' to avoid side effects.

If you run r.connect more than one time with the same config object,
it gets mutated in case 'username' is set instead of 'user'.

Then, the second time you run r.connect, with the same config object,
the driver will complain that you can't use both 'username' and 'user'
at the same time.

Object.assign on 'hostOrCallback' will fix this issue.
