### PR TITLE
Restore deterministic r.now

### DIFF
--- a/src/rdb_protocol/datum_stream/lazy.hpp
+++ b/src/rdb_protocol/datum_stream/lazy.hpp
@@ -37,8 +37,7 @@ private:
     std::vector<datum_t >
     next_batch_impl(env_t *env, const batchspec_t &batchspec);
 
-    virtual void add_transformation(transform_variant_t &&tv,
-                                    backtrace_id_t bt);
+    virtual void help_add_transformation(transform_variant_t &&tv, backtrace_id_t bt);
     virtual void accumulate(env_t *env, eager_acc_t *acc, const terminal_variant_t &tv);
     virtual void accumulate_all(env_t *env, eager_acc_t *acc);
 

--- a/src/rdb_protocol/datum_stream/union.hpp
+++ b/src/rdb_protocol/datum_stream/union.hpp
@@ -16,8 +16,7 @@ public:
                          backtrace_id_t bt,
                          size_t expected_states = 0);
 
-    virtual void add_transformation(transform_variant_t &&tv,
-                                    backtrace_id_t bt);
+    virtual void help_add_transformation(transform_variant_t &&tv, backtrace_id_t bt);
     virtual void accumulate(env_t *env, eager_acc_t *acc, const terminal_variant_t &tv);
     virtual void accumulate_all(env_t *env, eager_acc_t *acc);
 

--- a/src/rdb_protocol/datum_stream/vector.hpp
+++ b/src/rdb_protocol/datum_stream/vector.hpp
@@ -16,8 +16,7 @@ private:
     datum_t next_impl(env_t *);
     std::vector<datum_t> next_raw_batch(env_t *env, const batchspec_t &bs);
 
