### PR TITLE
fix the webui database and table delete button

### DIFF
--- a/admin/static/handlebars/database.hbs
+++ b/admin/static/handlebars/database.hbs
@@ -3,7 +3,7 @@
   <h3 class="name">{{name}}</h3>
   <div class="buttons">
     <button class="btn add-table">+ Add Table</button>
-    <button class="btn delete-database" data-id={{id}}>Delete Database</a>
+    <button class="btn for-multiple-elements remove-tables" disabled="disabled">&ndash; Delete selected tables</button>
   </div>
 </div>
 <div class="tables_container element-list-container"></div>

--- a/admin/static/handlebars/databases_container.hbs
+++ b/admin/static/handlebars/databases_container.hbs
@@ -1,6 +1,6 @@
 <div class="actions-bar">
   <button class="btn add_database">+ Add Database</button>
-  <button class="btn for-multiple-elements remove-tables" disabled="disabled">&ndash; Delete selected tables</button>
+  <button class="btn delete-database" data-id={{id}}>Delete Database</a>
 </div>
 <h1 class="title">Tables in the cluster</h1>
 <div id="user-alert-space"></div>


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

In WebUI, 
the position of delete database and delete selected table button position has been interchanged.

<img width="996" alt="screen shot 2016-11-18 at 11 05 43 am" src="https://cloud.githubusercontent.com/assets/191992/20417248/10c165cc-ad7f-11e6-934c-14b6fb9e4990.png">