### PR TITLE
When connection is non-existential, continue to parse parameters.

### DIFF
--- a/drivers/javascript/ast.coffee
+++ b/drivers/javascript/ast.coffee
@@ -70,7 +70,7 @@ class TermBase
         # Depreciated syntaxes are
         # optionsWithConnection, callback
 
-        if net.isConnection(connection) is true
+        if net.isConnection(connection) is true or not connection?
             # Handle run(connection, callback)
             if typeof options is "function"
                 if callback is undefined


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
### Description

When connection is non-existential (`undefined` or `null`), we should continue to parse parameters. This allows options to treated as callback, fixing issue #5453 (the exception is then thrown properly).