-    void add_transformation(
-        transform_variant_t &&tv, backtrace_id_t bt);
+    void help_add_transformation(transform_variant_t &&tv, backtrace_id_t bt);
 
     bool is_exhausted() const;
     virtual feed_type_t cfeed_type() const;

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -141,7 +141,7 @@ optional<size_t> js_func_t::arity() const {
 }
 
 deterministic_t js_func_t::is_deterministic() const {
-    return deterministic_t::NONDET();
+    return deterministic_t::no();
 }
 
 void reql_func_t::visit(func_visitor_t *visitor) const {

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -33,8 +33,8 @@ scoped_ptr_t<val_t> func_t::call(env_t *env,
     return call(env, make_vector(arg1, arg2), eval_flags);
 }
 
-void func_t::assert_deterministic(deterministic_t mask, const char *extra_msg) const {
-    rcheck((is_deterministic() & ~mask) == deterministic_t::DETERMINISTIC,
+void func_t::assert_deterministic(constant_now cn, const char *extra_msg) const {
+    rcheck(is_deterministic().test(single_server::no, cn),
            base_exc_t::LOGIC,
            strprintf("Could not prove function deterministic.  %s", extra_msg));
 }
@@ -141,7 +141,7 @@ optional<size_t> js_func_t::arity() const {
 }
 
 deterministic_t js_func_t::is_deterministic() const {
-    return deterministic_t::NONDET;
+    return deterministic_t::NONDET();
 }
 
 void reql_func_t::visit(func_visitor_t *visitor) const {

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -33,8 +33,8 @@ scoped_ptr_t<val_t> func_t::call(env_t *env,
     return call(env, make_vector(arg1, arg2), eval_flags);
 }
 
-void func_t::assert_deterministic(constant_now cn, const char *extra_msg) const {
-    rcheck(is_deterministic().test(single_server::no, cn),
+void func_t::assert_deterministic(constant_now_t cn, const char *extra_msg) const {
+    rcheck(is_deterministic().test(single_server_t::no, cn),
            base_exc_t::LOGIC,
            strprintf("Could not prove function deterministic.  %s", extra_msg));
 }

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -34,7 +34,7 @@ scoped_ptr_t<val_t> func_t::call(env_t *env,
 }
 
 void func_t::assert_deterministic(deterministic_t mask, const char *extra_msg) const {
-    rcheck((is_deterministic() &~ mask) == DET_DETERMINISTIC,
+    rcheck((is_deterministic() & ~mask) == deterministic_t::DETERMINISTIC,
            base_exc_t::LOGIC,
            strprintf("Could not prove function deterministic.  %s", extra_msg));
 }
@@ -141,7 +141,7 @@ optional<size_t> js_func_t::arity() const {
 }
 
 deterministic_t js_func_t::is_deterministic() const {
-    return DET_NONDET;
+    return deterministic_t::NONDET;
 }
 
 void reql_func_t::visit(func_visitor_t *visitor) const {

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -33,8 +33,8 @@ scoped_ptr_t<val_t> func_t::call(env_t *env,
     return call(env, make_vector(arg1, arg2), eval_flags);
 }
 
-void func_t::assert_deterministic(const char *extra_msg) const {
-    rcheck(is_deterministic() == deterministic_t::always,
+void func_t::assert_deterministic(deterministic_t mask, const char *extra_msg) const {
+    rcheck((is_deterministic() &~ mask) == DET_DETERMINISTIC,
            base_exc_t::LOGIC,
            strprintf("Could not prove function deterministic.  %s", extra_msg));
 }
@@ -141,7 +141,7 @@ optional<size_t> js_func_t::arity() const {
 }
 
 deterministic_t js_func_t::is_deterministic() const {
-    return deterministic_t::no;
+    return DET_NONDET;
 }
 
 void reql_func_t::visit(func_visitor_t *visitor) const {

--- a/src/rdb_protocol/func.hpp
+++ b/src/rdb_protocol/func.hpp
@@ -49,7 +49,7 @@ public:
 
     virtual void visit(func_visitor_t *visitor) const = 0;
 
-    void assert_deterministic(deterministic_t mask, const char *extra_msg) const;
+    void assert_deterministic(constant_now cn, const char *extra_msg) const;
 
     bool filter_call(env_t *env,
                      datum_t arg,

--- a/src/rdb_protocol/func.hpp
+++ b/src/rdb_protocol/func.hpp
@@ -49,7 +49,7 @@ public:
 
     virtual void visit(func_visitor_t *visitor) const = 0;
 
-    void assert_deterministic(constant_now cn, const char *extra_msg) const;
+    void assert_deterministic(constant_now_t cn, const char *extra_msg) const;
 
     bool filter_call(env_t *env,
                      datum_t arg,

--- a/src/rdb_protocol/func.hpp
+++ b/src/rdb_protocol/func.hpp
@@ -49,7 +49,7 @@ public:
 
     virtual void visit(func_visitor_t *visitor) const = 0;
 
-    void assert_deterministic(const char *extra_msg) const;
+    void assert_deterministic(deterministic_t mask, const char *extra_msg) const;
 
     bool filter_call(env_t *env,
                      datum_t arg,

--- a/src/rdb_protocol/op.cc
+++ b/src/rdb_protocol/op.cc
@@ -286,7 +286,7 @@ const std::vector<counted_t<const term_t> > &op_term_t::get_original_args() cons
 deterministic_t op_term_t::is_deterministic() const {
     const std::vector<counted_t<const term_t> > &original_args
         = arg_terms->get_original_args();
-    deterministic_t det = DET_DETERMINISTIC;
+    deterministic_t det = deterministic_t::DETERMINISTIC;
     for (const auto &arg : original_args) {
         det |= arg->is_deterministic();
     }
@@ -352,21 +352,25 @@ bool bounded_op_term_t::open_bool(
     }
 }
 
-std::string deterministic_string(deterministic_t det) {
-    if (det == DET_DETERMINISTIC) {
-        return "DETERMINISTIC";
+void debug_print(printf_buffer_t *buf, deterministic_t det) {
+    if (det == deterministic_t::DETERMINISTIC) {
+        buf->appendf("DETERMINISTIC");
     }
     std::string ret;
-    if (det & DET_NONDET) {
-        ret += "NONDET ";
+    if (det & deterministic_t::NONDET) {
+        buf->appendf("NONDET ");
     }
-    if (det & DET_CONSTANT_NOW) {
-        ret += "CONSTANT_NOW ";
+    if (det & deterministic_t::CONSTANT_NOW) {
+        buf->appendf("CONSTANT_NOW ");
     }
-    if (det & DET_SINGLE_SERVER) {
-        ret += "SINGLE_SERVER ";
+    if (det & deterministic_t::SINGLE_SERVER) {
+        buf->appendf("SINGLE_SERVER ");
     }
-    return ret;
 }
+
+const deterministic_t deterministic_t::NONDET{1};
+const deterministic_t deterministic_t::SINGLE_SERVER{2};
+const deterministic_t deterministic_t::CONSTANT_NOW{4};
+const deterministic_t deterministic_t::DETERMINISTIC{0};
 
 } // namespace ql

--- a/src/rdb_protocol/op.cc
+++ b/src/rdb_protocol/op.cc
@@ -283,21 +283,17 @@ const std::vector<counted_t<const term_t> > &op_term_t::get_original_args() cons
     return arg_terms->get_original_args();
 }
 
-deterministic_t worst_determinism(const deterministic_t a, const deterministic_t b) {
-    return a < b ? a : b;
-}
-
 deterministic_t op_term_t::is_deterministic() const {
     const std::vector<counted_t<const term_t> > &original_args
         = arg_terms->get_original_args();
-    deterministic_t worst_so_far = deterministic_t::always;
+    deterministic_t det = DET_DETERMINISTIC;
     for (const auto &arg : original_args) {
-        worst_so_far = worst_determinism(worst_so_far, arg->is_deterministic());
+        det |= arg->is_deterministic();
     }
     for (const auto &arg : optargs) {
-        worst_so_far = worst_determinism(worst_so_far, arg.second->is_deterministic());
+        det |= arg.second->is_deterministic();
     }
-    return worst_so_far;
+    return det;
 }
 
 void op_term_t::maybe_grouped_data(scope_env_t *env,
@@ -356,5 +352,21 @@ bool bounded_op_term_t::open_bool(
     }
 }
 
+std::string deterministic_string(deterministic_t det) {
+    if (det == DET_DETERMINISTIC) {
+        return "DETERMINISTIC";
+    }
+    std::string ret;
+    if (det & DET_NONDET) {
+        ret += "NONDET ";
+    }
+    if (det & DET_CONSTANT_NOW) {
+        ret += "CONSTANT_NOW ";
+    }
+    if (det & DET_SINGLE_SERVER) {
+        ret += "SINGLE_SERVER ";
+    }
+    return ret;
+}
 
 } // namespace ql

--- a/src/rdb_protocol/op.cc
+++ b/src/rdb_protocol/op.cc
@@ -286,12 +286,12 @@ const std::vector<counted_t<const term_t> > &op_term_t::get_original_args() cons
 deterministic_t op_term_t::is_deterministic() const {
     const std::vector<counted_t<const term_t> > &original_args
         = arg_terms->get_original_args();
-    deterministic_t det = deterministic_t::DETERMINISTIC;
+    deterministic_t det = deterministic_t::DETERMINISTIC();
     for (const auto &arg : original_args) {
-        det |= arg->is_deterministic();
+        det = det.join(arg->is_deterministic());
     }
     for (const auto &arg : optargs) {
-        det |= arg.second->is_deterministic();
+        det = det.join(arg.second->is_deterministic());
     }
     return det;
 }
@@ -351,26 +351,5 @@ bool bounded_op_term_t::open_bool(
               key.c_str(), v->trunc_print().c_str());
     }
 }
-
-void debug_print(printf_buffer_t *buf, deterministic_t det) {
-    if (det == deterministic_t::DETERMINISTIC) {
-        buf->appendf("DETERMINISTIC");
-    }
-    std::string ret;
-    if (det & deterministic_t::NONDET) {
-        buf->appendf("NONDET ");
-    }
-    if (det & deterministic_t::CONSTANT_NOW) {
-        buf->appendf("CONSTANT_NOW ");
-    }
-    if (det & deterministic_t::SINGLE_SERVER) {
-        buf->appendf("SINGLE_SERVER ");
-    }
-}
-
-const deterministic_t deterministic_t::NONDET{1};
-const deterministic_t deterministic_t::SINGLE_SERVER{2};
-const deterministic_t deterministic_t::CONSTANT_NOW{4};
-const deterministic_t deterministic_t::DETERMINISTIC{0};
 
 } // namespace ql

--- a/src/rdb_protocol/op.cc
+++ b/src/rdb_protocol/op.cc
@@ -286,7 +286,7 @@ const std::vector<counted_t<const term_t> > &op_term_t::get_original_args() cons
 deterministic_t op_term_t::is_deterministic() const {
     const std::vector<counted_t<const term_t> > &original_args
         = arg_terms->get_original_args();
-    deterministic_t det = deterministic_t::DETERMINISTIC();
+    deterministic_t det = deterministic_t::always();
     for (const auto &arg : original_args) {
         det = det.join(arg->is_deterministic());
     }

--- a/src/rdb_protocol/op.hpp
+++ b/src/rdb_protocol/op.hpp
@@ -18,24 +18,57 @@ namespace ql {
 
 class func_term_t;
 
-enum deterministic_bit_t {
+class deterministic_t {
+public:
     // non-deterministic operations, like ones involving external queries
-    DET_NONDET = 1,
+    static const deterministic_t NONDET;
 
     // deterministic on a single server, but not necessarily across the cluster (different
     // cpus, compilers), like geo operations
-    DET_SINGLE_SERVER = 2,
+    static const deterministic_t SINGLE_SERVER;
 
     // deterministic if r.now is constant
-    DET_CONSTANT_NOW = 4,
+    static const deterministic_t CONSTANT_NOW;
 
     // always deterministic
-    DET_DETERMINISTIC = 0
+    static const deterministic_t DETERMINISTIC;
+
+    deterministic_t operator|(deterministic_t other) const {
+        return deterministic_t(bitset | other.bitset);
+    }
+
+    deterministic_t& operator|=(deterministic_t other) {
+        bitset |= other.bitset;
+        return *this;
+    }
+
+    deterministic_t operator&(deterministic_t other) const {
+        return deterministic_t(bitset & other.bitset);
+    }
+
+    deterministic_t operator~() const {
+        return deterministic_t(~bitset);
+    }
+
+    bool operator==(deterministic_t other) const {
+        return bitset == other.bitset;
+    }
+
+    bool operator!=(deterministic_t other) const {
+        return bitset != other.bitset;
+    }
+
+    operator bool() {
+        return bitset;
+    }
+
+    explicit deterministic_t(int bits) : bitset(bits) { }
+
+private:
+    int bitset;
 };
 
-typedef int deterministic_t;
-
-std::string deterministic_string(deterministic_t det);
+void debug_print(printf_buffer_t *buf, deterministic_t det);
 
 // Specifies the range of normal arguments a function can take (arguments
 // provided by `r.args` count toward the total).  You may also optionally

--- a/src/rdb_protocol/op.hpp
+++ b/src/rdb_protocol/op.hpp
@@ -18,22 +18,24 @@ namespace ql {
 
 class func_term_t;
 
-// Note that worst_determinism depends on the order of these; if you want to add
-// a new value, make sure worst_determinism is properly defined for it.
-enum class deterministic_t {
+enum deterministic_bit_t {
     // non-deterministic operations, like ones involving external queries
-    no,
+    DET_NONDET = 1,
 
     // deterministic on a single server, but not necessarily across the cluster (different
     // cpus, compilers), like geo operations
-    single_server,
+    DET_SINGLE_SERVER = 2,
 
-    // always deterministic, even across different machines
-    always,
+    // deterministic if r.now is constant
+    DET_CONSTANT_NOW = 4,
+
+    // always deterministic
+    DET_DETERMINISTIC = 0
 };
 
-// Returns the most restrictive deterministic_t value passed in.
-deterministic_t worst_determinism(deterministic_t a, deterministic_t b);
+typedef int deterministic_t;
+
+std::string deterministic_string(deterministic_t det);
 
 // Specifies the range of normal arguments a function can take (arguments
 // provided by `r.args` count toward the total).  You may also optionally

--- a/src/rdb_protocol/op.hpp
+++ b/src/rdb_protocol/op.hpp
@@ -56,6 +56,12 @@ public:
         return remaining_bits == 0;
     }
 
+    // True if r.now() is used in the query.
+    bool uses_r_now() const {
+        return 0 != (bitset & constant_now().bitset);
+    }
+
+
 private:
     explicit deterministic_t(int bits) : bitset(bits) { }
 

--- a/src/rdb_protocol/op.hpp
+++ b/src/rdb_protocol/op.hpp
@@ -18,8 +18,8 @@ namespace ql {
 
 class func_term_t;
 
-enum class single_server { no, yes };
-enum class constant_now { no, yes };
+enum class single_server_t { no, yes };
+enum class constant_now_t { no, yes };
 
 
 class deterministic_t {
@@ -48,10 +48,10 @@ public:
     // Returns true if the expression is deterministic (under the given conditions).
     // ("The expression" is whatever expression this deterministic_t value was
     // computed from.)
-    bool test(enum single_server ss, enum constant_now cn) const {
+    bool test(single_server_t ss, constant_now_t cn) const {
         // Turn off the bits that don't apply.
-        int mask = (ss == single_server::yes ? single_server().bitset : 0)
-            | (cn == constant_now::yes ? constant_now().bitset : 0);
+        int mask = (ss == single_server_t::yes ? single_server().bitset : 0)
+            | (cn == constant_now_t::yes ? constant_now().bitset : 0);
         int remaining_bits = bitset & ~mask;
         return remaining_bits == 0;
     }

--- a/src/rdb_protocol/order_util.cc
+++ b/src/rdb_protocol/order_util.cc
@@ -30,7 +30,7 @@ build_comparison(const term_t* target,
 
     counted_t<const func_t> comparison_function = arg->as_func(GET_FIELD_SHORTCUT);
     rcheck_target(target,
-                  (comparison_function->is_deterministic() &~ DET_SINGLE_SERVER) == DET_DETERMINISTIC,
+                  (comparison_function->is_deterministic() & ~deterministic_t::SINGLE_SERVER) == deterministic_t::DETERMINISTIC,
                   base_exc_t::LOGIC,
                   "Sorting by a non-deterministic function is not supported.");
 

--- a/src/rdb_protocol/order_util.cc
+++ b/src/rdb_protocol/order_util.cc
@@ -22,7 +22,7 @@ void check_r_args(const term_t *target, const raw_term_t &term) {
 }
 
 std::pair<order_direction_t, counted_t<const func_t> >
-build_comparison(const term_t* target,
+build_comparison(const term_t *target,
                  scoped_ptr_t<val_t> arg,
                  raw_term_t item) {
 
@@ -31,7 +31,7 @@ build_comparison(const term_t* target,
     counted_t<const func_t> comparison_function = arg->as_func(GET_FIELD_SHORTCUT);
     rcheck_target(target,
                   comparison_function->is_deterministic().test(single_server::yes,
-                                                               constant_now::no),
+                                                               constant_now::yes),
                   base_exc_t::LOGIC,
                   "Sorting by a non-deterministic function is not supported.");
 

--- a/src/rdb_protocol/order_util.cc
+++ b/src/rdb_protocol/order_util.cc
@@ -30,7 +30,7 @@ build_comparison(const term_t* target,
 
     counted_t<const func_t> comparison_function = arg->as_func(GET_FIELD_SHORTCUT);
     rcheck_target(target,
-                  comparison_function->is_deterministic() != deterministic_t::no,
+                  (comparison_function->is_deterministic() &~ DET_SINGLE_SERVER) == DET_DETERMINISTIC,
                   base_exc_t::LOGIC,
                   "Sorting by a non-deterministic function is not supported.");
 

--- a/src/rdb_protocol/order_util.cc
+++ b/src/rdb_protocol/order_util.cc
@@ -23,14 +23,15 @@ void check_r_args(const term_t *target, const raw_term_t &term) {
 
 std::pair<order_direction_t, counted_t<const func_t> >
 build_comparison(const term_t* target,
-                      scoped_ptr_t<val_t> arg,
-                      raw_term_t item) {
+                 scoped_ptr_t<val_t> arg,
+                 raw_term_t item) {
 
     check_r_args(target, item);
 
     counted_t<const func_t> comparison_function = arg->as_func(GET_FIELD_SHORTCUT);
     rcheck_target(target,
-                  (comparison_function->is_deterministic() & ~deterministic_t::SINGLE_SERVER) == deterministic_t::DETERMINISTIC,
+                  comparison_function->is_deterministic().test(single_server::yes,
+                                                               constant_now::no),
                   base_exc_t::LOGIC,
                   "Sorting by a non-deterministic function is not supported.");
 

--- a/src/rdb_protocol/order_util.cc
+++ b/src/rdb_protocol/order_util.cc
@@ -30,8 +30,8 @@ build_comparison(const term_t *target,
 
     counted_t<const func_t> comparison_function = arg->as_func(GET_FIELD_SHORTCUT);
     rcheck_target(target,
-                  comparison_function->is_deterministic().test(single_server::yes,
-                                                               constant_now::yes),
+                  comparison_function->is_deterministic().test(single_server_t::yes,
+                                                               constant_now_t::yes),
                   base_exc_t::LOGIC,
                   "Sorting by a non-deterministic function is not supported.");
 

--- a/src/rdb_protocol/term.hpp
+++ b/src/rdb_protocol/term.hpp
@@ -21,7 +21,7 @@ class table_t;
 class table_slice_t;
 class var_captures_t;
 class compile_env_t;
-typedef int deterministic_t;
+struct deterministic_t;
 
 enum eval_flags_t {
     NO_FLAGS = 0,

--- a/src/rdb_protocol/term.hpp
+++ b/src/rdb_protocol/term.hpp
@@ -21,7 +21,7 @@ class table_t;
 class table_slice_t;
 class var_captures_t;
 class compile_env_t;
-enum class deterministic_t;
+typedef int deterministic_t;
 
 enum eval_flags_t {
     NO_FLAGS = 0,

--- a/src/rdb_protocol/term.hpp
+++ b/src/rdb_protocol/term.hpp
@@ -21,7 +21,7 @@ class table_t;
 class table_slice_t;
 class var_captures_t;
 class compile_env_t;
-struct deterministic_t;
+class deterministic_t;
 
 enum eval_flags_t {
     NO_FLAGS = 0,

--- a/src/rdb_protocol/terms/datum_terms.cc
+++ b/src/rdb_protocol/terms/datum_terms.cc
@@ -24,7 +24,7 @@ public:
 
 private:
     virtual void accumulate_captures(var_captures_t *) const { /* do nothing */ }
-    virtual deterministic_t is_deterministic() const { return DET_DETERMINISTIC; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::DETERMINISTIC; }
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *, eval_flags_t) const {
         return new_val(datum);
     }
@@ -107,7 +107,7 @@ public:
     }
 
     deterministic_t is_deterministic() const {
-        deterministic_t combined = DET_DETERMINISTIC;
+        deterministic_t combined = deterministic_t::DETERMINISTIC;
         for (const auto &arg : optargs) {
             combined |= arg.second->is_deterministic();
         }

--- a/src/rdb_protocol/terms/datum_terms.cc
+++ b/src/rdb_protocol/terms/datum_terms.cc
@@ -24,7 +24,7 @@ public:
 
 private:
     virtual void accumulate_captures(var_captures_t *) const { /* do nothing */ }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::always; }
+    virtual deterministic_t is_deterministic() const { return DET_DETERMINISTIC; }
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *, eval_flags_t) const {
         return new_val(datum);
     }
@@ -107,11 +107,11 @@ public:
     }
 
     deterministic_t is_deterministic() const {
-        deterministic_t worst_so_far = deterministic_t::always;
+        deterministic_t combined = DET_DETERMINISTIC;
         for (const auto &arg : optargs) {
-            worst_so_far = worst_determinism(worst_so_far, arg.second->is_deterministic());
+            combined |= arg.second->is_deterministic();
         }
-        return worst_so_far;
+        return combined;
     }
 
     void accumulate_captures(var_captures_t *captures) const {

--- a/src/rdb_protocol/terms/datum_terms.cc
+++ b/src/rdb_protocol/terms/datum_terms.cc
@@ -25,7 +25,7 @@ public:
 private:
     virtual void accumulate_captures(var_captures_t *) const { /* do nothing */ }
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::DETERMINISTIC();
+        return deterministic_t::always();
     }
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *, eval_flags_t) const {
         return new_val(datum);
@@ -109,7 +109,7 @@ public:
     }
 
     deterministic_t is_deterministic() const {
-        deterministic_t combined = deterministic_t::DETERMINISTIC();
+        deterministic_t combined = deterministic_t::always();
         for (const auto &arg : optargs) {
             combined = combined.join(arg.second->is_deterministic());
         }

--- a/src/rdb_protocol/terms/datum_terms.cc
+++ b/src/rdb_protocol/terms/datum_terms.cc
@@ -24,7 +24,9 @@ public:
 
 private:
     virtual void accumulate_captures(var_captures_t *) const { /* do nothing */ }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::DETERMINISTIC; }
+    virtual deterministic_t is_deterministic() const {
+        return deterministic_t::DETERMINISTIC();
+    }
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *, eval_flags_t) const {
         return new_val(datum);
     }
@@ -107,9 +109,9 @@ public:
     }
 
     deterministic_t is_deterministic() const {
-        deterministic_t combined = deterministic_t::DETERMINISTIC;
+        deterministic_t combined = deterministic_t::DETERMINISTIC();
         for (const auto &arg : optargs) {
-            combined |= arg.second->is_deterministic();
+            combined = combined.join(arg.second->is_deterministic());
         }
         return combined;
     }

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -106,7 +106,7 @@ public:
         : op_term_t(env, term, std::move(argspec), std::move(optargspec)) { }
 
 private:
-    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET(); }
 };
 
 class db_term_t : public meta_op_term_t {
@@ -886,7 +886,7 @@ private:
         return new_val(make_counted<table_t>(
             std::move(table), db, table_name.str(), read_mode, backtrace()));
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET(); }
     virtual const char *name() const { return "table"; }
 };
 

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -106,7 +106,7 @@ public:
         : op_term_t(env, term, std::move(argspec), std::move(optargspec)) { }
 
 private:
-    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET(); }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::no(); }
 };
 
 class db_term_t : public meta_op_term_t {
@@ -886,7 +886,7 @@ private:
         return new_val(make_counted<table_t>(
             std::move(table), db, table_name.str(), read_mode, backtrace()));
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET(); }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::no(); }
     virtual const char *name() const { return "table"; }
 };
 

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -106,7 +106,7 @@ public:
         : op_term_t(env, term, std::move(argspec), std::move(optargspec)) { }
 
 private:
-    virtual deterministic_t is_deterministic() const { return DET_NONDET; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET; }
 };
 
 class db_term_t : public meta_op_term_t {
@@ -886,7 +886,7 @@ private:
         return new_val(make_counted<table_t>(
             std::move(table), db, table_name.str(), read_mode, backtrace()));
     }
-    virtual deterministic_t is_deterministic() const { return DET_NONDET; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::NONDET; }
     virtual const char *name() const { return "table"; }
 };
 

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -106,7 +106,7 @@ public:
         : op_term_t(env, term, std::move(argspec), std::move(optargspec)) { }
 
 private:
-    virtual deterministic_t is_deterministic() const { return deterministic_t::no; }
+    virtual deterministic_t is_deterministic() const { return DET_NONDET; }
 };
 
 class db_term_t : public meta_op_term_t {
@@ -886,7 +886,7 @@ private:
         return new_val(make_counted<table_t>(
             std::move(table), db, table_name.str(), read_mode, backtrace()));
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::no; }
+    virtual deterministic_t is_deterministic() const { return DET_NONDET; }
     virtual const char *name() const { return "table"; }
 };
 

--- a/src/rdb_protocol/terms/geo.cc
+++ b/src/rdb_protocol/terms/geo.cc
@@ -35,7 +35,7 @@ private:
     // Even seemingly harmless things such as r.line() are affected because they perform
     // geometric validation.
     deterministic_t is_deterministic() const {
-        return worst_determinism(op_term_t::is_deterministic(), deterministic_t::single_server);
+        return op_term_t::is_deterministic() | DET_SINGLE_SERVER;
     }
     virtual scoped_ptr_t<val_t> eval_geo(
             scope_env_t *env, args_t *args, eval_flags_t flags) const = 0;
@@ -58,7 +58,7 @@ public:
 private:
     // See comment in geo_term_t about non-determinism
     deterministic_t is_deterministic() const {
-        return worst_determinism(obj_or_seq_op_term_t::is_deterministic(), deterministic_t::single_server);
+        return obj_or_seq_op_term_t::is_deterministic() | DET_SINGLE_SERVER;
     }
     virtual scoped_ptr_t<val_t> obj_eval_geo(
             scope_env_t *env, args_t *args, const scoped_ptr_t<val_t> &v0) const = 0;

--- a/src/rdb_protocol/terms/geo.cc
+++ b/src/rdb_protocol/terms/geo.cc
@@ -35,7 +35,7 @@ private:
     // Even seemingly harmless things such as r.line() are affected because they perform
     // geometric validation.
     deterministic_t is_deterministic() const {
-        return op_term_t::is_deterministic() | DET_SINGLE_SERVER;
+        return op_term_t::is_deterministic() | deterministic_t::SINGLE_SERVER;
     }
     virtual scoped_ptr_t<val_t> eval_geo(
             scope_env_t *env, args_t *args, eval_flags_t flags) const = 0;
@@ -58,7 +58,7 @@ public:
 private:
     // See comment in geo_term_t about non-determinism
     deterministic_t is_deterministic() const {
-        return obj_or_seq_op_term_t::is_deterministic() | DET_SINGLE_SERVER;
+        return obj_or_seq_op_term_t::is_deterministic() | deterministic_t::SINGLE_SERVER;
     }
     virtual scoped_ptr_t<val_t> obj_eval_geo(
             scope_env_t *env, args_t *args, const scoped_ptr_t<val_t> &v0) const = 0;

--- a/src/rdb_protocol/terms/geo.cc
+++ b/src/rdb_protocol/terms/geo.cc
@@ -35,7 +35,7 @@ private:
     // Even seemingly harmless things such as r.line() are affected because they perform
     // geometric validation.
     deterministic_t is_deterministic() const {
-        return op_term_t::is_deterministic() | deterministic_t::SINGLE_SERVER;
+        return op_term_t::is_deterministic().join(deterministic_t::SINGLE_SERVER());
     }
     virtual scoped_ptr_t<val_t> eval_geo(
             scope_env_t *env, args_t *args, eval_flags_t flags) const = 0;
@@ -58,7 +58,7 @@ public:
 private:
     // See comment in geo_term_t about non-determinism
     deterministic_t is_deterministic() const {
-        return obj_or_seq_op_term_t::is_deterministic() | deterministic_t::SINGLE_SERVER;
+        return obj_or_seq_op_term_t::is_deterministic().join(deterministic_t::SINGLE_SERVER());
     }
     virtual scoped_ptr_t<val_t> obj_eval_geo(
             scope_env_t *env, args_t *args, const scoped_ptr_t<val_t> &v0) const = 0;

--- a/src/rdb_protocol/terms/geo.cc
+++ b/src/rdb_protocol/terms/geo.cc
@@ -35,7 +35,7 @@ private:
     // Even seemingly harmless things such as r.line() are affected because they perform
     // geometric validation.
     deterministic_t is_deterministic() const {
-        return op_term_t::is_deterministic().join(deterministic_t::SINGLE_SERVER());
+        return op_term_t::is_deterministic().join(deterministic_t::single_server());
     }
     virtual scoped_ptr_t<val_t> eval_geo(
             scope_env_t *env, args_t *args, eval_flags_t flags) const = 0;
@@ -58,7 +58,7 @@ public:
 private:
     // See comment in geo_term_t about non-determinism
     deterministic_t is_deterministic() const {
-        return obj_or_seq_op_term_t::is_deterministic().join(deterministic_t::SINGLE_SERVER());
+        return obj_or_seq_op_term_t::is_deterministic().join(deterministic_t::single_server());
     }
     virtual scoped_ptr_t<val_t> obj_eval_geo(
             scope_env_t *env, args_t *args, const scoped_ptr_t<val_t> &v0) const = 0;

--- a/src/rdb_protocol/terms/http.cc
+++ b/src/rdb_protocol/terms/http.cc
@@ -37,7 +37,7 @@ private:
 
     // No HTTP term is considered deterministic
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const;

--- a/src/rdb_protocol/terms/http.cc
+++ b/src/rdb_protocol/terms/http.cc
@@ -37,7 +37,7 @@ private:
 
     // No HTTP term is considered deterministic
     virtual deterministic_t is_deterministic() const {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const;

--- a/src/rdb_protocol/terms/http.cc
+++ b/src/rdb_protocol/terms/http.cc
@@ -37,7 +37,7 @@ private:
 
     // No HTTP term is considered deterministic
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET;
+        return deterministic_t::NONDET();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const;

--- a/src/rdb_protocol/terms/http.cc
+++ b/src/rdb_protocol/terms/http.cc
@@ -37,7 +37,7 @@ private:
 
     // No HTTP term is considered deterministic
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const;

--- a/src/rdb_protocol/terms/js.cc
+++ b/src/rdb_protocol/terms/js.cc
@@ -53,7 +53,7 @@ private:
 
     // No JS term is considered deterministic
     virtual deterministic_t  is_deterministic() const {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 };
 

--- a/src/rdb_protocol/terms/js.cc
+++ b/src/rdb_protocol/terms/js.cc
@@ -53,7 +53,7 @@ private:
 
     // No JS term is considered deterministic
     virtual deterministic_t  is_deterministic() const {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 };
 

--- a/src/rdb_protocol/terms/js.cc
+++ b/src/rdb_protocol/terms/js.cc
@@ -52,8 +52,8 @@ private:
     virtual const char *name() const { return "javascript"; }
 
     // No JS term is considered deterministic
-    virtual deterministic_t  is_deterministic() const {
-        return deterministic_t::NONDET;
+    virtual deterministic_t is_deterministic() const {
+        return deterministic_t::NONDET();
     }
 };
 

--- a/src/rdb_protocol/terms/js.cc
+++ b/src/rdb_protocol/terms/js.cc
@@ -53,7 +53,7 @@ private:
 
     // No JS term is considered deterministic
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 };
 

--- a/src/rdb_protocol/terms/random.cc
+++ b/src/rdb_protocol/terms/random.cc
@@ -76,7 +76,7 @@ public:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 
     virtual const char *name() const { return "sample"; }
@@ -88,7 +88,7 @@ public:
         : op_term_t(env, term, argspec_t(0, 2), optargspec_t({"float"})) { }
 private:
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 
     enum class bound_type_t {

--- a/src/rdb_protocol/terms/random.cc
+++ b/src/rdb_protocol/terms/random.cc
@@ -76,7 +76,7 @@ public:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 
     virtual const char *name() const { return "sample"; }
@@ -88,7 +88,7 @@ public:
         : op_term_t(env, term, argspec_t(0, 2), optargspec_t({"float"})) { }
 private:
     virtual deterministic_t is_deterministic() const {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 
     enum class bound_type_t {

--- a/src/rdb_protocol/terms/random.cc
+++ b/src/rdb_protocol/terms/random.cc
@@ -76,7 +76,7 @@ public:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET;
+        return deterministic_t::NONDET();
     }
 
     virtual const char *name() const { return "sample"; }
@@ -88,7 +88,7 @@ public:
         : op_term_t(env, term, argspec_t(0, 2), optargspec_t({"float"})) { }
 private:
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET;
+        return deterministic_t::NONDET();
     }
 
     enum class bound_type_t {

--- a/src/rdb_protocol/terms/random.cc
+++ b/src/rdb_protocol/terms/random.cc
@@ -76,7 +76,7 @@ public:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 
     virtual const char *name() const { return "sample"; }
@@ -88,7 +88,7 @@ public:
         : op_term_t(env, term, argspec_t(0, 2), optargspec_t({"float"})) { }
 private:
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 
     enum class bound_type_t {

--- a/src/rdb_protocol/terms/rewrites.cc
+++ b/src/rdb_protocol/terms/rewrites.cc
@@ -22,7 +22,7 @@ public:
     }
 
 private:
-    raw_term_t do_rewrite(const raw_term_t &term, 
+    raw_term_t do_rewrite(const raw_term_t &term,
                           argspec_t argspec,
                           minidriver_t::reql_t (*rewrite)(const raw_term_t &)) {
         rcheck(argspec.contains(term.num_args()),

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -465,9 +465,8 @@ private:
 
 struct rcheck_transform_visitor_t : public bt_rcheckable_t,
                                     public boost::static_visitor<void> {
-    template<class... Args>
-    explicit rcheck_transform_visitor_t(Args &&... args)
-        : bt_rcheckable_t(std::forward<Args...>(args)...) { }
+    explicit rcheck_transform_visitor_t(backtrace_id_t bt)
+        : bt_rcheckable_t(bt) { }
     void check_f(const wire_func_t &f) const {
         if (!f.compile_wire_func()->is_deterministic().test(single_server::yes,
                                                             constant_now::yes)) {
@@ -510,9 +509,8 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
 
 struct rcheck_spec_visitor_t : public bt_rcheckable_t,
                                public boost::static_visitor<void> {
-    template<class... Args>
-    explicit rcheck_spec_visitor_t(env_t *_env, Args &&... args)
-        : bt_rcheckable_t(std::forward<Args...>(args)...), env(_env) { }
+    explicit rcheck_spec_visitor_t(env_t *_env, backtrace_id_t bt)
+        : bt_rcheckable_t(bt), env(_env) { }
     void operator()(const changefeed::keyspec_t::range_t &spec) const {
         for (const auto &t : spec.transforms) {
             boost::apply_visitor(rcheck_transform_visitor_t(backtrace()), t);

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -468,8 +468,8 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
     explicit rcheck_transform_visitor_t(backtrace_id_t bt)
         : bt_rcheckable_t(bt) { }
     void check_f(const wire_func_t &f) const {
-        if (!f.compile_wire_func()->is_deterministic().test(single_server::yes,
-                                                            constant_now::yes)) {
+        if (!f.compile_wire_func()->is_deterministic().test(single_server_t::yes,
+                                                            constant_now_t::yes)) {
             rfail_src(f.get_bt(),
                       base_exc_t::LOGIC,
                       "Cannot call `changes` after a non-deterministic function.");

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -469,7 +469,7 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
     explicit rcheck_transform_visitor_t(Args &&... args)
         : bt_rcheckable_t(std::forward<Args...>(args)...) { }
     void check_f(const wire_func_t &f) const {
-        if((f.compile_wire_func()->is_deterministic() &~ DET_SINGLE_SERVER) != DET_DETERMINISTIC) {
+        if((f.compile_wire_func()->is_deterministic() & ~deterministic_t::SINGLE_SERVER) != deterministic_t::DETERMINISTIC) {
             rfail_src(f.get_bt(),
                       base_exc_t::LOGIC,
                       "Cannot call `changes` after a non-deterministic function.");

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -469,18 +469,10 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
     explicit rcheck_transform_visitor_t(Args &&... args)
         : bt_rcheckable_t(std::forward<Args...>(args)...) { }
     void check_f(const wire_func_t &f) const {
-        switch (f.compile_wire_func()->is_deterministic()) {
-            case deterministic_t::always:
-            case deterministic_t::single_server:
-                // ok
-                break;
-
-            case deterministic_t::no:
-                rfail_src(f.get_bt(),
-                          base_exc_t::LOGIC,
-                          "Cannot call `changes` after a non-deterministic function.");
-
-            default: unreachable();
+        if((f.compile_wire_func()->is_deterministic() &~ DET_SINGLE_SERVER) != DET_DETERMINISTIC) {
+            rfail_src(f.get_bt(),
+                      base_exc_t::LOGIC,
+                      "Cannot call `changes` after a non-deterministic function.");
         }
     }
     void operator()(const map_wire_func_t &f) const {

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -470,7 +470,7 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
         : bt_rcheckable_t(std::forward<Args...>(args)...) { }
     void check_f(const wire_func_t &f) const {
         if (!f.compile_wire_func()->is_deterministic().test(single_server::yes,
-                                                            constant_now::no)) {
+                                                            constant_now::yes)) {
             rfail_src(f.get_bt(),
                       base_exc_t::LOGIC,
                       "Cannot call `changes` after a non-deterministic function.");

--- a/src/rdb_protocol/terms/seq.cc
+++ b/src/rdb_protocol/terms/seq.cc
@@ -469,7 +469,8 @@ struct rcheck_transform_visitor_t : public bt_rcheckable_t,
     explicit rcheck_transform_visitor_t(Args &&... args)
         : bt_rcheckable_t(std::forward<Args...>(args)...) { }
     void check_f(const wire_func_t &f) const {
-        if((f.compile_wire_func()->is_deterministic() & ~deterministic_t::SINGLE_SERVER) != deterministic_t::DETERMINISTIC) {
+        if (!f.compile_wire_func()->is_deterministic().test(single_server::yes,
+                                                            constant_now::no)) {
             rfail_src(f.get_bt(),
                       base_exc_t::LOGIC,
                       "Cannot call `changes` after a non-deterministic function.");

--- a/src/rdb_protocol/terms/sindex.cc
+++ b/src/rdb_protocol/terms/sindex.cc
@@ -204,7 +204,7 @@ public:
         }
 
         config.func.compile_wire_func()->assert_deterministic(
-            DET_DETERMINISTIC,
+            deterministic_t::DETERMINISTIC,
             "Index functions must be deterministic.");
 
         /* Check if we're doing a multi index or a normal index. */

--- a/src/rdb_protocol/terms/sindex.cc
+++ b/src/rdb_protocol/terms/sindex.cc
@@ -204,6 +204,7 @@ public:
         }
 
         config.func.compile_wire_func()->assert_deterministic(
+            DET_DETERMINISTIC,
             "Index functions must be deterministic.");
 
         /* Check if we're doing a multi index or a normal index. */

--- a/src/rdb_protocol/terms/sindex.cc
+++ b/src/rdb_protocol/terms/sindex.cc
@@ -204,8 +204,8 @@ public:
         }
 
         config.func.compile_wire_func()->assert_deterministic(
-            deterministic_t::DETERMINISTIC,
-            "Index functions must be deterministic.");
+                constant_now::no,
+                "Index functions must be deterministic.");
 
         /* Check if we're doing a multi index or a normal index. */
         if (scoped_ptr_t<val_t> multi_val = args->optarg(env, "multi")) {

--- a/src/rdb_protocol/terms/sindex.cc
+++ b/src/rdb_protocol/terms/sindex.cc
@@ -204,7 +204,7 @@ public:
         }
 
         config.func.compile_wire_func()->assert_deterministic(
-                constant_now::no,
+                constant_now_t::no,
                 "Index functions must be deterministic.");
 
         /* Check if we're doing a multi index or a normal index. */

--- a/src/rdb_protocol/terms/time.cc
+++ b/src/rdb_protocol/terms/time.cc
@@ -73,7 +73,7 @@ private:
         r_sanity_check(env->env->get_deterministic_time().has());
         return new_val(env->env->get_deterministic_time());
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::no; }
+    virtual deterministic_t is_deterministic() const { return DET_CONSTANT_NOW; }
     virtual const char *name() const { return "now"; }
 };
 

--- a/src/rdb_protocol/terms/time.cc
+++ b/src/rdb_protocol/terms/time.cc
@@ -73,7 +73,7 @@ private:
         r_sanity_check(env->env->get_deterministic_time().has());
         return new_val(env->env->get_deterministic_time());
     }
-    virtual deterministic_t is_deterministic() const { return DET_CONSTANT_NOW; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::CONSTANT_NOW; }
     virtual const char *name() const { return "now"; }
 };
 

--- a/src/rdb_protocol/terms/time.cc
+++ b/src/rdb_protocol/terms/time.cc
@@ -73,7 +73,7 @@ private:
         r_sanity_check(env->env->get_deterministic_time().has());
         return new_val(env->env->get_deterministic_time());
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::CONSTANT_NOW(); }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::constant_now(); }
     virtual const char *name() const { return "now"; }
 };
 

--- a/src/rdb_protocol/terms/time.cc
+++ b/src/rdb_protocol/terms/time.cc
@@ -73,7 +73,7 @@ private:
         r_sanity_check(env->env->get_deterministic_time().has());
         return new_val(env->env->get_deterministic_time());
     }
-    virtual deterministic_t is_deterministic() const { return deterministic_t::CONSTANT_NOW; }
+    virtual deterministic_t is_deterministic() const { return deterministic_t::CONSTANT_NOW(); }
     virtual const char *name() const { return "now"; }
 };
 

--- a/src/rdb_protocol/terms/uuid.cc
+++ b/src/rdb_protocol/terms/uuid.cc
@@ -44,7 +44,7 @@ private:
             && get_original_args()[0]->get_src().type() != Term::ARGS) {
             return op_term_t::is_deterministic();
         } else {
-            return deterministic_t::no;
+            return DET_NONDET;
         }
     }
 };

--- a/src/rdb_protocol/terms/uuid.cc
+++ b/src/rdb_protocol/terms/uuid.cc
@@ -44,7 +44,7 @@ private:
             && get_original_args()[0]->get_src().type() != Term::ARGS) {
             return op_term_t::is_deterministic();
         } else {
-            return DET_NONDET;
+            return deterministic_t::NONDET;
         }
     }
 };

--- a/src/rdb_protocol/terms/uuid.cc
+++ b/src/rdb_protocol/terms/uuid.cc
@@ -44,7 +44,7 @@ private:
             && get_original_args()[0]->get_src().type() != Term::ARGS) {
             return op_term_t::is_deterministic();
         } else {
-            return deterministic_t::NONDET;
+            return deterministic_t::NONDET();
         }
     }
 };

--- a/src/rdb_protocol/terms/uuid.cc
+++ b/src/rdb_protocol/terms/uuid.cc
@@ -44,7 +44,7 @@ private:
             && get_original_args()[0]->get_src().type() != Term::ARGS) {
             return op_term_t::is_deterministic();
         } else {
-            return deterministic_t::NONDET();
+            return deterministic_t::no();
         }
     }
 };

--- a/src/rdb_protocol/terms/var.cc
+++ b/src/rdb_protocol/terms/var.cc
@@ -36,7 +36,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return DET_DETERMINISTIC;
+        return deterministic_t::DETERMINISTIC;
     }
 
     sym_t varname;
@@ -69,7 +69,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return DET_DETERMINISTIC;
+        return deterministic_t::DETERMINISTIC;
     }
 
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *env, UNUSED eval_flags_t flags) const {

--- a/src/rdb_protocol/terms/var.cc
+++ b/src/rdb_protocol/terms/var.cc
@@ -36,7 +36,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::always;
+        return DET_DETERMINISTIC;
     }
 
     sym_t varname;
@@ -69,7 +69,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::always;
+        return DET_DETERMINISTIC;
     }
 
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *env, UNUSED eval_flags_t flags) const {

--- a/src/rdb_protocol/terms/var.cc
+++ b/src/rdb_protocol/terms/var.cc
@@ -36,7 +36,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::DETERMINISTIC();
+        return deterministic_t::always();
     }
 
     sym_t varname;
@@ -69,7 +69,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::DETERMINISTIC();
+        return deterministic_t::always();
     }
 
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *env, UNUSED eval_flags_t flags) const {

--- a/src/rdb_protocol/terms/var.cc
+++ b/src/rdb_protocol/terms/var.cc
@@ -36,7 +36,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::DETERMINISTIC;
+        return deterministic_t::DETERMINISTIC();
     }
 
     sym_t varname;
@@ -69,7 +69,7 @@ private:
     }
 
     virtual deterministic_t is_deterministic() const {
-        return deterministic_t::DETERMINISTIC;
+        return deterministic_t::DETERMINISTIC();
     }
 
     virtual scoped_ptr_t<val_t> term_eval(scope_env_t *env, UNUSED eval_flags_t flags) const {

--- a/src/rdb_protocol/terms/write_hook.cc
+++ b/src/rdb_protocol/terms/write_hook.cc
@@ -87,7 +87,7 @@ public:
 
                 config.set(conf);
                 config->func.compile_wire_func()->assert_deterministic(
-                        constant_now::yes,
+                        constant_now_t::yes,
                         "Write hook functions must be deterministic.");
 
                 optional<size_t> arity = config->func.compile_wire_func()->arity();
@@ -114,7 +114,7 @@ public:
 
             config.set(conf);
             config->func.compile_wire_func()->assert_deterministic(
-                    constant_now::yes,
+                    constant_now_t::yes,
                     "Write hook functions must be deterministic.");
 
             optional<size_t> arity = config->func.compile_wire_func()->arity();

--- a/src/rdb_protocol/terms/write_hook.cc
+++ b/src/rdb_protocol/terms/write_hook.cc
@@ -29,7 +29,7 @@ public:
         : op_term_t(env, term, argspec_t(2)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(
@@ -87,6 +87,7 @@ public:
 
                 config.set(conf);
                 config->func.compile_wire_func()->assert_deterministic(
+                    DET_CONSTANT_NOW,
                     "Write hook functions must be deterministic.");
 
                 optional<size_t> arity = config->func.compile_wire_func()->arity();
@@ -113,6 +114,7 @@ public:
 
             config.set(conf);
             config->func.compile_wire_func()->assert_deterministic(
+                DET_CONSTANT_NOW,
                 "Write hook functions must be deterministic.");
 
             optional<size_t> arity = config->func.compile_wire_func()->arity();
@@ -155,7 +157,7 @@ public:
         : op_term_t(env, term, argspec_t(1)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::no;
+        return DET_NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const {

--- a/src/rdb_protocol/terms/write_hook.cc
+++ b/src/rdb_protocol/terms/write_hook.cc
@@ -29,7 +29,7 @@ public:
         : op_term_t(env, term, argspec_t(2)) { }
 
     deterministic_t is_deterministic() const final {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(
@@ -87,7 +87,7 @@ public:
 
                 config.set(conf);
                 config->func.compile_wire_func()->assert_deterministic(
-                    DET_CONSTANT_NOW,
+                    deterministic_t::CONSTANT_NOW,
                     "Write hook functions must be deterministic.");
 
                 optional<size_t> arity = config->func.compile_wire_func()->arity();
@@ -114,7 +114,7 @@ public:
 
             config.set(conf);
             config->func.compile_wire_func()->assert_deterministic(
-                DET_CONSTANT_NOW,
+                deterministic_t::CONSTANT_NOW,
                 "Write hook functions must be deterministic.");
 
             optional<size_t> arity = config->func.compile_wire_func()->arity();
@@ -157,7 +157,7 @@ public:
         : op_term_t(env, term, argspec_t(1)) { }
 
     deterministic_t is_deterministic() const final {
-        return DET_NONDET;
+        return deterministic_t::NONDET;
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const {

--- a/src/rdb_protocol/terms/write_hook.cc
+++ b/src/rdb_protocol/terms/write_hook.cc
@@ -29,7 +29,7 @@ public:
         : op_term_t(env, term, argspec_t(2)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(
@@ -157,7 +157,7 @@ public:
         : op_term_t(env, term, argspec_t(1)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::NONDET();
+        return deterministic_t::no();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const {

--- a/src/rdb_protocol/terms/write_hook.cc
+++ b/src/rdb_protocol/terms/write_hook.cc
@@ -29,7 +29,7 @@ public:
         : op_term_t(env, term, argspec_t(2)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::NONDET;
+        return deterministic_t::NONDET();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(
@@ -87,8 +87,8 @@ public:
 
                 config.set(conf);
                 config->func.compile_wire_func()->assert_deterministic(
-                    deterministic_t::CONSTANT_NOW,
-                    "Write hook functions must be deterministic.");
+                        constant_now::yes,
+                        "Write hook functions must be deterministic.");
 
                 optional<size_t> arity = config->func.compile_wire_func()->arity();
 
@@ -114,8 +114,8 @@ public:
 
             config.set(conf);
             config->func.compile_wire_func()->assert_deterministic(
-                deterministic_t::CONSTANT_NOW,
-                "Write hook functions must be deterministic.");
+                    constant_now::yes,
+                    "Write hook functions must be deterministic.");
 
             optional<size_t> arity = config->func.compile_wire_func()->arity();
 
@@ -157,7 +157,7 @@ public:
         : op_term_t(env, term, argspec_t(1)) { }
 
     deterministic_t is_deterministic() const final {
-        return deterministic_t::NONDET;
+        return deterministic_t::NONDET();
     }
 
     virtual scoped_ptr_t<val_t> eval_impl(scope_env_t *env, args_t *args, eval_flags_t) const {

--- a/src/rdb_protocol/terms/writes.cc
+++ b/src/rdb_protocol/terms/writes.cc
@@ -158,7 +158,8 @@ private:
             conflict_func.set(conflict_optarg->as_func());
 
             // Check that insert function is atomic.
-            rcheck(((*conflict_func)->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC,
+            rcheck((*conflict_func)->is_deterministic().test(single_server::no,
+                                                              constant_now::yes),
                    base_exc_t::LOGIC,
                    strprintf("The conflict function passed to `insert` must "
                              "be deterministic."));
@@ -304,7 +305,8 @@ private:
         }
 
         if (!nondet_ok) {
-            rcheck((args->arg_is_deterministic(1) & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC,
+            rcheck(args->arg_is_deterministic(1).test(single_server::no,
+                                                      constant_now::yes),
                    base_exc_t::LOGIC,
                    "Could not prove argument deterministic.  "
                    "Maybe you want to use the non_atomic flag?");
@@ -313,7 +315,7 @@ private:
             args->arg(env, 1)->as_func(CONSTANT_SHORTCUT);
         if (!nondet_ok) {
             // If this isn't true we should have caught it in the `rcheck` above.
-            rassert((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC);
+            rassert(f->is_deterministic().test(single_server::no, constant_now::yes));
         }
 
         scoped_ptr_t<val_t> v0 = args->arg(env, 0);
@@ -347,7 +349,7 @@ private:
                     tbl->db->id,
                     tbl->get_id());
             }
-            if ((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC) {
+            if (f->is_deterministic().test(single_server::no, constant_now::yes)) {
                 // Attach a transformation to `ds` to pull out the primary key.
                 minidriver_t r(backtrace());
                 auto x = minidriver_t::dummy_var_t::REPLACE_HELPER_ROW;
@@ -367,7 +369,7 @@ private:
                 }
 
                 scoped_ptr_t<std::vector<datum_t> > keys;
-                if ((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) != deterministic_t::DETERMINISTIC) {
+                if (!f->is_deterministic().test(single_server::no, constant_now::yes)) {
                     keys = make_scoped<std::vector<datum_t> >();
                     keys->reserve(vals.size());
                     for (const auto &val : vals) {

--- a/src/rdb_protocol/terms/writes.cc
+++ b/src/rdb_protocol/terms/writes.cc
@@ -158,7 +158,7 @@ private:
             conflict_func.set(conflict_optarg->as_func());
 
             // Check that insert function is atomic.
-            rcheck((*conflict_func)->is_deterministic() == deterministic_t::always,
+            rcheck(((*conflict_func)->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC,
                    base_exc_t::LOGIC,
                    strprintf("The conflict function passed to `insert` must "
                              "be deterministic."));
@@ -304,7 +304,7 @@ private:
         }
 
         if (!nondet_ok) {
-            rcheck(args->arg_is_deterministic(1) == deterministic_t::always,
+            rcheck((args->arg_is_deterministic(1) &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC,
                    base_exc_t::LOGIC,
                    "Could not prove argument deterministic.  "
                    "Maybe you want to use the non_atomic flag?");
@@ -313,7 +313,7 @@ private:
             args->arg(env, 1)->as_func(CONSTANT_SHORTCUT);
         if (!nondet_ok) {
             // If this isn't true we should have caught it in the `rcheck` above.
-            rassert(f->is_deterministic() == deterministic_t::always);
+            rassert((f->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC);
         }
 
         scoped_ptr_t<val_t> v0 = args->arg(env, 0);
@@ -347,7 +347,7 @@ private:
                     tbl->db->id,
                     tbl->get_id());
             }
-            if (f->is_deterministic() == deterministic_t::always) {
+            if ((f->is_deterministic() &~ DET_CONSTANT_NOW)== DET_DETERMINISTIC) {
                 // Attach a transformation to `ds` to pull out the primary key.
                 minidriver_t r(backtrace());
                 auto x = minidriver_t::dummy_var_t::REPLACE_HELPER_ROW;
@@ -367,7 +367,7 @@ private:
                 }
 
                 scoped_ptr_t<std::vector<datum_t> > keys;
-                if (f->is_deterministic() != deterministic_t::always) {
+                if ((f->is_deterministic() &~ DET_CONSTANT_NOW) != DET_DETERMINISTIC) {
                     keys = make_scoped<std::vector<datum_t> >();
                     keys->reserve(vals.size());
                     for (const auto &val : vals) {

--- a/src/rdb_protocol/terms/writes.cc
+++ b/src/rdb_protocol/terms/writes.cc
@@ -158,8 +158,8 @@ private:
             conflict_func.set(conflict_optarg->as_func());
 
             // Check that insert function is atomic.
-            rcheck((*conflict_func)->is_deterministic().test(single_server::no,
-                                                              constant_now::yes),
+            rcheck((*conflict_func)->is_deterministic().test(single_server_t::no,
+                                                              constant_now_t::yes),
                    base_exc_t::LOGIC,
                    strprintf("The conflict function passed to `insert` must "
                              "be deterministic."));
@@ -305,8 +305,8 @@ private:
         }
 
         if (!nondet_ok) {
-            rcheck(args->arg_is_deterministic(1).test(single_server::no,
-                                                      constant_now::yes),
+            rcheck(args->arg_is_deterministic(1).test(single_server_t::no,
+                                                      constant_now_t::yes),
                    base_exc_t::LOGIC,
                    "Could not prove argument deterministic.  "
                    "Maybe you want to use the non_atomic flag?");
@@ -349,7 +349,7 @@ private:
                     tbl->db->id,
                     tbl->get_id());
             }
-            if (f->is_deterministic().test(single_server::no, constant_now::yes)) {
+            if (f->is_deterministic().test(single_server_t::no, constant_now_t::yes)) {
                 // Attach a transformation to `ds` to pull out the primary key.
                 minidriver_t r(backtrace());
                 auto x = minidriver_t::dummy_var_t::REPLACE_HELPER_ROW;
@@ -369,7 +369,7 @@ private:
                 }
 
                 scoped_ptr_t<std::vector<datum_t> > keys;
-                if (!f->is_deterministic().test(single_server::no, constant_now::yes)) {
+                if (!f->is_deterministic().test(single_server_t::no, constant_now_t::yes)) {
                     keys = make_scoped<std::vector<datum_t> >();
                     keys->reserve(vals.size());
                     for (const auto &val : vals) {

--- a/src/rdb_protocol/terms/writes.cc
+++ b/src/rdb_protocol/terms/writes.cc
@@ -158,7 +158,7 @@ private:
             conflict_func.set(conflict_optarg->as_func());
 
             // Check that insert function is atomic.
-            rcheck(((*conflict_func)->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC,
+            rcheck(((*conflict_func)->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC,
                    base_exc_t::LOGIC,
                    strprintf("The conflict function passed to `insert` must "
                              "be deterministic."));
@@ -304,7 +304,7 @@ private:
         }
 
         if (!nondet_ok) {
-            rcheck((args->arg_is_deterministic(1) &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC,
+            rcheck((args->arg_is_deterministic(1) & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC,
                    base_exc_t::LOGIC,
                    "Could not prove argument deterministic.  "
                    "Maybe you want to use the non_atomic flag?");
@@ -313,7 +313,7 @@ private:
             args->arg(env, 1)->as_func(CONSTANT_SHORTCUT);
         if (!nondet_ok) {
             // If this isn't true we should have caught it in the `rcheck` above.
-            rassert((f->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC);
+            rassert((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC);
         }
 
         scoped_ptr_t<val_t> v0 = args->arg(env, 0);
@@ -347,7 +347,7 @@ private:
                     tbl->db->id,
                     tbl->get_id());
             }
-            if ((f->is_deterministic() &~ DET_CONSTANT_NOW)== DET_DETERMINISTIC) {
+            if ((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC) {
                 // Attach a transformation to `ds` to pull out the primary key.
                 minidriver_t r(backtrace());
                 auto x = minidriver_t::dummy_var_t::REPLACE_HELPER_ROW;
@@ -367,7 +367,7 @@ private:
                 }
 
                 scoped_ptr_t<std::vector<datum_t> > keys;
-                if ((f->is_deterministic() &~ DET_CONSTANT_NOW) != DET_DETERMINISTIC) {
+                if ((f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) != deterministic_t::DETERMINISTIC) {
                     keys = make_scoped<std::vector<datum_t> >();
                     keys->reserve(vals.size());
                     for (const auto &val : vals) {

--- a/src/rdb_protocol/val.cc
+++ b/src/rdb_protocol/val.cc
@@ -40,7 +40,7 @@ public:
         std::vector<datum_t > keys{key};
         // We don't need to fetch the value for deterministic replacements.
         std::vector<datum_t > vals{
-            f->is_deterministic() == deterministic_t::always ? datum_t() : get()};
+            (f->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC ? datum_t() : get()};
         return tbl->batched_replace(
             env, vals, keys, f, nondet_ok, dur_req, return_changes, ignore_write_hook);
     }
@@ -258,7 +258,7 @@ datum_t table_t::batched_replace(
         return ql::datum_t::empty_object();
     }
 
-    if (replacement_generator->is_deterministic() != deterministic_t::always) {
+    if ((replacement_generator->is_deterministic() &~ DET_CONSTANT_NOW) != DET_DETERMINISTIC) {
         r_sanity_check(nondeterministic_replacements_ok);
         datum_object_builder_t stats;
         std::vector<datum_t> replacement_values;

--- a/src/rdb_protocol/val.cc
+++ b/src/rdb_protocol/val.cc
@@ -40,7 +40,7 @@ public:
         std::vector<datum_t> keys = {key};
         // We don't need to fetch the value for deterministic replacements.
         std::vector<datum_t> vals = {
-            f->is_deterministic().test(single_server::no, constant_now::yes) ? datum_t() : get()};
+            f->is_deterministic().test(single_server_t::no, constant_now_t::yes) ? datum_t() : get()};
         return tbl->batched_replace(
             env, vals, keys, f, nondet_ok, dur_req, return_changes, ignore_write_hook);
     }
@@ -258,8 +258,8 @@ datum_t table_t::batched_replace(
         return ql::datum_t::empty_object();
     }
 
-    if (!replacement_generator->is_deterministic().test(single_server::no,
-                                                        constant_now::yes)) {
+    if (!replacement_generator->is_deterministic().test(single_server_t::no,
+                                                        constant_now_t::yes)) {
         r_sanity_check(nondeterministic_replacements_ok);
         datum_object_builder_t stats;
         std::vector<datum_t> replacement_values;

--- a/src/rdb_protocol/val.cc
+++ b/src/rdb_protocol/val.cc
@@ -37,10 +37,10 @@ public:
         durability_requirement_t dur_req,
         return_changes_t return_changes,
         ignore_write_hook_t ignore_write_hook) {
-        std::vector<datum_t > keys{key};
+        std::vector<datum_t> keys = {key};
         // We don't need to fetch the value for deterministic replacements.
-        std::vector<datum_t > vals{
-            (f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC ? datum_t() : get()};
+        std::vector<datum_t> vals = {
+            f->is_deterministic().test(single_server::no, constant_now::yes) ? datum_t() : get()};
         return tbl->batched_replace(
             env, vals, keys, f, nondet_ok, dur_req, return_changes, ignore_write_hook);
     }
@@ -258,7 +258,8 @@ datum_t table_t::batched_replace(
         return ql::datum_t::empty_object();
     }
 
-    if ((replacement_generator->is_deterministic() & ~deterministic_t::CONSTANT_NOW) != deterministic_t::DETERMINISTIC) {
+    if (!replacement_generator->is_deterministic().test(single_server::no,
+                                                        constant_now::yes)) {
         r_sanity_check(nondeterministic_replacements_ok);
         datum_object_builder_t stats;
         std::vector<datum_t> replacement_values;

--- a/src/rdb_protocol/val.cc
+++ b/src/rdb_protocol/val.cc
@@ -40,7 +40,7 @@ public:
         std::vector<datum_t > keys{key};
         // We don't need to fetch the value for deterministic replacements.
         std::vector<datum_t > vals{
-            (f->is_deterministic() &~ DET_CONSTANT_NOW) == DET_DETERMINISTIC ? datum_t() : get()};
+            (f->is_deterministic() & ~deterministic_t::CONSTANT_NOW) == deterministic_t::DETERMINISTIC ? datum_t() : get()};
         return tbl->batched_replace(
             env, vals, keys, f, nondet_ok, dur_req, return_changes, ignore_write_hook);
     }
@@ -258,7 +258,7 @@ datum_t table_t::batched_replace(
         return ql::datum_t::empty_object();
     }
 
-    if ((replacement_generator->is_deterministic() &~ DET_CONSTANT_NOW) != DET_DETERMINISTIC) {
+    if ((replacement_generator->is_deterministic() & ~deterministic_t::CONSTANT_NOW) != deterministic_t::DETERMINISTIC) {
         r_sanity_check(nondeterministic_replacements_ok);
         datum_object_builder_t stats;
         std::vector<datum_t> replacement_values;

--- a/test/rql_test/src/changefeeds/now.py_one.yaml
+++ b/test/rql_test/src/changefeeds/now.py_one.yaml
@@ -1,0 +1,8 @@
+desc: Test that r.now() is allowed before changes(), disallowed after.
+table_variable_name: tbl
+tests:
+
+    - py: tbl.changes().merge({'a': r.now()})
+      ot: err('ReqlQueryLogicError')
+
+    - py: tbl.merge({'a': r.now()}).changes()

--- a/test/rql_test/src/regression/6191.py_one.yaml
+++ b/test/rql_test/src/regression/6191.py_one.yaml
@@ -1,0 +1,5 @@
+desc: 6191 (bug in PR, order-by disallowed deterministic r.now())
+tests:
+  - py: r.expr([1, 2]).order_by(lambda x: r.now())
+    ot: [1, 2]
+


### PR DESCRIPTION
Fixes #6125

Replaces the pseudo-boolean `deterministic_t` with a bitmask.