### PR TITLE
Add license reference for node/npm driver

### DIFF
--- a/drivers/javascript/package.json
+++ b/drivers/javascript/package.json
@@ -1,6 +1,7 @@
 { "name" : "rethinkdb"
 , "version" : "2.3.1"
 , "main" : "rethinkdb"
+, "license": "Apache-2.0"
 , "description" : "This package provides the JavaScript driver library for the RethinkDB database server for use in your node application."
 , "keywords" : ["database", "NoSQL", "reql", "query language"]
 , "homepage" : "http://rethinkdb.com"


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
### Description

Add spdx license reference for client driver so that it shows up in npm.
