### PR TITLE
Fix use-after-move bug in lru_cache

### DIFF
--- a/src/containers/lru_cache.hpp
+++ b/src/containers/lru_cache.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <list>
 
+#include "debug.hpp"
 #include "errors.hpp"
 
 template <typename K, typename V>
@@ -83,7 +84,7 @@ public:
     }
 private:
     V &insert(const K &key) {
-        cache_list_.push_front(std::make_pair(key, V()));
+        cache_list_.emplace_front(key, V());
         cache_map_[key] = cache_list_.begin();
         if (cache_list_.size() > _max) {
             cache_map_.erase(cache_list_.back().first);
@@ -92,8 +93,8 @@ private:
         return cache_list_.begin()->second;
     }
     V &insert(K &&key) {
-        cache_list_.push_front(std::make_pair(std::move(key), V()));
-        cache_map_[key] = cache_list_.begin();
+        cache_list_.emplace_front(key, V());
+        cache_map_[std::move(key)] = cache_list_.begin();
         if (cache_list_.size() > _max) {
             cache_map_.erase(cache_list_.back().first);
             cache_list_.pop_back();
@@ -106,6 +107,21 @@ private:
         cache_list_.push_front(std::move(pair));
         it->second = cache_list_.begin();
     }
+
+    friend void debug_print(printf_buffer_t *buf, const lru_cache_t &cache) {
+        buf->appendf("lru_cache:\n");
+        buf->appendf("  list: [\n");
+        for (auto &it : cache.cache_list_) {
+            buf->appendf("    '%s' x '%s'\n", it.first.c_str(), it.second ? it.second->pattern().c_str() : "null");
+        }
+        buf->appendf("  ]\n");
+        buf->appendf("  map: [\n");
+        for (auto &it : cache.cache_map_) {
+            buf->appendf("    '%s' -> '%s'\n", it.first.c_str(), it.second->first.c_str());
+        }
+        buf->appendf("  ]\n");
+    }
+
 };
 
 #endif // CONTAINERS_LRU_CACHE_HPP_

--- a/src/unittest/lru_cache_test.cc
+++ b/src/unittest/lru_cache_test.cc
@@ -1,68 +1,72 @@
 #include "unittest/gtest.hpp"
 
+#include <string>
+
 #include "containers/lru_cache.hpp"
 
 namespace unittest {
 
 TEST(LRUCacheTest, Simple) {
-    lru_cache_t<int, int> cache(10);
-    cache[4] = 5;
-    cache[8] = 10;
-    cache[0] = 12;
+    lru_cache_t<std::string, int> cache(10);
+    cache["4"] = 5;
+    cache["8"] = 10;
+    cache["0"] = 12;
     EXPECT_EQ(10, cache.max_size()) << "cache max size is not correct";
     EXPECT_EQ(3, cache.size()) << "cache current size is not correct";
-    EXPECT_EQ(10, cache[8]) << "cache [] is not correct";
-    cache[4] = 18;
-    EXPECT_EQ(cache[4], 18) << "cache update is wrong";
-    
+    EXPECT_EQ(10, cache["8"]) << "cache [] is not correct";
+    cache["4"] = 18;
+    EXPECT_EQ(cache["4"], 18) << "cache update is wrong";
+
     auto it = cache.begin();
-    EXPECT_EQ(4, it->first);
+    EXPECT_EQ("4", it->first);
     EXPECT_EQ(18, it->second);
     ++it;
-    EXPECT_EQ(8, it->first);
+    EXPECT_EQ("8", it->first);
     EXPECT_EQ(10, it->second);
     ++it;
-    EXPECT_EQ(0, it->first);
+    EXPECT_EQ("0", it->first);
     EXPECT_EQ(12, it->second);
     ++it;
     EXPECT_EQ(cache.end(), it) << "Wrong number of iterations?";
 }
 
 TEST(LRUCacheTest, Eviction) {
-    lru_cache_t<int, int> cache(10);
-    for (int i = 0; i < 20; i++) cache[i] = i;
+    lru_cache_t<std::string, int> cache(10);
+    char c[2] = {0};
+    for (c[0] = 'a'; c[0] < 'u'; c[0]++) cache[c] = c[0] - 'a';
     EXPECT_EQ(10, cache.size());
-    EXPECT_EQ(19, cache.begin()->first);
-    EXPECT_EQ(10, cache.rbegin()->first);
-    cache[4] = 42;
-    cache[14] = 88;
-    cache[8] = 18;
+    EXPECT_EQ("t", cache.begin()->first);
+    EXPECT_EQ("k", cache.rbegin()->first);
+    cache["e"] = 42;
+    cache["o"] = 88;
+    cache["i"] = 18;
     EXPECT_EQ(10, cache.size());
-    
+
     auto it = cache.begin();
-    EXPECT_EQ(8, it->first);
+    EXPECT_EQ("i", it->first);
     EXPECT_EQ(18, it->second);
     ++it;
-    EXPECT_EQ(14, it->first);
+    EXPECT_EQ("o", it->first);
     EXPECT_EQ(88, it->second);
     ++it;
-    EXPECT_EQ(4, it->first);
+    EXPECT_EQ("e", it->first);
     EXPECT_EQ(42, it->second);
     ++it;
-    EXPECT_EQ(19, it->first);
+    EXPECT_EQ("t", it->first);
     EXPECT_EQ(19, it->second);
-    EXPECT_EQ(12, cache.rbegin()->first);
+    EXPECT_EQ("m", cache.rbegin()->first);
 }
 
 TEST(LRUCacheTest, Find) {
-    lru_cache_t<int, int> cache(10);
-    for (int i = 0; i < 20; i++) cache[i] = i;
-    EXPECT_EQ(19, cache.begin()->first);
-    EXPECT_EQ(cache.end(), cache.find(3));
-    EXPECT_EQ(19, cache.begin()->first);
-    EXPECT_EQ(13, cache.find(13)->first);
-    EXPECT_EQ(13, cache.begin()->first);
-    EXPECT_EQ(10, cache.rbegin()->first);
+    lru_cache_t<std::string, int> cache(10);
+    char c[2] = {0};
+    for (c[0] = 'a'; c[0] < 'u'; c[0]++) cache[c] = c[0] - 'a';
+    EXPECT_EQ("t", cache.begin()->first);
+    EXPECT_EQ(cache.end(), cache.find("d"));
+    EXPECT_EQ("t", cache.begin()->first);
+    EXPECT_EQ("n", cache.find("n")->first);
+    EXPECT_EQ("n", cache.begin()->first);
+    EXPECT_EQ("k", cache.rbegin()->first);
 }
 
 } // namespace unittest


### PR DESCRIPTION
This fixes #6202

This fix should make empty regexp patterns behave correctly and allow all other regexp patterns to hit the cache.