### PR TITLE
Server Name Indication (Let's Encrypt / Server only certificate) support for Ruby, Python and Java drivers

### DIFF
--- a/drivers/java/src/main/java/com/rethinkdb/net/SocketWrapper.java
+++ b/drivers/java/src/main/java/com/rethinkdb/net/SocketWrapper.java
@@ -3,7 +3,10 @@ package com.rethinkdb.net;
 import com.rethinkdb.gen.exc.ReqlDriverError;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.DataInputStream;
@@ -14,7 +17,9 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.Optional;
+import java.util.List;
 
 public class SocketWrapper {
     // networking stuff
@@ -62,6 +67,15 @@ public class SocketWrapper {
                         socket.getInetAddress().getHostAddress(),
                         socket.getPort(),
                         true);
+
+                // SNI support, Java 8 only
+                SNIHostName serverName = new SNIHostName(hostname);
+                List<SNIServerName> serverNames = new ArrayList<>(1);
+                serverNames.add(serverName);
+
+                SSLParameters params = sslSocket.getSSLParameters();
+                params.setServerNames(serverNames);
+                sslSocket.setSSLParameters(params);
 
                 // replace input/output streams
                 readStream = new DataInputStream(sslSocket.getInputStream());

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -486,7 +486,7 @@ module RethinkDB
       @nonce = SecureRandom.base64(18)
       @timeout = opts[:timeout].to_i
       @timeout = 20 if @timeout <= 0
-      @ssl_opts = opts[:ssl] || {}
+      @ssl_opts = opts[:ssl] || nil
 
       @@last = self
       @default_opts = @default_db ? {:db => RQL.new.db(@default_db)} : {}
@@ -690,7 +690,7 @@ module RethinkDB
     end
 
     def init_socket
-      unless @ssl_opts.empty?
+      unless @ssl_opts.nil?
         @tcp_socket = base_socket
         context = create_context(@ssl_opts)
         @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
@@ -713,11 +713,11 @@ module RethinkDB
     def create_context(options)
       context = OpenSSL::SSL::SSLContext.new
       context.ssl_version = :TLSv1_2
-      if options[:ca_certs]
-        context.ca_file = options[:ca_certs]
-      elsif options[:ssl]
+      if @ssl_opts.empty?
         #Assume system certs
         context.ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
+      elsif options[:ca_certs]
+        context.ca_file = options[:ca_certs]
       end
       context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       context

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -715,10 +715,11 @@ module RethinkDB
       context.ssl_version = :TLSv1_2
       if options[:ca_certs]
         context.ca_file = options[:ca_certs]
-        context.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      else
-        raise 'ssl options provided but missing required "ca_certs" option'
+      elsif options[:ssl]
+        #Assume system certs
+        context.ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
       end
+      context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       context
     end
 

--- a/drivers/ruby/lib/net.rb
+++ b/drivers/ruby/lib/net.rb
@@ -695,6 +695,7 @@ module RethinkDB
         context = create_context(@ssl_opts)
         @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
         @socket.sync_close = true
+        @socket.hostname = @host
         @socket.connect
         verify_cert!(@socket, context)
       else


### PR DESCRIPTION
- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

Enable Server Name Indication / Let's Encrypt / Server only certificate support in the Ruby, Python and Java drivers; The Node/Javascript driver already works with server only certificates using the `servername` property.

The changes are minimal and non-breaking to existing usage. These commits can be cleaned up, squashed, etc, but for now providing it as is to provide as much information and context as possible.

#### Ruby

For Ruby you'd specify an empty ssl hash to indicate SNI:

```ruby
    conn = r.connect(:host =>'rethink.domain.com',
        :port => 11111,
        :auth_key => '<auth_key>',
        :ssl => {}
    )
```


#### Python

For Python you'd do the same as for Ruby:

```python
    conn = r.connect(host='rethink.domain.com',
        port=11111,
        auth_key='<auth_key>',
        ssl=>{})
```

#### Java

For Java you have to use the sslContext option and initiate it using nulls (which means it uses the system trust manager):

```java
    Connection conn = null;
    Connection.Builder builder = r.connection().
        hostname(host).
	port(port).
	authKey(authKey);

    final SSLContext sslContext = SSLContext.getInstance(DEFAULT_SSL_PROTOCOL);
    sslContext.init(null, null, null);
    conn = builder.sslContext(sslContext).connect();
```

Also need to look at making corresponding changes to the rethinkdb client itself, i.e. for `rethinkdb dump` and `rethinkdb restore`, but I thought this would be a good place to start.
