### PR TITLE
Bugfix rwlock_in_line_t move constructor.

### DIFF
--- a/src/concurrency/rwlock.cc
+++ b/src/concurrency/rwlock.cc
@@ -70,6 +70,16 @@ rwlock_in_line_t::rwlock_in_line_t(rwlock_t *lock, access_t access)
     lock_->add_acq(this);
 }
 
+rwlock_in_line_t::rwlock_in_line_t(rwlock_in_line_t &&other)
+    : lock_(other.lock_),
+      access_(other.access_),
+      read_cond_(std::move(other.read_cond_)),
+      write_cond_(std::move(other.write_cond_)) {
+    other.lock_ = nullptr;
+    other.access_ = valgrind_undefined(access_t::read);
+}
+
+
 rwlock_in_line_t::~rwlock_in_line_t() {
     reset();
 }

--- a/src/concurrency/rwlock.hpp
+++ b/src/concurrency/rwlock.hpp
@@ -41,7 +41,7 @@ public:
     // before the lock has been acquired.
     ~rwlock_in_line_t();
 
-    MOVABLE_BUT_NOT_COPYABLE(rwlock_in_line_t);
+    rwlock_in_line_t(rwlock_in_line_t &&other);
 
     const signal_t *read_signal() const { return &read_cond_; }
     const signal_t *write_signal() const {
@@ -61,6 +61,8 @@ private:
     access_t access_;
     cond_t read_cond_;
     cond_t write_cond_;
+
+    DISABLE_COPYING(rwlock_in_line_t);
 };
 
 class rwlock_acq_t : private rwlock_in_line_t {


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

Fixes #6158.