### PR TITLE
Fix Node.js v7 deprecation warning

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1022,7 +1022,7 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString()))
+            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString()))
             @rawSocket.write Buffer.concat([version, buffer_message, nullbyte])
 
             # Now we have to wait for a response from the server
@@ -1174,7 +1174,7 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString()))
+                            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString()))
                             @rawSocket.write Buffer.concat([buffer_message, nullbyte])
                         else if state is 3
                             if not server_reply.success

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1022,7 +1022,7 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString))
+            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString()))
             @rawSocket.write Buffer.concat([version, buffer_message, nullbyte])
 
             # Now we have to wait for a response from the server
@@ -1174,7 +1174,7 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString))
+                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString()))
                             @rawSocket.write Buffer.concat([buffer_message, nullbyte])
                         else if state is 3
                             if not server_reply.success

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -128,7 +128,7 @@ HANDSHAKE_AUTHFAIL = "ERROR: Incorrect authorization key.\n"
 # - `"timeout"` will be emitted by the `TcpConnection` subclass if the
 #    underlying socket times out for any reason.
 class Connection extends events.EventEmitter
-    
+
     # By default, RethinkDB doesn't use an authorization key.
     DEFAULT_AUTH_KEY: ''
     # Each connection has a timeout (in seconds) for the initial handshake with the
@@ -1022,7 +1022,8 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            @rawSocket.write Buffer.concat([version, Buffer(message.toString()), nullbyte])
+            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : Buffer(message.toString))
+            @rawSocket.write Buffer.concat([version, buffer_message, nullbyte])
 
             # Now we have to wait for a response from the server
             # acknowledging the new connection. The following callback
@@ -1173,7 +1174,8 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            @rawSocket.write Buffer.concat([Buffer(message.toString()), nullbyte])
+                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : Buffer(message.toString))
+                            @rawSocket.write Buffer.concat([buffer_message, nullbyte])
                         else if state is 3
                             if not server_reply.success
                                 handshake_error(server_reply.error_code, server_reply.error)

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1022,7 +1022,7 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : Buffer(message.toString))
+            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString))
             @rawSocket.write Buffer.concat([version, buffer_message, nullbyte])
 
             # Now we have to wait for a response from the server
@@ -1174,7 +1174,7 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : Buffer(message.toString))
+                            buffer_message = (Buffer.from ? Buffer.from(message.toString()) : new Buffer(message.toString))
                             @rawSocket.write Buffer.concat([buffer_message, nullbyte])
                         else if state is 3
                             if not server_reply.success

--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -1022,7 +1022,7 @@ class TcpConnection extends Connection
 
             nullbyte = new Buffer('\0', "binary")
 
-            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString()))
+            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString())
             @rawSocket.write Buffer.concat([version, buffer_message, nullbyte])
 
             # Now we have to wait for a response from the server
@@ -1174,7 +1174,7 @@ class TcpConnection extends Connection
 
                             nullbyte = new Buffer('\0', "binary")
 
-                            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString()))
+                            buffer_message = if Buffer.from then Buffer.from(message.toString()) else new Buffer(message.toString())
                             @rawSocket.write Buffer.concat([buffer_message, nullbyte])
                         else if state is 3
                             if not server_reply.success


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This commit should fix the Buffer deprecation warning that occurs in Node.js v7, which is as follows: ```DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.```

It also attempts to ensure backwards-compatibility by using `Buffer.from` if present, while defaulting to `new Buffer` if `Buffer.from` is not available, which should allow the driver to remain backwards compatible for Node.js versions where `Buffer.from` was not yet implemented.