### PR TITLE
fix deprecation issues

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1022,7 +1022,7 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            @rawSocket.write Buffer.concat([version, Buffer(message.toString()), nullbyte])
+            @rawSocket.write Buffer.concat([version, new Buffer(message.toString()), nullbyte])
 
             # Now we have to wait for a response from the server
             # acknowledging the new connection. The following callback
@@ -1173,7 +1173,7 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            @rawSocket.write Buffer.concat([Buffer(message.toString()), nullbyte])
+                            @rawSocket.write Buffer.concat([new Buffer(message.toString()), nullbyte])
                         else if state is 3
                             if not server_reply.success
                                 handshake_error(server_reply.error_code, server_reply.error)


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
### Description

Fixes deprecation issues with node >= 6.0.0 (``DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.``)
