### PR TITLE
Misc makefile fixes

### DIFF
--- a/mk/packaging.mk
+++ b/mk/packaging.mk
@@ -134,7 +134,7 @@ clean-dist-dir:
 	rm -rf $(DIST_DIR)
 
 .PHONY: reset-dist-dir
-reset-dist-dir: FORCE | web-assets
+reset-dist-dir: FORCE
 	test ! -e $(DIST_DIR) || { echo "error: $(DIST_DIR) exists. make clean-dist-dir first"; false; }
 	$P CP $(DIST_DIR)
 	mkdir -p $(DIST_DIR)

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -11,7 +11,7 @@ clean:
 	dh_clean
 	if [ -e build ] ; then rm -rf build ; fi ;
 
-install: build
+install:
 	dh_clean
 	dh_installdirs
 	$(MAKE) DEBUG=$(DEBUG) DESTDIR=$(CURDIR)/debian/$(package) PVERSION=$(PVERSION) STRIP_ON_INSTALL=0 install

--- a/src/build.mk
+++ b/src/build.mk
@@ -374,7 +374,7 @@ $(OBJ_DIR)/web_assets/web_assets.o: $(BUILD_ROOT_DIR)/bundle_assets/web_assets.c
 $(OBJ_DIR)/%.pb.o: $(PROTO_DIR)/%.pb.cc $(MAKEFILE_DEPENDENCY) $(QL2_PROTO_HEADERS)
 	mkdir -p $(dir $@)
 	$P CC
-	$(RT_CXX) $(RT_CXXFLAGS) -c -o $@ $<
+	$(RT_CXX) $(RT_CXXFLAGS) -w -c -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SOURCE_DIR)/%.cc $(MAKEFILE_DEPENDENCY) $(ALL_INCLUDE_DEPS) | $(QL2_PROTO_OBJS)
 	mkdir -p $(dir $@) $(dir $(DEP_DIR)/$*)


### PR DESCRIPTION
- Don't unnecessarily build the web assets when packaging.
- Don't build RethinkDB twice when building Debian and Ubuntu packages
- Ignore warnings in generated C++ files