### PR TITLE
Disable failing InsertOp and DeleteOp tests.

### DIFF
--- a/src/unittest/rdb_interruptor.cc
+++ b/src/unittest/rdb_interruptor.cc
@@ -134,7 +134,7 @@ private:
     const bool should_exist;
 };
 
-TEST(RDBInterrupt, InsertOp) {
+TEST(RDBInterrupt, DISABLED_InsertOp) {
     ql::minidriver_t r(ql::backtrace_id_t::empty());
     ql::raw_term_t insert_term =
         r.db("db").table("table").insert(
@@ -212,7 +212,7 @@ TEST(RDBInterrupt, GetOp) {
     }
 }
 
-TEST(RDBInterrupt, DeleteOp) {
+TEST(RDBInterrupt, DISABLED_DeleteOp) {
     uint32_t eval_count;
     std::set<ql::datum_t, optional_datum_less_t> initial_data;
 


### PR DESCRIPTION
Apparently these have been failing since write hooks were
implemented.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Disables failing tests.  We get a nice warning that they're disabled when you run unit tests.  All the other unit tests pass.

See #6095, which is the issue about the test failures.