### PR TITLE
Serializer cleanup

### DIFF
--- a/src/buffer_cache/page.hpp
+++ b/src/buffer_cache/page.hpp
@@ -32,7 +32,7 @@ public:
 
     page_t(block_id_t block_id, buf_ptr_t buf, page_cache_t *page_cache);
     page_t(block_id_t block_id, buf_ptr_t buf,
-           const counted_t<standard_block_token_t> &token,
+           const counted_t<block_token_t> &token,
            page_cache_t *page_cache);
     page_t(page_t *copyee, page_cache_t *page_cache, cache_account_t *account);
     ~page_t();
@@ -72,12 +72,12 @@ public:
 
     bool page_ptr_count() const { return snapshot_refcount_; }
 
-    const counted_t<standard_block_token_t> &block_token() const {
+    const counted_t<block_token_t> &block_token() const {
         return block_token_;
     }
 
     ser_buffer_t *get_loaded_ser_buffer();
-    void init_block_token(counted_t<standard_block_token_t> token,
+    void init_block_token(counted_t<block_token_t> token,
                           page_cache_t *page_cache);
 
 private:
@@ -93,7 +93,7 @@ private:
 
 
     static void finish_load_with_block_id(page_t *page, page_cache_t *page_cache,
-                                          counted_t<standard_block_token_t> block_token,
+                                          counted_t<block_token_t> block_token,
                                           buf_ptr_t buf);
 
     static void catch_up_with_deferred_load(
@@ -128,7 +128,7 @@ private:
     page_loader_t *loader_;
 
     buf_ptr_t buf_;
-    counted_t<standard_block_token_t> block_token_;
+    counted_t<block_token_t> block_token_;
 
     uint64_t access_time_;
 

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -1075,14 +1075,14 @@ void page_txn_t::announce_waiting_for_flush() {
     page_cache_->im_waiting_for_flush(this);
 }
 
-std::map<block_id_t, page_cache_t::block_change_t>
+std::unordered_map<block_id_t, page_cache_t::block_change_t>
 page_cache_t::compute_changes(const std::vector<page_txn_t *> &txns) {
     // We combine changes, using the block_version_t value to see which change
     // happened later.  This even works if a single transaction acquired the same
     // block twice.
 
     // The map of changes we make.
-    std::map<block_id_t, block_change_t> changes;
+    std::unordered_map<block_id_t, block_change_t> changes;
 
     for (auto it = txns.begin(); it != txns.end(); ++it) {
         page_txn_t *txn = *it;
@@ -1222,7 +1222,7 @@ struct ancillary_info_t {
 };
 
 void page_cache_t::do_flush_changes(page_cache_t *page_cache,
-                                    std::map<block_id_t, block_change_t> &&changes,
+                                    std::unordered_map<block_id_t, block_change_t> &&changes,
                                     const std::vector<page_txn_t *> &txns,
                                     fifo_enforcer_write_token_t index_write_token) {
     rassert(!changes.empty());
@@ -1401,7 +1401,7 @@ void page_cache_t::do_flush_changes(page_cache_t *page_cache,
 }
 
 void page_cache_t::do_flush_txn_set(page_cache_t *page_cache,
-                                    std::map<block_id_t, block_change_t> *changes_ptr,
+                                    std::unordered_map<block_id_t, block_change_t> *changes_ptr,
                                     const std::vector<page_txn_t *> &txns) {
     // This is called with spawn_now_dangerously!  The reason is partly so that we
     // don't put a zillion coroutines on the message loop when doing a bunch of
@@ -1413,7 +1413,7 @@ void page_cache_t::do_flush_txn_set(page_cache_t *page_cache,
     // set of changes we're actually doing is, since any transaction may have touched
     // the same blocks.
 
-    std::map<block_id_t, block_change_t> changes = std::move(*changes_ptr);
+    std::unordered_map<block_id_t, block_change_t> changes = std::move(*changes_ptr);
     rassert(!changes.empty());
 
     fifo_enforcer_write_token_t index_write_token
@@ -1555,7 +1555,7 @@ void page_cache_t::im_waiting_for_flush(page_txn_t *base) {
             (*it)->spawned_flush_ = true;
         }
 
-        std::map<block_id_t, block_change_t> changes
+        std::unordered_map<block_id_t, block_change_t> changes
             = page_cache_t::compute_changes(flush_set);
 
         if (!changes.empty()) {

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -81,7 +81,7 @@ class current_page_t {
 public:
     current_page_t(block_id_t block_id, buf_ptr_t buf, page_cache_t *page_cache);
     current_page_t(block_id_t block_id, buf_ptr_t buf,
-                   const counted_t<standard_block_token_t> &token,
+                   const counted_t<block_token_t> &token,
                    page_cache_t *page_cache);
     // Constructs a page to be loaded from the serializer.
     explicit current_page_t(block_id_t block_id);
@@ -278,7 +278,7 @@ public:
 
     void offer_read_ahead_buf(block_id_t block_id,
                               buf_ptr_t *buf,
-                              const counted_t<standard_block_token_t> &token);
+                              const counted_t<block_token_t> &token);
 
     void destroy_self();
 
@@ -376,7 +376,7 @@ private:
     friend class page_read_ahead_cb_t;
     void add_read_ahead_buf(block_id_t block_id,
                             scoped_device_block_aligned_ptr_t<ser_buffer_t> ptr,
-                            const counted_t<standard_block_token_t> &token);
+                            const counted_t<block_token_t> &token);
 
     void read_ahead_cb_is_destroyed();
 

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -402,17 +402,17 @@ private:
 
     friend class page_txn_t;
     static void do_flush_changes(page_cache_t *page_cache,
-                                 std::map<block_id_t, block_change_t> &&changes,
+                                 std::unordered_map<block_id_t, block_change_t> &&changes,
                                  const std::vector<page_txn_t *> &txns,
                                  fifo_enforcer_write_token_t index_write_token);
     static void do_flush_txn_set(page_cache_t *page_cache,
-                                 std::map<block_id_t, block_change_t> *changes_ptr,
+                                 std::unordered_map<block_id_t, block_change_t> *changes_ptr,
                                  const std::vector<page_txn_t *> &txns);
 
     static void remove_txn_set_from_graph(page_cache_t *page_cache,
                                           const std::vector<page_txn_t *> &txns);
 
-    static std::map<block_id_t, block_change_t>
+    static std::unordered_map<block_id_t, block_change_t>
     compute_changes(const std::vector<page_txn_t *> &txns);
 
     static std::vector<page_txn_t *> maximal_flushable_txn_set(page_txn_t *base);

--- a/src/config/args.hpp
+++ b/src/config/args.hpp
@@ -132,13 +132,9 @@
 // How many block ids should the LBA garbage collector rewrite before yielding?
 #define LBA_GC_BATCH_SIZE                         (1024 * 8)
 
-// How many LBA structures to have for each file
+// How many LBA structures to have for each file (This value defines the disk format!
+// It can't change unless you're very careful.)
 #define LBA_SHARD_FACTOR                          4
-
-// How much space to reserve in the metablock to store inline LBA entries
-// Make sure that it fits into METABLOCK_SIZE, including all other meta data
-// TODO (daniel): Tune
-#define LBA_INLINE_SIZE                           (METABLOCK_SIZE - 512)
 
 // How many bytes of buffering space we can use per disk when reading the LBA. If it's set
 // too high, then RethinkDB will eat a lot of memory at startup. This is bad because tcmalloc

--- a/src/config/args.hpp
+++ b/src/config/args.hpp
@@ -72,9 +72,6 @@
 // Size of the device block size (in bytes)
 #define DEVICE_BLOCK_SIZE                         512
 
-// Size of the metablock (in bytes)
-#define METABLOCK_SIZE                            (4 * KILOBYTE)
-
 // Size of each btree node (in bytes) on disk
 #define DEFAULT_BTREE_BLOCK_SIZE                  (4 * KILOBYTE)
 

--- a/src/containers/scoped.hpp
+++ b/src/containers/scoped.hpp
@@ -254,9 +254,6 @@ private:
 template <class T, void*(*alloc)(size_t), void(*dealloc)(void*)>
 class scoped_alloc_t {
 
-    static_assert(std::is_pod<T>::value || std::is_same<T, void>::value,
-                  "refusing to malloc non-POD, non-void type");
-
 public:
     template <class U, void*(*alloc_)(size_t), void(*dealloc_)(void*)>
     friend class scoped_alloc_t;
@@ -308,6 +305,9 @@ public:
 protected:
 #endif
     ~scoped_alloc_t() {
+        static_assert(std::is_pod<T>::value || std::is_same<T, void>::value,
+                      "refusing to malloc non-POD, non-void type");
+
         dealloc(ptr_);
     }
 

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -88,9 +88,8 @@ struct change_val_t {
     store_key_t pkey;
     optional<indexed_datum_t> old_val, new_val;
     DEBUG_ONLY(optional<std::string> sindex;);
-    // This should be true, but older versions of boost don't support `move`
-    // well in optionals.
-    // MOVABLE_BUT_NOT_COPYABLE(change_val_t);
+
+    MOVABLE_BUT_NOT_COPYABLE(change_val_t);
 };
 
 namespace debug {

--- a/src/rdb_protocol/changefeed.hpp
+++ b/src/rdb_protocol/changefeed.hpp
@@ -95,11 +95,13 @@ struct msg_t {
         RDB_DECLARE_ME_SERIALIZABLE(limit_stop_t);
     };
     struct change_t {
-        index_vals_t old_indexes, new_indexes;
+        index_vals_t old_indexes;
+        index_vals_t new_indexes;
         store_key_t pkey;
         /* For a newly-created row, `old_val` is an empty `datum_t`. For a deleted row,
         `new_val` is an empty `datum_t`. */
-        datum_t old_val, new_val;
+        datum_t old_val;
+        datum_t new_val;
         RDB_DECLARE_ME_SERIALIZABLE(change_t);
     };
     struct stop_t {

--- a/src/rdb_protocol/changefeed.hpp
+++ b/src/rdb_protocol/changefeed.hpp
@@ -414,12 +414,12 @@ public:
         std::vector<item_t> &&item_vec);
 
     void add(rwlock_in_line_t *spot,
-             store_key_t sk,
+             const store_key_t &sk,
              is_primary_t is_primary,
              datum_t key,
              datum_t val) THROWS_NOTHING;
     void del(rwlock_in_line_t *spot,
-             store_key_t sk,
+             const store_key_t &sk,
              is_primary_t is_primary) THROWS_NOTHING;
     void commit(rwlock_in_line_t *spot,
                 const boost::variant<primary_ref_t, sindex_ref_t> &sindex_ref)

--- a/src/rdb_protocol/datum.hpp
+++ b/src/rdb_protocol/datum.hpp
@@ -63,8 +63,6 @@ enum throw_bool_t { NOTHROW = 0, THROW = 1 };
 // CLOBBER: Overwrite existing values.
 enum clobber_bool_t { NOCLOBBER = 0, CLOBBER = 1 };
 
-enum class use_json_t { NO = 0, YES = 1 };
-
 // When getting the typename of a datum, this should be YES if the name will be
 // used for sorting datums by type, and NO if the name is to be given to a user.
 enum class name_for_sorting_t { NO = 0, YES = 1 };

--- a/src/serializer/buf_ptr.cc
+++ b/src/serializer/buf_ptr.cc
@@ -20,9 +20,9 @@ buf_ptr_t buf_ptr_t::alloc_zeroed(block_size_t size) {
     return ret;
 }
 
-scoped_device_block_aligned_ptr_t<ser_buffer_t> help_allocate_copy(const ser_buffer_t *copyee,
-                                                                   size_t amount_to_copy,
-                                                                   size_t reserved_size) {
+scoped_device_block_aligned_ptr_t<ser_buffer_t>
+help_allocate_copy(const ser_buffer_t *copyee, size_t amount_to_copy,
+                   size_t reserved_size) {
     rassert(amount_to_copy <= reserved_size);
     auto buf = scoped_device_block_aligned_ptr_t<ser_buffer_t>(reserved_size);
     memcpy(buf.get(), copyee, amount_to_copy);

--- a/src/serializer/log/config.hpp
+++ b/src/serializer/log/config.hpp
@@ -32,7 +32,9 @@ struct log_serializer_on_disk_static_config_t {
     uint64_t extent_index(int64_t offset) const { return offset / extent_size_; }
 
     // Minimize calls to these.
-    max_block_size_t max_block_size() const { return max_block_size_t::unsafe_make(block_size_); }
+    max_block_size_t max_block_size() const {
+        return max_block_size_t::unsafe_make(block_size_);
+    }
     uint64_t extent_size() const { return extent_size_; }
 };
 

--- a/src/serializer/log/config.hpp
+++ b/src/serializer/log/config.hpp
@@ -14,15 +14,10 @@
 struct log_serializer_dynamic_config_t {
     log_serializer_dynamic_config_t() {
         read_ahead = true;
-        io_batch_factor = DEFAULT_IO_BATCH_FACTOR;
     }
 
-    /* The (minimal) batch size of i/o requests being taken from a single i/o account.
-    It is a factor because the actual batch size is this factor multiplied by the
-    i/o priority of the account. */
-    int32_t io_batch_factor;
-
-    /* Enable reading more data than requested to let the cache warmup more quickly esp. on rotational drives */
+    /* Enable reading more data than requested to let the cache warmup more quickly
+       esp. on rotational drives */
     bool read_ahead;
 };
 

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -408,7 +408,7 @@ data_block_manager_t::~data_block_manager_t() {
     guarantee(state == state_unstarted || state == state_shut_down);
 }
 
-void data_block_manager_t::prepare_initial_metablock(data_block_manager::metablock_mixin_t *mb) {
+void data_block_manager_t::prepare_initial_metablock(dbm_metablock_mixin_t *mb) {
     mb->active_extent = NULL_OFFSET;
 }
 
@@ -440,7 +440,7 @@ void data_block_manager_t::end_reconstruct() {
 
 void data_block_manager_t::start_existing(
         file_t *file,
-        const data_block_manager::metablock_mixin_t *last_metablock) {
+        const dbm_metablock_mixin_t *last_metablock) {
     guarantee(state == state_unstarted);
     dbfile = file;
     gc_io_account_nice.init(new file_account_t(file, GC_IO_PRIORITY_NICE));
@@ -1360,7 +1360,7 @@ void data_block_manager_t::flush_gc_index_writes(signal_t *) {
     serializer->index_write(&dummy_acq, [] {}, index_write_ops);
 }
 
-void data_block_manager_t::prepare_metablock(data_block_manager::metablock_mixin_t *metablock) {
+void data_block_manager_t::prepare_metablock(dbm_metablock_mixin_t *metablock) {
     guarantee(state == state_ready || state == state_shutting_down);
 
     if (active_extent != nullptr) {

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -232,7 +232,8 @@ public:
         return info.relative_offset < relative_offset;
     }
 
-    std::vector<block_info_t>::const_iterator find_lower_bound_iter(uint32_t _relative_offset) const {
+    std::vector<block_info_t>::const_iterator
+    find_lower_bound_iter(uint32_t _relative_offset) const {
         return std::lower_bound(block_infos.begin(),
                                 block_infos.end(),
                                 _relative_offset,
@@ -437,8 +438,9 @@ void data_block_manager_t::end_reconstruct() {
     guarantee(state == state_unstarted);
 }
 
-void data_block_manager_t::start_existing(file_t *file,
-                                          const data_block_manager::metablock_mixin_t *last_metablock) {
+void data_block_manager_t::start_existing(
+        file_t *file,
+        const data_block_manager::metablock_mixin_t *last_metablock) {
     guarantee(state == state_unstarted);
     dbfile = file;
     gc_io_account_nice.init(new file_account_t(file, GC_IO_PRIORITY_NICE));
@@ -650,7 +652,8 @@ public:
                     continue;
                 }
 
-                const block_size_t block_size = block_size_t::unsafe_make(info.ser_block_size);
+                const block_size_t block_size
+                    = block_size_t::unsafe_make(info.ser_block_size);
                 buf_ptr_t buf = buf_ptr_t::alloc_uninitialized(block_size);
                 memcpy(buf.ser_buffer(), current_buf, info.ser_block_size);
                 buf.fill_padding_zero();
@@ -971,7 +974,8 @@ void data_block_manager_t::mark_garbage_tokenwise_with_offset(int64_t offset) {
     // Add to old garbage count if necessary (works because of the
     // !entry->block_is_garbage(block_index) assertion above).
     if (entry->state == gc_entry_t::state_old && entry->block_is_garbage(block_index)) {
-        gc_stats.old_garbage_block_bytes += gc_entry_t::aligned_value(entry->block_size(block_index));
+        gc_stats.old_garbage_block_bytes
+            += gc_entry_t::aligned_value(entry->block_size(block_index));
     }
 
     check_and_handle_empty_extent(extent_id);
@@ -1235,8 +1239,9 @@ void data_block_manager_t::write_gcs(
         std::vector<buf_write_info_t> the_writes;
         the_writes.reserve(writes.size());
         for (size_t i = 0; i < writes.size(); ++i) {
-            old_block_tokens.push_back(serializer->generate_block_token(writes[i].old_offset,
-                                                                        writes[i].block_size));
+            old_block_tokens.push_back(
+                    serializer->generate_block_token(writes[i].old_offset,
+                                                     writes[i].block_size));
 
             the_writes.push_back(buf_write_info_t(writes[i].buf,
                                                   writes[i].block_size,
@@ -1453,7 +1458,8 @@ data_block_manager_t::gimme_some_new_offsets(const std::vector<buf_write_info_t>
                                                              &block_index);
             guarantee(succeeded);
 
-            // Push the current group of tokens, if it's nonempty, onto the return vector.
+            // Push the current group of tokens, if it's nonempty, onto the return
+            // vector.
             if (!tokens.empty()) {
                 ret.push_back(std::move(tokens));
                 tokens.clear();

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -656,7 +656,7 @@ public:
                 buf.fill_padding_zero();
                 guarantee(info.ser_block_size <= *(lower_it + 1) - *lower_it);
 
-                counted_t<standard_block_token_t> token
+                counted_t<block_token_t> token
                     = parent->serializer->generate_block_token(current_offset,
                                                                block_size);
 
@@ -722,13 +722,13 @@ buf_ptr_t data_block_manager_t::read(int64_t off_in, block_size_t block_size,
     }
 }
 
-std::vector<counted_t<standard_block_token_t>>
+std::vector<counted_t<block_token_t>>
 data_block_manager_t::many_writes(const std::vector<buf_write_info_t> &writes,
                                   file_account_t *io_account,
                                   iocallback_t *cb) {
     // These tokens are grouped by extent.  You can do a contiguous write in each
     // extent.
-    std::vector<std::vector<counted_t<standard_block_token_t> > > token_groups
+    std::vector<std::vector<counted_t<block_token_t>>> token_groups
         = gimme_some_new_offsets(writes);
 
     for (auto it = writes.begin(); it != writes.end(); ++it) {
@@ -801,7 +801,7 @@ data_block_manager_t::many_writes(const std::vector<buf_write_info_t> &writes,
     // earlier).
     intermediate_cb->on_io_complete();
 
-    std::vector<counted_t<standard_block_token_t> > ret;
+    std::vector<counted_t<block_token_t>> ret;
     ret.reserve(writes.size());
     for (auto it = token_groups.begin(); it != token_groups.end(); ++it) {
         for (auto jt = it->begin(); jt != it->end(); ++jt) {
@@ -1220,13 +1220,13 @@ void data_block_manager_t::write_gcs(
     // We acquire block tokens for all the blocks before writing new
     // version.  The point of this is to make sure the _new_ block is
     // correctly "alive" when we write it.
-    std::vector<counted_t<standard_block_token_t> > old_block_tokens;
+    std::vector<counted_t<block_token_t>> old_block_tokens;
     old_block_tokens.reserve(writes.size());
 
     // New block tokens, to hold the return value of
     // data_block_manager_t::write() instead of immediately discarding the
     // created token and causing the extent or block to be collected.
-    std::vector<counted_t<standard_block_token_t> > new_block_tokens;
+    std::vector<counted_t<block_token_t>> new_block_tokens;
 
     {
         // Step 1: Write buffers to disk and assemble index operations
@@ -1413,7 +1413,7 @@ void data_block_manager_t::actually_shutdown() {
     }
 }
 
-std::vector<std::vector<counted_t<standard_block_token_t>>>
+std::vector<std::vector<counted_t<block_token_t>>>
 data_block_manager_t::gimme_some_new_offsets(const std::vector<buf_write_info_t> &writes) {
     ASSERT_NO_CORO_WAITING;
 
@@ -1426,9 +1426,9 @@ data_block_manager_t::gimme_some_new_offsets(const std::vector<buf_write_info_t>
 
     guarantee(active_extent->state == gc_entry_t::state_active);
 
-    std::vector<std::vector<counted_t<standard_block_token_t>>> ret;
+    std::vector<std::vector<counted_t<block_token_t>>> ret;
 
-    std::vector<counted_t<standard_block_token_t> > tokens;
+    std::vector<counted_t<block_token_t>> tokens;
     for (auto it = writes.begin(); it != writes.end(); ++it) {
         uint32_t relative_offset = valgrind_undefined<uint32_t>(UINT32_MAX);
         unsigned int block_index = valgrind_undefined<unsigned int>(UINT_MAX);

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -48,7 +48,7 @@ public:
     void start_existing(file_t *dbfile, const data_block_manager::metablock_mixin_t *last_metablock);
 
     buf_ptr_t read(int64_t off_in, block_size_t block_size,
-                 file_account_t *io_account);
+                   file_account_t *io_account);
 
     /* exposed gc api */
     /* mark a buffer as garbage */

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -21,13 +21,14 @@ class log_serializer_t;
 class data_block_manager_t;
 class gc_entry_t;
 
+struct dbm_metablock_mixin_t;
+
 struct gc_entry_less_t {
     bool operator() (const gc_entry_t *x, const gc_entry_t *y);
 };
 
 namespace data_block_manager {
 struct shutdown_callback_t;  // see log_serializer.hpp.
-struct metablock_mixin_t;  // see log_serializer.hpp.
 }  // namespace data_block_manager
 
 class data_block_manager_t {
@@ -44,8 +45,8 @@ public:
     database FD. When restarting an existing database, call start() with the last
     metablock. */
 
-    static void prepare_initial_metablock(data_block_manager::metablock_mixin_t *mb);
-    void start_existing(file_t *dbfile, const data_block_manager::metablock_mixin_t *last_metablock);
+    static void prepare_initial_metablock(dbm_metablock_mixin_t *mb);
+    void start_existing(file_t *dbfile, const dbm_metablock_mixin_t *last_metablock);
 
     buf_ptr_t read(int64_t off_in, block_size_t block_size,
                    file_account_t *io_account);
@@ -68,7 +69,7 @@ public:
     /* garbage collect the extents which meet the gc_criterion */
     void start_gc();
 
-    void prepare_metablock(data_block_manager::metablock_mixin_t *metablock);
+    void prepare_metablock(dbm_metablock_mixin_t *metablock);
     bool do_we_want_to_start_gcing() const;
 
     // This stops further GC rounds from starting, but it doesn't wait for all

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -81,12 +81,12 @@ public:
     // ratio of garbage to blocks in the system
     double garbage_ratio() const;
 
-    std::vector<counted_t<ls_block_token_pointee_t> >
+    std::vector<counted_t<standard_block_token_t>>
     many_writes(const std::vector<buf_write_info_t> &writes,
                 file_account_t *io_account,
                 iocallback_t *cb);
 
-    std::vector<std::vector<counted_t<ls_block_token_pointee_t> > >
+    std::vector<std::vector<counted_t<standard_block_token_t>>>
     gimme_some_new_offsets(const std::vector<buf_write_info_t> &writes);
 
     bool is_gc_active() const;
@@ -221,8 +221,8 @@ private:
     to improve GC efficiency on drives with slow random access. */
     struct gc_index_write_t {
         gc_index_write_t(
-            std::vector<counted_t<ls_block_token_pointee_t> > &&old_block_tokens_,
-            std::vector<counted_t<ls_block_token_pointee_t> > &&new_block_tokens_,
+            std::vector<counted_t<standard_block_token_t> > &&old_block_tokens_,
+            std::vector<counted_t<standard_block_token_t> > &&new_block_tokens_,
             std::vector<gc_write_t> &&writes_,
             gc_state_t *gc_state_,
             scoped_device_block_aligned_ptr_t<char> &&gc_blocks_)
@@ -231,8 +231,8 @@ private:
               writes(std::move(writes_)),
               gc_state(gc_state_),
               gc_blocks(std::move(gc_blocks_)) { }
-        std::vector<counted_t<ls_block_token_pointee_t> > old_block_tokens;
-        std::vector<counted_t<ls_block_token_pointee_t> > new_block_tokens;
+        std::vector<counted_t<standard_block_token_t> > old_block_tokens;
+        std::vector<counted_t<standard_block_token_t> > new_block_tokens;
         std::vector<gc_write_t> writes;
         gc_state_t *gc_state;
         scoped_device_block_aligned_ptr_t<char> gc_blocks;

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -81,12 +81,12 @@ public:
     // ratio of garbage to blocks in the system
     double garbage_ratio() const;
 
-    std::vector<counted_t<standard_block_token_t>>
+    std::vector<counted_t<block_token_t>>
     many_writes(const std::vector<buf_write_info_t> &writes,
                 file_account_t *io_account,
                 iocallback_t *cb);
 
-    std::vector<std::vector<counted_t<standard_block_token_t>>>
+    std::vector<std::vector<counted_t<block_token_t>>>
     gimme_some_new_offsets(const std::vector<buf_write_info_t> &writes);
 
     bool is_gc_active() const;
@@ -221,8 +221,8 @@ private:
     to improve GC efficiency on drives with slow random access. */
     struct gc_index_write_t {
         gc_index_write_t(
-            std::vector<counted_t<standard_block_token_t> > &&old_block_tokens_,
-            std::vector<counted_t<standard_block_token_t> > &&new_block_tokens_,
+            std::vector<counted_t<block_token_t>> &&old_block_tokens_,
+            std::vector<counted_t<block_token_t>> &&new_block_tokens_,
             std::vector<gc_write_t> &&writes_,
             gc_state_t *gc_state_,
             scoped_device_block_aligned_ptr_t<char> &&gc_blocks_)
@@ -231,8 +231,8 @@ private:
               writes(std::move(writes_)),
               gc_state(gc_state_),
               gc_blocks(std::move(gc_blocks_)) { }
-        std::vector<counted_t<standard_block_token_t> > old_block_tokens;
-        std::vector<counted_t<standard_block_token_t> > new_block_tokens;
+        std::vector<counted_t<block_token_t>> old_block_tokens;
+        std::vector<counted_t<block_token_t>> new_block_tokens;
         std::vector<gc_write_t> writes;
         gc_state_t *gc_state;
         scoped_device_block_aligned_ptr_t<char> gc_blocks;

--- a/src/serializer/log/extent_manager.cc
+++ b/src/serializer/log/extent_manager.cc
@@ -76,7 +76,8 @@ public:
         return held_extents_;
     }
 
-    extent_zone_t(file_t *_dbfile, uint64_t _extent_size, log_serializer_stats_t *_stats)
+    extent_zone_t(file_t *_dbfile, uint64_t _extent_size,
+                  log_serializer_stats_t *_stats)
         : extent_size(_extent_size), dbfile(_dbfile), stats(_stats), held_extents_(0) {
         // (Avoid a bunch of reallocations by resize calls (avoiding O(n log n)
         // work on average).)
@@ -195,7 +196,8 @@ public:
                 // entries to tmp.  The remaining entries must therefore point off the
                 // end of the file.  Check that no remaining entries point within the
                 // file.
-                guarantee(free_queue.top() >= extents.size(), "Tried to discard valid held extents.");
+                guarantee(free_queue.top() >= extents.size(),
+                          "Tried to discard valid held extents.");
                 free_queue = std::move(tmp);
             }
         }
@@ -284,7 +286,8 @@ extent_manager_t::copy_extent_reference(const extent_reference_t &extent_ref) {
     return zone->make_extent_reference(offset);
 }
 
-void extent_manager_t::release_extent_into_transaction(extent_reference_t &&extent_ref, extent_transaction_t *txn) {
+void extent_manager_t::release_extent_into_transaction(extent_reference_t &&extent_ref,
+                                                       extent_transaction_t *txn) {
     release_extent_preliminaries();
     rassert(current_transaction);
     txn->push_extent(std::move(extent_ref));

--- a/src/serializer/log/extent_manager.cc
+++ b/src/serializer/log/extent_manager.cc
@@ -239,7 +239,7 @@ extent_reference_t extent_manager_t::reserve_extent(int64_t extent) {
     return zone->reserve_extent(extent);
 }
 
-void extent_manager_t::prepare_initial_metablock(metablock_mixin_t *mb) {
+void extent_manager_t::prepare_initial_metablock(extent_manager_metablock_mixin_t *mb) {
     mb->padding = 0;
 }
 
@@ -252,7 +252,7 @@ void extent_manager_t::start_existing() {
 
 }
 
-void extent_manager_t::prepare_metablock(metablock_mixin_t *metablock) {
+void extent_manager_t::prepare_metablock(extent_manager_metablock_mixin_t *metablock) {
     assert_thread();
     rassert(state == state_running);
     metablock->padding = 0;

--- a/src/serializer/log/extent_manager.hpp
+++ b/src/serializer/log/extent_manager.hpp
@@ -19,6 +19,7 @@
 class extent_zone_t;
 
 struct log_serializer_stats_t;
+struct extent_manager_metablock_mixin_t;
 
 // A reference to an extent in the extent manager.  An extent may not be freed until
 // all of the references go away (unless the server is shutting down).
@@ -93,10 +94,6 @@ private:
 
 class extent_manager_t : public home_thread_mixin_debug_only_t {
 public:
-    struct metablock_mixin_t {
-        int64_t padding;
-    };
-
     extent_manager_t(file_t *file,
                      const log_serializer_on_disk_static_config_t *static_config,
                      log_serializer_stats_t *);
@@ -107,9 +104,9 @@ public:
 
     MUST_USE extent_reference_t reserve_extent(int64_t extent);
 
-    static void prepare_initial_metablock(metablock_mixin_t *mb);
+    static void prepare_initial_metablock(extent_manager_metablock_mixin_t *mb);
     void start_existing();
-    void prepare_metablock(metablock_mixin_t *metablock);
+    void prepare_metablock(extent_manager_metablock_mixin_t *metablock);
     void shutdown();
 
     /* The extent manager uses transactions to make sure that extents are not freed

--- a/src/serializer/log/extent_manager.hpp
+++ b/src/serializer/log/extent_manager.hpp
@@ -25,7 +25,8 @@ struct log_serializer_stats_t;
 class extent_reference_t {
 public:
     extent_reference_t() : extent_offset_(-1) {}
-    explicit extent_reference_t(int64_t extent_offset) : extent_offset_(extent_offset) {}
+    explicit extent_reference_t(int64_t extent_offset)
+        : extent_offset_(extent_offset) {}
     extent_reference_t(extent_reference_t &&movee)
         : extent_offset_(movee.release()) {}
     ~extent_reference_t() { guarantee(extent_offset_ == -1); }

--- a/src/serializer/log/lba/disk_extent.cc
+++ b/src/serializer/log/lba/disk_extent.cc
@@ -6,12 +6,13 @@
 #include "arch/arch.hpp"
 #include "math.hpp"
 
-lba_disk_extent_t::lba_disk_extent_t(extent_manager_t *_em, file_t *file, file_account_t *io_account)
+lba_disk_extent_t::lba_disk_extent_t(extent_manager_t *_em, file_t *file,
+                                     file_account_t *io_account)
     : em(_em), data(new extent_t(em, file)), count(0) {
     em->assert_thread();
 
-    // Make sure that the size of the header is a multiple of the size of one entry, so that the
-    // header doesn't prevent the entries from aligning with DEVICE_BLOCK_SIZE.
+    // Make sure that the size of the header is a multiple of the size of one entry, so
+    // that the header doesn't prevent the entries from aligning with DEVICE_BLOCK_SIZE.
     rassert(divides(sizeof(lba_entry_t), offsetof(lba_extent_t, entries[0])));
     rassert(offsetof(lba_extent_t, entries[0]) == sizeof(lba_extent_t::header_t));
 
@@ -21,8 +22,12 @@ lba_disk_extent_t::lba_disk_extent_t(extent_manager_t *_em, file_t *file, file_a
     data->append(&header, sizeof(header), io_account);
 }
 
-lba_disk_extent_t::lba_disk_extent_t(extent_manager_t *_em, file_t *file, int64_t _offset, int _count)
-    : em(_em), data(new extent_t(em, file, _offset, offsetof(lba_extent_t, entries[0]) + sizeof(lba_entry_t) * _count)), count(_count) {
+lba_disk_extent_t::lba_disk_extent_t(extent_manager_t *_em, file_t *file,
+                                     int64_t _offset, int _count)
+    : em(_em),
+      data(new extent_t(em, file, _offset,
+                        offsetof(lba_extent_t, entries[0]) + sizeof(lba_entry_t) * _count)),
+      count(_count) {
     em->assert_thread();
 }
 
@@ -38,7 +43,8 @@ void lba_disk_extent_t::add_entry(lba_entry_t entry, file_account_t *io_account)
     count++;
 }
 
-void lba_disk_extent_t::sync(file_account_t *io_account, extent_t::sync_callback_t *cb) {
+void lba_disk_extent_t::sync(file_account_t *io_account,
+                             extent_t::sync_callback_t *cb) {
     em->assert_thread();
     while (data->amount_filled % DEVICE_BLOCK_SIZE != 0) {
         add_entry(lba_entry_t::make_padding_entry(), io_account);
@@ -47,11 +53,13 @@ void lba_disk_extent_t::sync(file_account_t *io_account, extent_t::sync_callback
     data->sync(cb);
 }
 
-void lba_disk_extent_t::read_step_1(read_info_t *info_out, extent_t::read_callback_t *cb) {
+void lba_disk_extent_t::read_step_1(read_info_t *info_out,
+                                    extent_t::read_callback_t *cb) {
     em->assert_thread();
     info_out->buffer = scoped_device_block_aligned_ptr_t<lba_extent_t>(em->extent_size);
     info_out->count = count;
-    data->read(0, sizeof(lba_extent_t) + sizeof(lba_entry_t) * count, info_out->buffer.get(), cb);
+    data->read(0, sizeof(lba_extent_t) + sizeof(lba_entry_t) * count,
+               info_out->buffer.get(), cb);
 }
 
 void lba_disk_extent_t::read_step_2(read_info_t *info, in_memory_index_t *index) {

--- a/src/serializer/log/lba/disk_extent.cc
+++ b/src/serializer/log/lba/disk_extent.cc
@@ -43,14 +43,14 @@ void lba_disk_extent_t::add_entry(lba_entry_t entry, file_account_t *io_account)
     count++;
 }
 
-void lba_disk_extent_t::sync(file_account_t *io_account,
-                             extent_t::sync_callback_t *cb) {
+void lba_disk_extent_t::write_outstanding(file_account_t *io_account,
+                                          extent_t::completion_callback_t *cb) {
     em->assert_thread();
     while (data->amount_filled % DEVICE_BLOCK_SIZE != 0) {
         add_entry(lba_entry_t::make_padding_entry(), io_account);
     }
 
-    data->sync(cb);
+    data->wait_for_write_completion(cb);
 }
 
 void lba_disk_extent_t::read_step_1(read_info_t *info_out,

--- a/src/serializer/log/lba/disk_extent.hpp
+++ b/src/serializer/log/lba/disk_extent.hpp
@@ -32,8 +32,8 @@ public:
 
     void sync(file_account_t *io_account, extent_t::sync_callback_t *cb);
 
-    /* To read from an LBA on disk, first call read_step_1(), passing it the address of a
-    new read_info_t structure. When it calls the callback you provide, then call
+    /* To read from an LBA on disk, first call read_step_1(), passing it the address of
+    a new read_info_t structure. When it calls the callback you provide, then call
     read_step_2() with the same read_info_t as before and with a pointer to the
     in_memory_index_t to be filled with data. */
 
@@ -45,8 +45,8 @@ public:
     void read_step_1(read_info_t *info_out, extent_t::read_callback_t *cb);
     void read_step_2(read_info_t *info, in_memory_index_t *index);
 
-    /* destroy() deletes the structure in memory and also tells the extent manager that the extent
-    can be safely reused */
+    /* destroy() deletes the structure in memory and also tells the extent manager that
+    the extent can be safely reused */
     void destroy(extent_transaction_t *txn) {
         data->destroy(txn);
         delete this;

--- a/src/serializer/log/lba/disk_extent.hpp
+++ b/src/serializer/log/lba/disk_extent.hpp
@@ -30,7 +30,8 @@ public:
 
     void add_entry(lba_entry_t entry, file_account_t *io_account);
 
-    void sync(file_account_t *io_account, extent_t::sync_callback_t *cb);
+    void write_outstanding(file_account_t *io_account,
+                           extent_t::completion_callback_t *cb);
 
     /* To read from an LBA on disk, first call read_step_1(), passing it the address of
     a new read_info_t structure. When it calls the callback you provide, then call

--- a/src/serializer/log/lba/disk_format.hpp
+++ b/src/serializer/log/lba/disk_format.hpp
@@ -5,10 +5,6 @@
 #include <limits.h>
 
 #include "serializer/serializer.hpp"
-#include "config/args.hpp"
-
-
-#define LBA_NUM_INLINE_ENTRIES                    (static_cast<int32_t>(LBA_INLINE_SIZE / sizeof(lba_entry_t)))
 
 
 // Contains an int64_t, or a "padding" value, or a "unused" value.  I
@@ -115,21 +111,6 @@ ATTR_PACKED(struct lba_shard_metablock_t {
     int64_t lba_superblock_offset;
     int32_t lba_superblock_entries_count;
     int32_t padding2;
-});
-
-ATTR_PACKED(struct lba_metablock_mixin_t {
-    lba_shard_metablock_t shards[LBA_SHARD_FACTOR];
-
-    /* Note that inline_lba_entries is not sharded into LBA_SHARD_FACTOR shards.
-     * Instead it contains entries from all shards. Sharding is not necessary
-     * for the inlined entries, because we do not perform any blocking operations
-     * on those (especially no garbage collection).
-     * You can assign an entry from the inline LBA to its respective LBA shard
-     * by taking the LBA_SHARD_FACTOR modulo of its block id.
-     */
-    lba_entry_t inline_lba_entries[LBA_NUM_INLINE_ENTRIES];
-    int32_t inline_lba_entries_count;
-    int32_t padding;
 });
 
 

--- a/src/serializer/log/lba/disk_format.hpp
+++ b/src/serializer/log/lba/disk_format.hpp
@@ -54,8 +54,8 @@ inline bool operator==(flagged_off64_t x, flagged_off64_t y) {
     return x.the_value_ == y.the_value_;
 }
 
-// PADDING_BLOCK_ID and flagged_off64_t::padding() indicate that an entry in the LBA list only exists to fill
-// out a DEVICE_BLOCK_SIZE-sized chunk of the extent.
+// PADDING_BLOCK_ID and flagged_off64_t::padding() indicate that an entry in the LBA
+// list only exists to fill out a DEVICE_BLOCK_SIZE-sized chunk of the extent.
 
 static const block_id_t PADDING_BLOCK_ID = NULL_BLOCK_ID;
 
@@ -96,7 +96,8 @@ ATTR_PACKED(struct lba_entry_t {
     }
 
     static lba_entry_t make_padding_entry() {
-        return make(PADDING_BLOCK_ID, repli_timestamp_t::invalid, flagged_off64_t::padding(), 0);
+        return make(PADDING_BLOCK_ID, repli_timestamp_t::invalid,
+                    flagged_off64_t::padding(), 0);
     }
 });
 

--- a/src/serializer/log/lba/disk_structure.hpp
+++ b/src/serializer/log/lba/disk_structure.hpp
@@ -31,16 +31,17 @@ public:
                          lba_shard_metablock_t *metablock);
     void set_load_callback(load_callback_t *lcb);
 
-    // Put entries in an LBA and then call sync() to write to disk
+    // Put entries in an LBA and then call wait_for_write_completion() to write to disk
     void add_entry(block_id_t block_id, repli_timestamp_t recency,
                    flagged_off64_t offset, uint32_t ser_block_size,
                    file_account_t *io_account,
                    extent_transaction_t *txn);
-    struct sync_callback_t {
-        virtual void on_lba_sync() = 0;
-        virtual ~sync_callback_t() {}
+    struct completion_callback_t {
+        virtual void on_lba_completion() = 0;
+        virtual ~completion_callback_t() {}
     };
-    void sync(file_account_t *io_account, sync_callback_t *cb);
+    void write_outstanding(file_account_t *io_account,
+                           completion_callback_t *cb);
 
     // Returns a set of extents that are not currently active.  The returned pointers
     // are valid for as long as the LBA disk structure is not `destroy()`ed and

--- a/src/serializer/log/lba/disk_structure.hpp
+++ b/src/serializer/log/lba/disk_structure.hpp
@@ -27,7 +27,8 @@ public:
         virtual void on_lba_load() = 0;
         virtual ~load_callback_t() {}
     };
-    lba_disk_structure_t(extent_manager_t *em, file_t *file, lba_shard_metablock_t *metablock);
+    lba_disk_structure_t(extent_manager_t *em, file_t *file,
+                         lba_shard_metablock_t *metablock);
     void set_load_callback(load_callback_t *lcb);
 
     // Put entries in an LBA and then call sync() to write to disk
@@ -41,20 +42,19 @@ public:
     };
     void sync(file_account_t *io_account, sync_callback_t *cb);
 
-    // Returns a set of extents that are not currently active.
-    // The returned pointers are valid for as long as the LBA disk structure is not
-    // `destroy()`ed and `destroy_extents()` is not called on them.
+    // Returns a set of extents that are not currently active.  The returned pointers
+    // are valid for as long as the LBA disk structure is not `destroy()`ed and
+    // `destroy_extents()` is not called on them.
     std::set<lba_disk_extent_t *> get_inactive_extents() const;
 
-    // Destroy the given set of extents. Assumes that the extents pointed to
-    // are part of the `extents_in_superblock` list.
-    // Once the extents have been destroyed, a new superblock is written to persist
-    // the change.
+    // Destroy the given set of extents. Assumes that the extents pointed to are part of
+    // the `extents_in_superblock` list.  Once the extents have been destroyed, a new
+    // superblock is written to persist the change.
     void destroy_extents(const std::set<lba_disk_extent_t *> &extents,
                          file_account_t *io_account, extent_transaction_t *txn);
 
-    // If you call read(), then the in_memory_index_t will be populated and then the read_callback_t
-    // will be called when it is done.
+    // If you call read(), then the in_memory_index_t will be populated and then the
+    // read_callback_t will be called when it is done.
     struct read_callback_t {
         virtual void on_lba_extents_read() = 0;
         virtual ~read_callback_t() {}

--- a/src/serializer/log/lba/extent.cc
+++ b/src/serializer/log/lba/extent.cc
@@ -31,8 +31,9 @@ struct extent_block_t :
         parent->last_block = this;
         is_last_block = true;
 
-        parent->file->write_async(parent->extent_ref.offset() + offset, DEVICE_BLOCK_SIZE,
-                                  data.get(), io_account, this, file_t::NO_DATASYNCS);
+        parent->file->write_async(
+                parent->extent_ref.offset() + offset, DEVICE_BLOCK_SIZE,
+                data.get(), io_account, this, file_t::NO_DATASYNCS);
     }
 
     void on_extent_sync() {
@@ -93,7 +94,8 @@ extent_t::~extent_t() {
 
 void extent_t::read(size_t pos, size_t length, void *buffer, read_callback_t *cb) {
     rassert(!last_block);
-    file->read_async(extent_ref.offset() + pos, length, buffer, DEFAULT_DISK_ACCOUNT, cb);
+    file->read_async(extent_ref.offset() + pos, length, buffer, DEFAULT_DISK_ACCOUNT,
+                     cb);
 
     // Ideally we would count these stats when the io operation completes,
     // but this is more generic than doing it in each callback
@@ -115,7 +117,8 @@ void extent_t::append(void *buffer, size_t length, file_account_t *io_account) {
         }
 
         size_t chunk = std::min(length, room_in_block);
-        memcpy(current_block->data.get() + (amount_filled % DEVICE_BLOCK_SIZE), buffer, chunk);
+        memcpy(current_block->data.get() + (amount_filled % DEVICE_BLOCK_SIZE),
+               buffer, chunk);
         amount_filled += chunk;
 
         if (amount_filled % DEVICE_BLOCK_SIZE == 0) {

--- a/src/serializer/log/lba/extent.hpp
+++ b/src/serializer/log/lba/extent.hpp
@@ -32,11 +32,11 @@ public:
 
     void append(void *buffer, size_t length, file_account_t *io_account);
 
-    struct sync_callback_t {
-        virtual void on_extent_sync() = 0;
-        virtual ~sync_callback_t() {}
+    struct completion_callback_t {
+        virtual void on_extent_completion() = 0;
+        virtual ~completion_callback_t() {}
     };
-    void sync(sync_callback_t *cb);
+    void wait_for_write_completion(completion_callback_t *cb);
 
     extent_reference_t extent_ref;
     size_t amount_filled;

--- a/src/serializer/log/lba/extent.hpp
+++ b/src/serializer/log/lba/extent.hpp
@@ -11,11 +11,15 @@ class extent_t {
     friend struct extent_block_t;
 
 public:
-    extent_t(extent_manager_t *em, file_t *file);   // Creates new extent
-    extent_t(extent_manager_t *em, file_t *file, int64_t loc, size_t size);   // Recreates extent at given offset (used during startup)
+    // Creates new extent
+    extent_t(extent_manager_t *em, file_t *file);
+    // Recreates extent at given offset (used during startup)
+    extent_t(extent_manager_t *em, file_t *file, int64_t loc, size_t size);
 
-    void destroy(extent_transaction_t *txn);   // Releases extent and destroys structure in memory
-    void shutdown();   // Only destroys structure in memory
+    // Releases extent and destroys structure in memory
+    void destroy(extent_transaction_t *txn);
+    // Only destroys structure in memory
+    void shutdown();
 
 public:
     struct read_callback_t : private iocallback_t {

--- a/src/serializer/log/lba/in_memory_index.cc
+++ b/src/serializer/log/lba/in_memory_index.cc
@@ -18,7 +18,8 @@ block_id_t in_memory_index_t::end_aux_block_id() {
 
 index_block_info_t in_memory_index_t::get_block_info(block_id_t id) {
     if (is_aux_block_id(id)) {
-        index_aux_block_info_t aux_info = aux_infos_.get(make_aux_block_id_relative(id));
+        index_aux_block_info_t aux_info
+            = aux_infos_.get(make_aux_block_id_relative(id));
         return index_block_info_t(aux_info.offset,
                                   repli_timestamp_t::invalid,
                                   aux_info.ser_block_size);
@@ -28,7 +29,8 @@ index_block_info_t in_memory_index_t::get_block_info(block_id_t id) {
 }
 
 void in_memory_index_t::set_block_info(block_id_t id, repli_timestamp_t recency,
-                                       flagged_off64_t offset, uint16_t ser_block_size) {
+                                       flagged_off64_t offset,
+                                       uint16_t ser_block_size) {
     if (is_aux_block_id(id)) {
         if (id >= end_aux_block_id_) {
             end_aux_block_id_ = id + 1;

--- a/src/serializer/log/lba/lba_list.cc
+++ b/src/serializer/log/lba/lba_list.cc
@@ -21,7 +21,7 @@ lba_list_t::lba_list_t(extent_manager_t *em,
     }
 }
 
-void lba_list_t::prepare_initial_metablock(metablock_mixin_t *mb_out) {
+void lba_list_t::prepare_initial_metablock(lba_metablock_mixin_t *mb_out) {
 
     for (int i = 0; i < LBA_SHARD_FACTOR; i++) {
         mb_out->shards[i].lba_superblock_offset = NULL_OFFSET;
@@ -35,7 +35,7 @@ void lba_list_t::prepare_initial_metablock(metablock_mixin_t *mb_out) {
            LBA_NUM_INLINE_ENTRIES * sizeof(lba_entry_t));
 }
 
-void lba_list_t::prepare_metablock(metablock_mixin_t *mb_out) {
+void lba_list_t::prepare_metablock(lba_metablock_mixin_t *mb_out) {
     for (int i = 0; i < LBA_SHARD_FACTOR; i++) {
         disk_structures[i]->prepare_metablock(&mb_out->shards[i]);
     }
@@ -59,7 +59,7 @@ public:
     lba_list_t *owner;
     lba_list_t::ready_callback_t *callback;
 
-    lba_start_fsm_t(lba_list_t *l, lba_list_t::metablock_mixin_t *last_metablock)
+    lba_start_fsm_t(lba_list_t *l, lba_metablock_mixin_t *last_metablock)
         : owner(l), callback(nullptr)
     {
         rassert(owner->state == lba_list_t::state_unstarted);
@@ -119,7 +119,7 @@ public:
     }
 };
 
-bool lba_list_t::start_existing(file_t *file, metablock_mixin_t *last_metablock,
+bool lba_list_t::start_existing(file_t *file, lba_metablock_mixin_t *last_metablock,
         ready_callback_t *cb) {
     rassert(state == state_unstarted);
 

--- a/src/serializer/log/lba/lba_list.hpp
+++ b/src/serializer/log/lba/lba_list.hpp
@@ -19,7 +19,7 @@ class lba_syncer_t;
 class lba_list_t
 {
     friend class lba_start_fsm_t;
-    friend class lba_syncer_t;
+    friend class lba_writer_t;
 
     typedef std::function<void(const signal_t *, file_account_t *)> write_metablock_fun_t;
 
@@ -66,11 +66,11 @@ public:
                         file_account_t *io_account,
                         extent_transaction_t *txn);
 
-    struct sync_callback_t {
-        virtual void on_lba_sync() = 0;
-        virtual ~sync_callback_t() {}
+    struct completion_callback_t {
+        virtual void on_lba_completion() = 0;
+        virtual ~completion_callback_t() {}
     };
-    void sync(file_account_t *io_account, sync_callback_t *cb);
+    void write_outstanding(file_account_t *io_account, completion_callback_t *cb);
 
     void consider_gc();
 

--- a/src/serializer/log/lba/lba_list.hpp
+++ b/src/serializer/log/lba/lba_list.hpp
@@ -50,8 +50,8 @@ public:
     segmented_vector_t<repli_timestamp_t> get_block_recencies(block_id_t first,
                                                               block_id_t step);
 
-    /* Returns a block ID such that all blocks that exist are guaranteed to have IDs less than
-    that block ID. */
+    /* Returns a block ID such that all blocks that exist are guaranteed to have IDs
+    less than that block ID. */
     block_id_t end_block_id();
     block_id_t end_aux_block_id();
 
@@ -115,9 +115,10 @@ private:
     lba_entry_t inline_lba_entries[LBA_NUM_INLINE_ENTRIES];
     int32_t inline_lba_entries_count;
     bool check_inline_lba_full() const;
-    void move_inline_entries_to_extents(file_account_t *io_account, extent_transaction_t *txn);
+    void move_inline_entries_to_extents(file_account_t *io_account,
+                                        extent_transaction_t *txn);
     void add_inline_entry(block_id_t block, repli_timestamp_t recency,
-                                flagged_off64_t offset, uint16_t ser_block_size);
+                          flagged_off64_t offset, uint16_t ser_block_size);
 
     lba_disk_structure_t *disk_structures[LBA_SHARD_FACTOR];
 

--- a/src/serializer/log/lba/lba_list.hpp
+++ b/src/serializer/log/lba/lba_list.hpp
@@ -9,6 +9,7 @@
 #include "containers/scoped.hpp"
 #include "serializer/serializer.hpp"
 #include "serializer/log/extent_manager.hpp"
+#include "serializer/log/metablock.hpp"
 #include "serializer/log/lba/disk_format.hpp"
 #include "serializer/log/lba/in_memory_index.hpp"
 #include "serializer/log/lba/disk_structure.hpp"
@@ -24,20 +25,18 @@ class lba_list_t
     typedef std::function<void(const signal_t *, file_account_t *)> write_metablock_fun_t;
 
 public:
-    typedef lba_metablock_mixin_t metablock_mixin_t;
-
     explicit lba_list_t(extent_manager_t *em,
                         const write_metablock_fun_t &_write_metablock_fun);
     ~lba_list_t();
 
-    static void prepare_initial_metablock(metablock_mixin_t *mb_out);
-    void prepare_metablock(metablock_mixin_t *mb_out);
+    static void prepare_initial_metablock(lba_metablock_mixin_t *mb_out);
+    void prepare_metablock(lba_metablock_mixin_t *mb_out);
 
     struct ready_callback_t {
         virtual void on_lba_ready() = 0;
         virtual ~ready_callback_t() {}
     };
-    bool start_existing(file_t *dbfile, metablock_mixin_t *last_metablock,
+    bool start_existing(file_t *dbfile, lba_metablock_mixin_t *last_metablock,
                         ready_callback_t *cb);
 
     index_block_info_t get_block_info(block_id_t block);

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -177,7 +177,7 @@ void log_serializer_t::create(serializer_file_opener_t *file_opener,
 
     co_static_header_write(file.get(), on_disk_config, sizeof(*on_disk_config));
 
-    metablock_t metablock;
+    log_serializer_metablock_t metablock;
     memset(&metablock, 0, sizeof(metablock));
 
     extent_manager_metablock_mixin_t extent_manager_part;
@@ -407,7 +407,7 @@ struct ls_start_existing_fsm_t :
     block_id_t next_block_to_reconstruct;
 
     bool metablock_found;
-    log_serializer_t::metablock_t metablock_buffer;
+    log_serializer_metablock_t metablock_buffer;
 
 private:
     DISABLE_COPYING(ls_start_existing_fsm_t);
@@ -607,7 +607,7 @@ void log_serializer_t::write_metablock(new_mutex_in_line_t *mutex_acq,
                                        const signal_t *safe_to_write_cond,
                                        file_account_t *io_account) {
     assert_thread();
-    metablock_t mb_buffer;
+    log_serializer_metablock_t mb_buffer;
 
     /* Prepare metablock now instead of in when we write it so that we will have the
     correct metablock information for this write even if another write starts before we
@@ -927,7 +927,7 @@ void log_serializer_t::on_datablock_manager_shutdown() {
     next_shutdown_step();
 }
 
-void log_serializer_t::prepare_metablock(metablock_t *mb_buffer) {
+void log_serializer_t::prepare_metablock(log_serializer_metablock_t *mb_buffer) {
     assert_thread();
     memset(mb_buffer, 0, sizeof(*mb_buffer));
 

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -635,8 +635,7 @@ void log_serializer_t::write_metablock(new_mutex_in_line_t *mutex_acq,
     struct : public cond_t, public mb_manager_t::metablock_write_callback_t {
         void on_metablock_write() { pulse(); }
     } on_metablock_write;
-    const bool done_with_metablock =
-        metablock_manager->write_metablock(&mb_buffer, io_account, &on_metablock_write);
+    metablock_manager->write_metablock(&mb_buffer, io_account, &on_metablock_write);
 
     /* Remove ourselves from the list of metablock waiters. */
     metablock_waiter_queue.pop_front();
@@ -647,7 +646,7 @@ void log_serializer_t::write_metablock(new_mutex_in_line_t *mutex_acq,
         metablock_waiter_queue.front()->pulse();
     }
 
-    if (!done_with_metablock) on_metablock_write.wait();
+    on_metablock_write.wait();
 }
 
 void log_serializer_t::write_metablock_sans_pipelining(const signal_t *safe_to_write_cond,

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -180,15 +180,15 @@ void log_serializer_t::create(serializer_file_opener_t *file_opener,
     metablock_t metablock;
     memset(&metablock, 0, sizeof(metablock));
 
-    extent_manager_t::metablock_mixin_t extent_manager_part;
+    extent_manager_metablock_mixin_t extent_manager_part;
     extent_manager_t::prepare_initial_metablock(&extent_manager_part);
     metablock.extent_manager_part = extent_manager_part;
 
-    data_block_manager::metablock_mixin_t data_block_manager_part;
+    dbm_metablock_mixin_t data_block_manager_part;
     data_block_manager_t::prepare_initial_metablock(&data_block_manager_part);
     metablock.data_block_manager_part = data_block_manager_part;
 
-    lba_list_t::metablock_mixin_t lba_index_part;
+    lba_metablock_mixin_t lba_index_part;
     lba_list_t::prepare_initial_metablock(&lba_index_part);
     metablock.lba_index_part = lba_index_part;
 
@@ -931,15 +931,15 @@ void log_serializer_t::prepare_metablock(metablock_t *mb_buffer) {
     assert_thread();
     memset(mb_buffer, 0, sizeof(*mb_buffer));
 
-    extent_manager_t::metablock_mixin_t extent_manager_part;
+    extent_manager_metablock_mixin_t extent_manager_part;
     extent_manager->prepare_metablock(&extent_manager_part);
     mb_buffer->extent_manager_part = extent_manager_part;
 
-    data_block_manager::metablock_mixin_t data_block_manager_part;
+    dbm_metablock_mixin_t data_block_manager_part;
     data_block_manager->prepare_metablock(&data_block_manager_part);
     mb_buffer->data_block_manager_part = data_block_manager_part;
 
-    lba_list_t::metablock_mixin_t lba_index_part;
+    lba_metablock_mixin_t lba_index_part;
     lba_index->prepare_metablock(&lba_index_part);
     mb_buffer->lba_index_part = lba_index_part;
 }

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -76,7 +76,8 @@ private:
     // The path of the temporary file.  This is file_name() with some suffix appended.
     std::string temporary_file_name() const;
 
-    // Either file_name() or temporary_file_name(), depending on whether opened_temporary_ is true.
+    // Either file_name() or temporary_file_name(), depending on whether
+    // opened_temporary_ is true.
     std::string current_file_name() const;
 
     // The filepath of the final position of the file.
@@ -84,14 +85,16 @@ private:
 
     io_backender_t *const backender_;
 
-    // Makes sure that only one member function gets called at a time.  Some of them are blocking,
-    // and we don't want to have to worry about stuff like what the value of opened_temporary_
-    // should be during the blocking call to move_serializer_file_to_permanent_location().
+    // Makes sure that only one member function gets called at a time.  Some of them are
+    // blocking, and we don't want to have to worry about stuff like what the value of
+    // opened_temporary_ should be during the blocking call to
+    // move_serializer_file_to_permanent_location().
     mutex_assertion_t reentrance_mutex_;
 
-    // This begins false.  It becomes true when open_serializer_file_create_temporary is called.  It
-    // becomes false again when move_serializer_file_to_permanent_location is called.  It is used by
-    // open_serializer_file_existing to know whether it should use the temporary or permanent path.
+    // This begins false.  It becomes true when open_serializer_file_create_temporary is
+    // called.  It becomes false again when move_serializer_file_to_permanent_location
+    // is called.  It is used by open_serializer_file_existing to know whether it should
+    // use the temporary or permanent path.
     bool opened_temporary_;
 
     DISABLE_COPYING(filepath_file_opener_t);
@@ -111,18 +114,21 @@ class log_serializer_t :
     friend class block_token_t;
 
 public:
-    /* Serializer configuration. dynamic_config_t is everything that can be changed from run
-    to run; static_config_t is the parameters that are set when the database is created and
-    cannot be changed after that. */
+    /* Serializer configuration. dynamic_config_t is everything that can be changed from
+    run to run; static_config_t is the parameters that are set when the database is
+    created and cannot be changed after that. */
     typedef log_serializer_dynamic_config_t dynamic_config_t;
     typedef log_serializer_static_config_t static_config_t;
 
 
     /* Blocks. Does not check for an existing database--use check_existing for that. */
-    static void create(serializer_file_opener_t *file_opener, static_config_t static_config);
+    static void create(serializer_file_opener_t *file_opener,
+                       static_config_t static_config);
 
     /* Blocks. */
-    log_serializer_t(dynamic_config_t dynamic_config, serializer_file_opener_t *file_opener, perfmon_collection_t *perfmon_collection);
+    log_serializer_t(dynamic_config_t dynamic_config,
+                     serializer_file_opener_t *file_opener,
+                     perfmon_collection_t *perfmon_collection);
 
     /* Blocks. */
     virtual ~log_serializer_t();
@@ -147,8 +153,10 @@ public:
                      const std::function<void()> &on_writes_reflected,
                      const std::vector<index_write_op_t> &write_ops);
 
-    std::vector<counted_t<block_token_t>> block_writes(const std::vector<buf_write_info_t> &write_infos,
-                                                                file_account_t *io_account, iocallback_t *cb);
+    std::vector<counted_t<block_token_t>> block_writes(
+            const std::vector<buf_write_info_t> &write_infos,
+            file_account_t *io_account,
+            iocallback_t *cb);
 
     max_block_size_t max_block_size() const;
 
@@ -259,9 +267,9 @@ private:
     lba_list_t *lba_index;
     data_block_manager_t *data_block_manager;
 
-    /* The running index writes organize themselves into a list so that they can be sure to
-    write their metablocks in the correct order. The first element in the list
-    is the oldest transaction that started but did not finish. */
+    /* The running index writes organize themselves into a list so that they can be sure
+    to write their metablocks in the correct order. The first element in the list is the
+    oldest transaction that started but did not finish. */
     std::list<cond_t *> metablock_waiter_queue;
 
     int active_write_count;

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -108,7 +108,7 @@ class log_serializer_t :
     friend struct ls_start_existing_fsm_t;
     friend class data_block_manager_t;
     friend class dbm_read_ahead_t;
-    friend class standard_block_token_t;
+    friend class block_token_t;
 
 public:
     /* Serializer configuration. dynamic_config_t is everything that can be changed from run
@@ -138,16 +138,16 @@ public:
                                                             block_id_t step);
 
     bool get_delete_bit(block_id_t id);
-    counted_t<standard_block_token_t> index_read(block_id_t block_id);
+    counted_t<block_token_t> index_read(block_id_t block_id);
 
-    buf_ptr_t block_read(const counted_t<standard_block_token_t> &token,
+    buf_ptr_t block_read(const counted_t<block_token_t> &token,
                        file_account_t *io_account);
 
     void index_write(new_mutex_in_line_t *mutex_acq,
                      const std::function<void()> &on_writes_reflected,
                      const std::vector<index_write_op_t> &write_ops);
 
-    std::vector<counted_t<standard_block_token_t>> block_writes(const std::vector<buf_write_info_t> &write_infos,
+    std::vector<counted_t<block_token_t>> block_writes(const std::vector<buf_write_info_t> &write_infos,
                                                                 file_account_t *io_account, iocallback_t *cb);
 
     max_block_size_t max_block_size() const;
@@ -157,15 +157,15 @@ public:
     virtual bool is_gc_active() const;
 
 private:
-    void unregister_block_token(standard_block_token_t *token);
+    void unregister_block_token(block_token_t *token);
     void remap_block_to_new_offset(int64_t current_offset, int64_t new_offset);
-    counted_t<standard_block_token_t> generate_block_token(int64_t offset,
+    counted_t<block_token_t> generate_block_token(int64_t offset,
                                                              block_size_t block_size);
 
     void offer_buf_to_read_ahead_callbacks(
             block_id_t block_id,
             buf_ptr_t &&buf,
-            const counted_t<standard_block_token_t> &token);
+            const counted_t<block_token_t> &token);
     bool should_perform_read_ahead();
 
     /* Starts a new transaction, updates perfmons etc. */
@@ -210,7 +210,7 @@ private:
     // a GC.  It's a multimap (we create duplicate tokens for an offset) because on-disk
     // GC (which remaps offsets) will move block tokens from an "old" offset to a "new"
     // offset while simultaneously having already created tokens at the "new" offset.
-    std::multimap<int64_t, standard_block_token_t *> offset_tokens;
+    std::multimap<int64_t, block_token_t *> offset_tokens;
     scoped_ptr_t<log_serializer_stats_t> stats;
     perfmon_collection_t disk_stats_collection;
     perfmon_membership_t disk_stats_membership;

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -197,8 +197,7 @@ private:
                                          file_account_t *io_account);
 
 
-    typedef log_serializer_metablock_t metablock_t;
-    void prepare_metablock(metablock_t *mb_buffer);
+    void prepare_metablock(log_serializer_metablock_t *mb_buffer);
 
     void consider_start_gc();
 

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -157,8 +157,6 @@ public:
     virtual bool is_gc_active() const;
 
 private:
-    void register_block_token(standard_block_token_t *token, int64_t offset);
-    bool tokens_exist_for_offset(int64_t off);
     void unregister_block_token(standard_block_token_t *token);
     void remap_block_to_new_offset(int64_t current_offset, int64_t new_offset);
     counted_t<standard_block_token_t> generate_block_token(int64_t offset,
@@ -208,6 +206,10 @@ private:
 
     void consider_start_gc();
 
+    // We maintain offset_tokens so that we can remap block tokens' offsets while doing
+    // a GC.  It's a multimap (we create duplicate tokens for an offset) because on-disk
+    // GC (which remaps offsets) will move block tokens from an "old" offset to a "new"
+    // offset while simultaneously having already created tokens at the "new" offset.
     std::multimap<int64_t, standard_block_token_t *> offset_tokens;
     scoped_ptr_t<log_serializer_stats_t> stats;
     perfmon_collection_t disk_stats_collection;

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -18,6 +18,7 @@
 #include "concurrency/cond_var.hpp"
 #include "containers/scoped.hpp"
 #include "paths.hpp"
+#include "serializer/log/metablock.hpp"
 #include "serializer/log/metablock_manager.hpp"
 #include "serializer/log/extent_manager.hpp"
 #include "serializer/log/lba/lba_list.hpp"
@@ -34,11 +35,6 @@ struct shutdown_callback_t {
     virtual void on_datablock_manager_shutdown() = 0;
     virtual ~shutdown_callback_t() {}
 };
-
-ATTR_PACKED(struct metablock_mixin_t {
-    int64_t active_extent;
-});
-
 }  // namespace data_block_manager
 
 /**
@@ -46,14 +42,6 @@ ATTR_PACKED(struct metablock_mixin_t {
  * RethinkDB. Please treat it with courtesy, professionalism, and
  * respect that it deserves.
  */
-
-//  Data to be serialized to disk with each block.  Changing this changes the disk format!
-ATTR_PACKED(struct log_serializer_metablock_t {
-    extent_manager_t::metablock_mixin_t extent_manager_part;
-    lba_list_t::metablock_mixin_t lba_index_part;
-    data_block_manager::metablock_mixin_t data_block_manager_part;
-});
-
 
 // Used to open a file (with the given filepath) for the log serializer.
 class filepath_file_opener_t : public serializer_file_opener_t {

--- a/src/serializer/log/metablock.hpp
+++ b/src/serializer/log/metablock.hpp
@@ -3,20 +3,38 @@
 
 #include "serializer/log/lba/disk_format.hpp"
 
-// How much space to reserve in the metablock to store inline LBA entries Make sure that
-// it fits into METABLOCK_SIZE, including all other meta data.  (Defines the disk
-// format!  Can't change unless you're careful.)
-#define LBA_INLINE_SIZE                           (METABLOCK_SIZE - 512)
+// Size of the metablock (in bytes)
+#define METABLOCK_SIZE (4 * KILOBYTE)
 
-#define LBA_NUM_INLINE_ENTRIES                    (static_cast<int32_t>(LBA_INLINE_SIZE / sizeof(lba_entry_t)))
+// How much space to reserve in the metablock to store inline LBA entries.  Make sure
+// that it fits into METABLOCK_SIZE, including all other meta data.  (Defines the disk
+// format!  Can't change unless you're careful.)
+
+// LBA_INLINE_SIZE is 3.5 KB.  You might note, it's a good thing that this value is a
+// bit shy of 8 * 512, in terms of LBA usage.  It being 7*512bytes means that when we do
+// spill over the inline LBA entries into the actual LBA, we'll use 2 device blocks
+// (2*512bytes) in most LBA shards (because LBA_SHARD_FACTOR is 4).  Each shard gets on
+// average 28 entries.  If one gets more than 32 entries, we have spillover (into a
+// third block).  It's a binomial distribution (right?) with mean 28, stddev 4.5, so I
+// suspect we could stand to lower the value of LBA_INLINE_SIZE a tad.  There's some
+// trade-off here that minimizes LBA space usage.  (Lowering the spill threshold doesn't
+// have to change the disk format, either.)
+
+// 3.5 KB
+#define LBA_INLINE_SIZE (METABLOCK_SIZE - 512)
+
+// sizeof(lba_entry_t) is 32, meaning this is 7*2^9/2^5 = 7*2^4 = 112
+// Value is 112.
+#define LBA_NUM_INLINE_ENTRIES (static_cast<int32_t>(LBA_INLINE_SIZE / sizeof(lba_entry_t)))
 
 
 ATTR_PACKED(struct dbm_metablock_mixin_t {
     int64_t active_extent;
 });
 
-
 ATTR_PACKED(struct lba_metablock_mixin_t {
+    // LBA_SHARD_FACTOR is 4, sizeof(lba_shard_metablock_t) is 32.
+    // Total size of shards: 128 bytes.
     lba_shard_metablock_t shards[LBA_SHARD_FACTOR];
 
     /* Note that inline_lba_entries is not sharded into LBA_SHARD_FACTOR shards.
@@ -26,9 +44,11 @@ ATTR_PACKED(struct lba_metablock_mixin_t {
      * You can assign an entry from the inline LBA to its respective LBA shard
      * by taking the LBA_SHARD_FACTOR modulo of its block id.
      */
+    // 3584 bytes.  (3584 = 32 * 112 = 7 * 512.)
     lba_entry_t inline_lba_entries[LBA_NUM_INLINE_ENTRIES];
     int32_t inline_lba_entries_count;
     int32_t padding;
+    // 3720 bytes total
 });
 
 ATTR_PACKED(struct extent_manager_metablock_mixin_t {
@@ -41,9 +61,13 @@ ATTR_PACKED(struct extent_manager_metablock_mixin_t {
 //  Data to be serialized to disk with each block.  Changing this changes the disk
 //  format!
 ATTR_PACKED(struct log_serializer_metablock_t {
+    // 8 bytes.  (A "padding" field set to 0.)
     extent_manager_metablock_mixin_t extent_manager_part;
+    // offset: 8, size: 3720.
     lba_metablock_mixin_t lba_index_part;
+    // offset: 3728, size: 8.
     dbm_metablock_mixin_t data_block_manager_part;
+    // Size: 3736 bytes.
 });
 
 

--- a/src/serializer/log/metablock.hpp
+++ b/src/serializer/log/metablock.hpp
@@ -71,4 +71,26 @@ ATTR_PACKED(struct log_serializer_metablock_t {
 });
 
 
+static const char MB_MARKER_MAGIC[8] = {'m', 'e', 't', 'a', 'b', 'l', 'c', 'k'};
+typedef int64_t metablock_version_t;
+
+// This is stored directly to disk.  Changing it will change the disk format.
+ATTR_PACKED(struct crc_metablock_t {
+    char magic_marker[sizeof(MB_MARKER_MAGIC)];
+    // The version that differs only when the software is upgraded to a newer
+    // version.  This field might allow for in-place upgrading of the cluster.
+    uint32_t disk_format_version;
+    // The CRC checksum of [disk_format_version]+[version]+[metablock].
+    uint32_t _crc;
+    // The version that increments every time a metablock is written.
+    metablock_version_t version;
+
+    // Offset: 24, size: 3736 bytes.
+    // The value in the metablock (pointing at LBA superblocks, etc).
+    log_serializer_metablock_t metablock;
+
+    // Size: 3760 bytes.
+});
+
+
 #endif  // SERIALIZER_LOG_METABLOCK_HPP_

--- a/src/serializer/log/metablock.hpp
+++ b/src/serializer/log/metablock.hpp
@@ -1,0 +1,50 @@
+#ifndef SERIALIZER_LOG_METABLOCK_HPP_
+#define SERIALIZER_LOG_METABLOCK_HPP_
+
+#include "serializer/log/lba/disk_format.hpp"
+
+// How much space to reserve in the metablock to store inline LBA entries Make sure that
+// it fits into METABLOCK_SIZE, including all other meta data.  (Defines the disk
+// format!  Can't change unless you're careful.)
+#define LBA_INLINE_SIZE                           (METABLOCK_SIZE - 512)
+
+#define LBA_NUM_INLINE_ENTRIES                    (static_cast<int32_t>(LBA_INLINE_SIZE / sizeof(lba_entry_t)))
+
+
+ATTR_PACKED(struct dbm_metablock_mixin_t {
+    int64_t active_extent;
+});
+
+
+ATTR_PACKED(struct lba_metablock_mixin_t {
+    lba_shard_metablock_t shards[LBA_SHARD_FACTOR];
+
+    /* Note that inline_lba_entries is not sharded into LBA_SHARD_FACTOR shards.
+     * Instead it contains entries from all shards. Sharding is not necessary
+     * for the inlined entries, because we do not perform any blocking operations
+     * on those (especially no garbage collection).
+     * You can assign an entry from the inline LBA to its respective LBA shard
+     * by taking the LBA_SHARD_FACTOR modulo of its block id.
+     */
+    lba_entry_t inline_lba_entries[LBA_NUM_INLINE_ENTRIES];
+    int32_t inline_lba_entries_count;
+    int32_t padding;
+});
+
+ATTR_PACKED(struct extent_manager_metablock_mixin_t {
+    int64_t padding;
+});
+
+
+
+
+//  Data to be serialized to disk with each block.  Changing this changes the disk
+//  format!
+ATTR_PACKED(struct log_serializer_metablock_t {
+    extent_manager_metablock_mixin_t extent_manager_part;
+    lba_metablock_mixin_t lba_index_part;
+    dbm_metablock_mixin_t data_block_manager_part;
+});
+
+
+#endif  // SERIALIZER_LOG_METABLOCK_HPP_

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -297,9 +297,8 @@ void metablock_manager_t<metablock_t>::write_metablock_callback(metablock_t *mb,
 }
 
 template<class metablock_t>
-bool metablock_manager_t<metablock_t>::write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb) {
+void metablock_manager_t<metablock_t>::write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb) {
     coro_t::spawn_later_ordered(std::bind(&metablock_manager_t<metablock_t>::write_metablock_callback, this, mb, io_account, cb));
-    return false;
 }
 
 template<class metablock_t>

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -77,15 +77,13 @@ std::vector<int64_t> initial_metablock_offsets(int64_t extent_size) {
 /* head functions */
 
 metablock_manager_t::metablock_manager_t::head_t::head_t(metablock_manager_t *manager)
-    : mb_slot(0), saved_mb_slot(static_cast<uint32_t>(-1)), wraparound(false), mgr(manager) { }
+    : mb_slot(0), saved_mb_slot(static_cast<uint32_t>(-1)), mgr(manager) { }
 
 void metablock_manager_t::metablock_manager_t::head_t::operator++() {
     mb_slot++;
-    wraparound = false;
 
     if (mb_slot >= metablock_offsets::count(mgr->extent_manager->extent_size)) {
         mb_slot = 0;
-        wraparound = true;
     }
 }
 

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -24,10 +24,10 @@ uint32_t compute_metablock_crc(const crc_metablock_t *crc_mb) {
     return crc.checksum();
 }
 
+// crc_mb->metablock is already initialized, the rest of the metablock is zero-filled.
 void prepare(crc_metablock_t *crc_mb, uint32_t _disk_format_version,
-             log_serializer_metablock_t *mb, metablock_version_t vers) {
+             metablock_version_t vers) {
     crc_mb->disk_format_version = _disk_format_version;
-    crc_mb->metablock = *mb;
     memcpy(crc_mb->magic_marker, MB_MARKER_MAGIC, sizeof(MB_MARKER_MAGIC));
     crc_mb->version = vers;
     crc_mb->_crc = compute_metablock_crc(crc_mb);
@@ -87,13 +87,11 @@ void metablock_manager_t::metablock_manager_t::head_t::pop() {
 }
 
 metablock_manager_t::metablock_manager_t(extent_manager_t *em)
-    : head(this), mb_buffer(METABLOCK_SIZE),
+    : head(this),
       extent_manager(em),
       metablock_offsets(initial_metablock_offsets(extent_manager->extent_size)),
       state(state_unstarted), dbfile(nullptr) {
     rassert(sizeof(crc_metablock_t) <= METABLOCK_SIZE);
-    rassert(mb_buffer.has());
-    mb_buffer_in_use = false;
 
     /* Build the list of metablock locations in the file */
 
@@ -103,14 +101,12 @@ metablock_manager_t::metablock_manager_t(extent_manager_t *em)
 }
 
 metablock_manager_t::~metablock_manager_t() {
-
     rassert(state == state_unstarted || state == state_shut_down);
-
-    rassert(!mb_buffer_in_use);
 }
 
-void metablock_manager_t::create(file_t *dbfile, int64_t extent_size,
-                                 log_serializer_metablock_t *initial) {
+void metablock_manager_t::create(
+        file_t *dbfile, int64_t extent_size,
+        scoped_device_block_aligned_ptr_t<crc_metablock_t> &&initial) {
 
     std::vector<int64_t> metablock_offsets = initial_metablock_offsets(extent_size);
 
@@ -138,12 +134,13 @@ void metablock_manager_t::create(file_t *dbfile, int64_t extent_size,
     }
     callback.wait();
 
+    buffer = std::move(initial);
+
     /* Write the first metablock */
     // We use cluster_version_t::LATEST_DISK.  Maybe we'd want to decouple cluster
     // versions from disk format versions?  We can do that later if we want.
     crc_metablock::prepare(buffer.get(),
                            static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
-                           initial,
                            MB_START_VERSION);
     co_write(dbfile, metablock_offsets[0], METABLOCK_SIZE, buffer.get(),
              DEFAULT_DISK_ACCOUNT, file_t::WRAP_IN_DATASYNCS);
@@ -180,9 +177,6 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
     rassert(state == state_unstarted);
     dbfile = file;
     rassert(dbfile != nullptr);
-
-    rassert(!mb_buffer_in_use);
-    mb_buffer_in_use = true;
 
     metablock_version_t latest_version = MB_BAD_VERSION;
 
@@ -272,10 +266,8 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
         latest_version = MB_BAD_VERSION; /* version is now useless */
         head.pop();
         *mb_found = true;
-        memcpy(mb_buffer.get(), last_good_mb, METABLOCK_SIZE);
-        memcpy(mb_out, &(mb_buffer->metablock), sizeof(log_serializer_metablock_t));
+        memcpy(mb_out, &last_good_mb->metablock, sizeof(log_serializer_metablock_t));
     }
-    mb_buffer_in_use = false;
     state = state_ready;
 }
 
@@ -294,50 +286,48 @@ bool metablock_manager_t::start_existing(
                                           this, file, mb_found, mb_out, cb));
     return false;
 }
-void metablock_manager_t::co_write_metablock(log_serializer_metablock_t *mb,
-                                             file_account_t *io_account) {
+
+// crc_mb is zero-initialized.
+void metablock_manager_t::co_write_metablock(
+        const scoped_device_block_aligned_ptr_t<crc_metablock_t> &crc_mb,
+        file_account_t *io_account) {
     mutex_t::acq_t hold(&write_lock);
 
     rassert(state == state_ready);
-    rassert(!mb_buffer_in_use);
 
-    crc_metablock::prepare(mb_buffer.get(),
+    crc_metablock::prepare(crc_mb.get(),
                            static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
-                           mb,
                            next_version_number++);
-    rassert(crc_metablock::check_crc(mb_buffer.get()));
-
-    mb_buffer_in_use = true;
+    rassert(crc_metablock::check_crc(crc_mb.get()));
 
     state = state_writing;
-    co_write(dbfile, head.offset(), METABLOCK_SIZE, mb_buffer.get(), io_account,
+    co_write(dbfile, head.offset(), METABLOCK_SIZE, crc_mb.get(), io_account,
              file_t::WRAP_IN_DATASYNCS);
 
     ++head;
 
     state = state_ready;
-    mb_buffer_in_use = false;
     extent_manager->stats->bytes_written(METABLOCK_SIZE);
 }
 
 void metablock_manager_t::write_metablock_callback(
-        log_serializer_metablock_t *mb,
+        const scoped_device_block_aligned_ptr_t<crc_metablock_t> *mb,
         file_account_t *io_account,
         metablock_write_callback_t *cb) {
-    co_write_metablock(mb, io_account);
+    co_write_metablock(*mb, io_account);
     cb->on_metablock_write();
 }
 
-void metablock_manager_t::write_metablock(log_serializer_metablock_t *mb,
-                                          file_account_t *io_account,
-                                          metablock_write_callback_t *cb) {
+void metablock_manager_t::write_metablock(
+        const scoped_device_block_aligned_ptr_t<crc_metablock_t> &crc_mb,
+        file_account_t *io_account,
+        metablock_write_callback_t *cb) {
     coro_t::spawn_later_ordered(std::bind(&metablock_manager_t::write_metablock_callback,
-                                          this, mb, io_account, cb));
+                                          this, &crc_mb, io_account, cb));
 }
 
 void metablock_manager_t::shutdown() {
 
     rassert(state == state_ready);
-    rassert(!mb_buffer_in_use);
     state = state_shut_down;
 }

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -55,6 +55,10 @@ int64_t get(int64_t extent_size, size_t index) {
 int64_t min_filesize(int64_t extent_size) {
     return (1 + metablock_offsets::count(extent_size)) * METABLOCK_SIZE;
 }
+
+int64_t next(int64_t extent_size, size_t index) {
+    return (1 + index) % metablock_offsets::count(extent_size);
+}
 }  // namespace metablock_offsets.
 
 
@@ -74,36 +78,8 @@ std::vector<int64_t> initial_metablock_offsets(int64_t extent_size) {
     return offsets;
 }
 
-/* head functions */
-
-metablock_manager_t::metablock_manager_t::head_t::head_t(metablock_manager_t *manager)
-    : mb_slot(0), saved_mb_slot(static_cast<uint32_t>(-1)), mgr(manager) { }
-
-void metablock_manager_t::metablock_manager_t::head_t::operator++() {
-    mb_slot++;
-
-    if (mb_slot >= metablock_offsets::count(mgr->extent_manager->extent_size)) {
-        mb_slot = 0;
-    }
-}
-
-int64_t metablock_manager_t::metablock_manager_t::head_t::offset() {
-    return metablock_offsets::get(mgr->extent_manager->extent_size, mb_slot);
-}
-
-void metablock_manager_t::metablock_manager_t::head_t::push() {
-    saved_mb_slot = mb_slot;
-}
-
-void metablock_manager_t::metablock_manager_t::head_t::pop() {
-    guarantee(saved_mb_slot != static_cast<uint32_t>(-1),
-              "Popping without a saved state");
-    mb_slot = saved_mb_slot;
-    saved_mb_slot = static_cast<uint32_t>(-1);
-}
-
 metablock_manager_t::metablock_manager_t(extent_manager_t *em)
-    : head(this),
+    : next_mb_slot(SIZE_MAX),
       extent_manager(em),
       state(state_unstarted),
       dbfile(nullptr) {
@@ -185,105 +161,78 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
 }
 
 
-void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
+void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found_out,
                                             log_serializer_metablock_t *mb_out) {
     rassert(state == state_unstarted);
     dbfile = file;
     rassert(dbfile != nullptr);
 
-    metablock_version_t latest_version = MB_BAD_VERSION;
-
     const int64_t extent_size = extent_manager->extent_size;
+    const size_t num_metablocks = metablock_offsets::count(extent_size);
 
     dbfile->set_file_size_at_least(metablock_offsets::min_filesize(extent_size));
 
     // Reading metablocks by issuing one I/O request at a time is
     // slow. Read all of them in one batch, and check them later.
     state = state_reading;
-    struct load_buffer_manager_t {
-        explicit load_buffer_manager_t(size_t nmetablocks)
-            : buffer(METABLOCK_SIZE * nmetablocks) { }
-        crc_metablock_t *get_metablock(unsigned i) {
-            return reinterpret_cast<crc_metablock_t *>(reinterpret_cast<char *>(buffer.get()) + METABLOCK_SIZE * i);
-        }
 
-    private:
-        scoped_device_block_aligned_ptr_t<crc_metablock_t> buffer;
-    } lbm(metablock_offsets::count(extent_size));
+    scoped_device_block_aligned_ptr_t<char> lbm(METABLOCK_SIZE * num_metablocks);
+
     struct : public iocallback_t, public cond_t {
         size_t refcount;
         void on_io_complete() {
             refcount--;
-            if (refcount == 0) pulse();
+            if (refcount == 0) { pulse(); }
         }
     } callback;
-    callback.refcount = metablock_offsets::count(extent_size);
-    for (size_t i = 0; i < metablock_offsets::count(extent_size); i++) {
+    callback.refcount = num_metablocks;
+    for (size_t i = 0; i < num_metablocks; ++i) {
         dbfile->read_async(metablock_offsets::get(extent_size, i), METABLOCK_SIZE,
-                           lbm.get_metablock(i),
+                           lbm.get() + i * METABLOCK_SIZE,
                            DEFAULT_DISK_ACCOUNT, &callback);
     }
     callback.wait();
     extent_manager->stats->bytes_read(METABLOCK_SIZE * metablock_offsets::count(extent_size));
 
-    // TODO: we can parallelize this code even further by doing crc
-    // checks as soon as a block is ready, as opposed to waiting for
-    // all IO operations to complete and then checking. I'm dubious
-    // about the benefits though, so leaving this alone.
+    static_assert(MB_BAD_VERSION < 0, "MB_BAD_VERSION is not -1, not signed int64_t");
+    metablock_version_t max_version = MB_BAD_VERSION;
+    size_t max_index = SIZE_MAX;
 
-    // We've read everything from disk. Now find the last good metablock.
-    crc_metablock_t *last_good_mb = nullptr;
-    for (size_t i = 0; i < metablock_offsets::count(extent_size); i++) {
-        crc_metablock_t *mb_temp = lbm.get_metablock(i);
-        if (crc_metablock::check_crc(mb_temp)) {
-            if (mb_temp->version > latest_version) {
-                /* this metablock is good, maybe there are more? */
-                latest_version = mb_temp->version;
-                head.push();
-                ++head;
-                last_good_mb = mb_temp;
-            } else {
-                break;
+    for (size_t i = 0; i < num_metablocks; ++i) {
+        crc_metablock_t *mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + i * METABLOCK_SIZE);
+        if (crc_metablock::check_crc(mb)) {
+            guarantee(mb->version != max_version);
+            if (mb->version > max_version) {
+                max_version = mb->version;
+                max_index = i;
             }
-        } else {
-            ++head;
         }
     }
 
-    // Cool, hopefully got our metablock. Wrap it up.
-    if (latest_version == MB_BAD_VERSION) {
-
+    if (max_index == SIZE_MAX) {
         /* no metablock found anywhere -- the DB is toast */
-
         next_version_number = MB_START_VERSION;
-        *mb_found = false;
+        *mb_found_out = false;
 
         /* The log serializer will catastrophically fail when it sees that mb_found is
-           false. We could catastrophically fail here, but it's a bit nicer to have the
-           metablock manager as a standalone component that doesn't know how to behave
-           if there is no metablock. */
-
+           false. */
     } else {
-        // Right now we don't have anything super-special between disk format
-        // versions, just some per-block serialization versioning (which is
-        // derived from the 4 bytes block_magic_t at the front of the block), so
-        // we don't need to remember the version number -- we just assert it's
-        // ok.
-        if (!disk_format_version_is_recognized(last_good_mb->disk_format_version)) {
+        crc_metablock_t *latest_crc_mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + max_index * METABLOCK_SIZE);
+        if (!disk_format_version_is_recognized(latest_crc_mb->disk_format_version)) {
             fail_due_to_user_error(
                     "Data version not recognized. Is the data "
                     "directory from a newer version of RethinkDB? "
                     "(version on disk: %" PRIu32 ")",
-                    last_good_mb->disk_format_version);
+                    latest_crc_mb->disk_format_version);
         }
 
-        /* we found a metablock, set everything up */
-        next_version_number = latest_version + 1;
-        latest_version = MB_BAD_VERSION; /* version is now useless */
-        head.pop();
-        *mb_found = true;
-        memcpy(mb_out, &last_good_mb->metablock, sizeof(log_serializer_metablock_t));
+        // We found a metablock.
+        next_version_number = max_version + 1;
+        next_mb_slot = metablock_offsets::next(extent_size, max_index);
+        *mb_found_out = true;
+        memcpy(mb_out, &latest_crc_mb->metablock, sizeof(log_serializer_metablock_t));
     }
+
     state = state_ready;
 }
 
@@ -317,10 +266,10 @@ void metablock_manager_t::co_write_metablock(
     rassert(crc_metablock::check_crc(crc_mb.get()));
 
     state = state_writing;
-    co_write(dbfile, head.offset(), METABLOCK_SIZE, crc_mb.get(), io_account,
+    int64_t offset = metablock_offsets::get(extent_manager->extent_size, next_mb_slot);
+    next_mb_slot = metablock_offsets::next(extent_manager->extent_size, next_mb_slot);
+    co_write(dbfile, offset, METABLOCK_SIZE, crc_mb.get(), io_account,
              file_t::WRAP_IN_DATASYNCS);
-
-    ++head;
 
     state = state_ready;
     extent_manager->stats->bytes_written(METABLOCK_SIZE);

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -38,6 +38,25 @@ bool check_crc(const crc_metablock_t *crc_mb) {
 }
 }  // namespace crc_metablock
 
+namespace metablock_offsets {
+// How many distinct metablock offsets there are.
+size_t count(int64_t extent_size) {
+    return std::min<int64_t>(extent_size / METABLOCK_SIZE, MB_BLOCKS_PER_EXTENT) - 1;
+}
+
+int64_t get(int64_t extent_size, size_t index) {
+    size_t nmetablocks = metablock_offsets::count(extent_size);
+    guarantee(index < nmetablocks);
+    // The first DEVICE_BLOCK_SIZE of the file is used for the static header.
+    return (index + 1) * METABLOCK_SIZE;
+}
+
+// How big the file has to be, to contain all metablocks.
+int64_t min_filesize(int64_t extent_size) {
+    return (1 + metablock_offsets::count(extent_size)) * METABLOCK_SIZE;
+}
+}  // namespace metablock_offsets.
+
 
 std::vector<int64_t> initial_metablock_offsets(int64_t extent_size) {
     std::vector<int64_t> offsets;
@@ -64,15 +83,14 @@ void metablock_manager_t::metablock_manager_t::head_t::operator++() {
     mb_slot++;
     wraparound = false;
 
-    if (mb_slot >= mgr->metablock_offsets.size()) {
+    if (mb_slot >= metablock_offsets::count(mgr->extent_manager->extent_size)) {
         mb_slot = 0;
         wraparound = true;
     }
 }
 
 int64_t metablock_manager_t::metablock_manager_t::head_t::offset() {
-
-    return mgr->metablock_offsets[mb_slot];
+    return metablock_offsets::get(mgr->extent_manager->extent_size, mb_slot);
 }
 
 void metablock_manager_t::metablock_manager_t::head_t::push() {
@@ -89,11 +107,10 @@ void metablock_manager_t::metablock_manager_t::head_t::pop() {
 metablock_manager_t::metablock_manager_t(extent_manager_t *em)
     : head(this),
       extent_manager(em),
-      metablock_offsets(initial_metablock_offsets(extent_manager->extent_size)),
-      state(state_unstarted), dbfile(nullptr) {
-    rassert(sizeof(crc_metablock_t) <= METABLOCK_SIZE);
-
-    /* Build the list of metablock locations in the file */
+      state(state_unstarted),
+      dbfile(nullptr) {
+    static_assert(sizeof(crc_metablock_t) <= METABLOCK_SIZE,
+                  "crc_metablock_t too big");
 
     // We don't try to reserve any metablock extents because the only
     // extent we use is extent 0.  Extent 0 is already reserved by the
@@ -107,10 +124,7 @@ metablock_manager_t::~metablock_manager_t() {
 void metablock_manager_t::create(
         file_t *dbfile, int64_t extent_size,
         scoped_device_block_aligned_ptr_t<crc_metablock_t> &&initial) {
-
-    std::vector<int64_t> metablock_offsets = initial_metablock_offsets(extent_size);
-
-    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE);
+    dbfile->set_file_size_at_least(metablock_offsets::min_filesize(extent_size));
 
     /* Allocate a buffer for doing our writes */
     scoped_device_block_aligned_ptr_t<crc_metablock_t> buffer(METABLOCK_SIZE);
@@ -119,17 +133,18 @@ void metablock_manager_t::create(
     /* Wipe the metablock slots so we don't mistake something left by a previous
     database for a valid metablock. */
     struct : public iocallback_t, public cond_t {
-        int refcount;
+        size_t refcount;
         void on_io_complete() {
             refcount--;
             if (refcount == 0) pulse();
         }
     } callback;
-    callback.refcount = metablock_offsets.size();
-    for (unsigned i = 0; i < metablock_offsets.size(); i++) {
+    callback.refcount = metablock_offsets::count(extent_size);
+    for (size_t i = 0; i < metablock_offsets::count(extent_size); i++) {
         // We don't datasync here -- we can datasync when we write the first real
         // metablock.
-        dbfile->write_async(metablock_offsets[i], METABLOCK_SIZE, buffer.get(),
+        dbfile->write_async(metablock_offsets::get(extent_size, i),
+                            METABLOCK_SIZE, buffer.get(),
                             DEFAULT_DISK_ACCOUNT, &callback, file_t::NO_DATASYNCS);
     }
     callback.wait();
@@ -142,7 +157,7 @@ void metablock_manager_t::create(
     crc_metablock::prepare(buffer.get(),
                            static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
                            MB_START_VERSION);
-    co_write(dbfile, metablock_offsets[0], METABLOCK_SIZE, buffer.get(),
+    co_write(dbfile, metablock_offsets::get(extent_size, 0), METABLOCK_SIZE, buffer.get(),
              DEFAULT_DISK_ACCOUNT, file_t::WRAP_IN_DATASYNCS);
 }
 
@@ -180,7 +195,9 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
 
     metablock_version_t latest_version = MB_BAD_VERSION;
 
-    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE);
+    const int64_t extent_size = extent_manager->extent_size;
+
+    dbfile->set_file_size_at_least(metablock_offsets::min_filesize(extent_size));
 
     // Reading metablocks by issuing one I/O request at a time is
     // slow. Read all of them in one batch, and check them later.
@@ -194,21 +211,22 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
 
     private:
         scoped_device_block_aligned_ptr_t<crc_metablock_t> buffer;
-    } lbm(metablock_offsets.size());
+    } lbm(metablock_offsets::count(extent_size));
     struct : public iocallback_t, public cond_t {
-        int refcount;
+        size_t refcount;
         void on_io_complete() {
             refcount--;
             if (refcount == 0) pulse();
         }
     } callback;
-    callback.refcount = metablock_offsets.size();
-    for (unsigned i = 0; i < metablock_offsets.size(); i++) {
-        dbfile->read_async(metablock_offsets[i], METABLOCK_SIZE, lbm.get_metablock(i),
+    callback.refcount = metablock_offsets::count(extent_size);
+    for (size_t i = 0; i < metablock_offsets::count(extent_size); i++) {
+        dbfile->read_async(metablock_offsets::get(extent_size, i), METABLOCK_SIZE,
+                           lbm.get_metablock(i),
                            DEFAULT_DISK_ACCOUNT, &callback);
     }
     callback.wait();
-    extent_manager->stats->bytes_read(METABLOCK_SIZE * metablock_offsets.size());
+    extent_manager->stats->bytes_read(METABLOCK_SIZE * metablock_offsets::count(extent_size));
 
     // TODO: we can parallelize this code even further by doing crc
     // checks as soon as a block is ready, as opposed to waiting for
@@ -217,7 +235,7 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
 
     // We've read everything from disk. Now find the last good metablock.
     crc_metablock_t *last_good_mb = nullptr;
-    for (unsigned i = 0; i < metablock_offsets.size(); i++) {
+    for (size_t i = 0; i < metablock_offsets::count(extent_size); i++) {
         crc_metablock_t *mb_temp = lbm.get_metablock(i);
         if (crc_metablock::check_crc(mb_temp)) {
             if (mb_temp->version > latest_version) {

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -12,21 +12,8 @@
 #include "arch/runtime/coroutines.hpp"
 #include "concurrency/cond_var.hpp"
 #include "serializer/log/log_serializer.hpp"
+#include "serializer/log/metablock.hpp"
 #include "version.hpp"
-
-// This is stored directly to disk.  Changing it will change the disk format.
-ATTR_PACKED(struct crc_metablock_t {
-    char magic_marker[sizeof(MB_MARKER_MAGIC)];
-    // The version that differs only when the software is upgraded to a newer
-    // version.  This field might allow for in-place upgrading of the cluster.
-    uint32_t disk_format_version;
-    // The CRC checksum of [disk_format_version]+[version]+[metablock].
-    uint32_t _crc;
-    // The version that increments every time a metablock is written.
-    metablock_version_t version;
-    // The value in the metablock (pointing at LBA superblocks, etc).
-    log_serializer_metablock_t metablock;
-});
 
 namespace crc_metablock {
 uint32_t compute_metablock_crc(const crc_metablock_t *crc_mb) {

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -110,7 +110,7 @@ metablock_manager_t::~metablock_manager_t() {
 }
 
 void metablock_manager_t::create(file_t *dbfile, int64_t extent_size,
-                                 metablock_t *initial) {
+                                 log_serializer_metablock_t *initial) {
 
     std::vector<int64_t> metablock_offsets = initial_metablock_offsets(extent_size);
 
@@ -176,7 +176,7 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
 
 
 void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
-                                            metablock_t *mb_out) {
+                                            log_serializer_metablock_t *mb_out) {
     rassert(state == state_unstarted);
     dbfile = file;
     rassert(dbfile != nullptr);
@@ -250,8 +250,8 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
 
         /* The log serializer will catastrophically fail when it sees that mb_found is
            false. We could catastrophically fail here, but it's a bit nicer to have the
-           metablock manager as a standalone component that doesn't know how to behave if there
-           is no metablock. */
+           metablock manager as a standalone component that doesn't know how to behave
+           if there is no metablock. */
 
     } else {
         // Right now we don't have anything super-special between disk format
@@ -273,7 +273,7 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
         head.pop();
         *mb_found = true;
         memcpy(mb_buffer.get(), last_good_mb, METABLOCK_SIZE);
-        memcpy(mb_out, &(mb_buffer->metablock), sizeof(metablock_t));
+        memcpy(mb_out, &(mb_buffer->metablock), sizeof(log_serializer_metablock_t));
     }
     mb_buffer_in_use = false;
     state = state_ready;
@@ -281,20 +281,20 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found,
 
 //The following two functions will go away in favor of the preceding one
 void metablock_manager_t::start_existing_callback(
-        file_t *file, bool *mb_found, metablock_t *mb_out,
+        file_t *file, bool *mb_found, log_serializer_metablock_t *mb_out,
         metablock_read_callback_t *cb) {
     co_start_existing(file, mb_found, mb_out);
     cb->on_metablock_read();
 }
 
 bool metablock_manager_t::start_existing(
-        file_t *file, bool *mb_found, metablock_t *mb_out,
+        file_t *file, bool *mb_found, log_serializer_metablock_t *mb_out,
         metablock_read_callback_t *cb) {
     coro_t::spawn_later_ordered(std::bind(&metablock_manager_t::start_existing_callback,
                                           this, file, mb_found, mb_out, cb));
     return false;
 }
-void metablock_manager_t::co_write_metablock(metablock_t *mb,
+void metablock_manager_t::co_write_metablock(log_serializer_metablock_t *mb,
                                              file_account_t *io_account) {
     mutex_t::acq_t hold(&write_lock);
 
@@ -320,12 +320,17 @@ void metablock_manager_t::co_write_metablock(metablock_t *mb,
     extent_manager->stats->bytes_written(METABLOCK_SIZE);
 }
 
-void metablock_manager_t::write_metablock_callback(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb) {
+void metablock_manager_t::write_metablock_callback(
+        log_serializer_metablock_t *mb,
+        file_account_t *io_account,
+        metablock_write_callback_t *cb) {
     co_write_metablock(mb, io_account);
     cb->on_metablock_write();
 }
 
-void metablock_manager_t::write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb) {
+void metablock_manager_t::write_metablock(log_serializer_metablock_t *mb,
+                                          file_account_t *io_account,
+                                          metablock_write_callback_t *cb) {
     coro_t::spawn_later_ordered(std::bind(&metablock_manager_t::write_metablock_callback,
                                           this, mb, io_account, cb));
 }

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -98,7 +98,7 @@ public:
         virtual void on_metablock_write() = 0;
         virtual ~metablock_write_callback_t() {}
     };
-    bool write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb);
+    void write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb);
     void co_write_metablock(metablock_t *mb, file_account_t *io_account);
 
     void shutdown();

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -50,13 +50,15 @@ public:
         virtual ~metablock_read_callback_t() {}
     };
 
-    bool start_existing(file_t *dbfile, bool *mb_found, metablock_t *mb_out, metablock_read_callback_t *cb);
+    bool start_existing(file_t *dbfile, bool *mb_found, metablock_t *mb_out,
+                        metablock_read_callback_t *cb);
 
     struct metablock_write_callback_t {
         virtual void on_metablock_write() = 0;
         virtual ~metablock_write_callback_t() {}
     };
-    void write_metablock(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb);
+    void write_metablock(metablock_t *mb, file_account_t *io_account,
+                         metablock_write_callback_t *cb);
     void co_write_metablock(metablock_t *mb, file_account_t *io_account);
 
     void shutdown();
@@ -79,15 +81,18 @@ private:
         // return the offset we should be writing to
         int64_t offset();
 
-        // save the state to be loaded later (used to save the last known uncorrupted metablock)
+        // save the state to be loaded later (used to save the last known uncorrupted
+        // metablock)
         void push();
 
         //load a previously saved state (stack has max depth one)
         void pop();
     };
 
-    void start_existing_callback(file_t *dbfile, bool *mb_found, metablock_t *mb_out, metablock_read_callback_t *cb);
-    void write_metablock_callback(metablock_t *mb, file_account_t *io_account, metablock_write_callback_t *cb);
+    void start_existing_callback(file_t *dbfile, bool *mb_found, metablock_t *mb_out,
+                                 metablock_read_callback_t *cb);
+    void write_metablock_callback(metablock_t *mb, file_account_t *io_account,
+                                  metablock_write_callback_t *cb);
 
     mutex_t write_lock;
 

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -12,6 +12,7 @@
 #include "concurrency/mutex.hpp"
 #include "serializer/log/extent_manager.hpp"
 #include "serializer/log/static_header.hpp"
+#include "serializer/log/metablock.hpp"
 
 
 #define MB_BLOCKS_PER_EXTENT 8
@@ -22,13 +23,8 @@
 
 
 /* TODO support multiple concurrent writes */
-static const char MB_MARKER_MAGIC[8] = {'m', 'e', 't', 'a', 'b', 'l', 'c', 'k'};
 
 std::vector<int64_t> initial_metablock_offsets(int64_t extent_size);
-
-struct log_serializer_metablock_t;
-struct crc_metablock_t;
-typedef int64_t metablock_version_t;
 
 class metablock_manager_t {
 public:

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -28,31 +28,33 @@ std::vector<int64_t> initial_metablock_offsets(int64_t extent_size);
 
 class metablock_manager_t {
 public:
-    typedef log_serializer_metablock_t metablock_t;
-
     explicit metablock_manager_t(extent_manager_t *em);
     ~metablock_manager_t();
 
     /* Clear metablock slots and write an initial metablock to the database file */
-    static void create(file_t *dbfile, int64_t extent_size, metablock_t *initial);
+    static void create(file_t *dbfile, int64_t extent_size,
+                       log_serializer_metablock_t *initial);
 
     /* Tries to load existing metablocks */
-    void co_start_existing(file_t *dbfile, bool *mb_found, metablock_t *mb_out);
+    void co_start_existing(file_t *dbfile, bool *mb_found,
+                           log_serializer_metablock_t *mb_out);
     struct metablock_read_callback_t {
         virtual void on_metablock_read() = 0;
         virtual ~metablock_read_callback_t() {}
     };
 
-    bool start_existing(file_t *dbfile, bool *mb_found, metablock_t *mb_out,
+    bool start_existing(file_t *dbfile, bool *mb_found,
+                        log_serializer_metablock_t *mb_out,
                         metablock_read_callback_t *cb);
 
     struct metablock_write_callback_t {
         virtual void on_metablock_write() = 0;
         virtual ~metablock_write_callback_t() {}
     };
-    void write_metablock(metablock_t *mb, file_account_t *io_account,
+    void write_metablock(log_serializer_metablock_t *mb,
+                         file_account_t *io_account,
                          metablock_write_callback_t *cb);
-    void co_write_metablock(metablock_t *mb, file_account_t *io_account);
+    void co_write_metablock(log_serializer_metablock_t *mb, file_account_t *io_account);
 
     void shutdown();
 
@@ -82,9 +84,12 @@ private:
         void pop();
     };
 
-    void start_existing_callback(file_t *dbfile, bool *mb_found, metablock_t *mb_out,
+    void start_existing_callback(file_t *dbfile,
+                                 bool *mb_found,
+                                 log_serializer_metablock_t *mb_out,
                                  metablock_read_callback_t *cb);
-    void write_metablock_callback(metablock_t *mb, file_account_t *io_account,
+    void write_metablock_callback(log_serializer_metablock_t *mb,
+                                  file_account_t *io_account,
                                   metablock_write_callback_t *cb);
 
     mutex_t write_lock;

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -63,28 +63,6 @@ public:
     void shutdown();
 
 private:
-    struct head_t {
-    private:
-        size_t mb_slot;
-        size_t saved_mb_slot;
-    public:
-        explicit head_t(metablock_manager_t *mgr);
-        metablock_manager_t *const mgr;
-
-        // handles moving along successive mb slots
-        void operator++();
-
-        // return the offset we should be writing to
-        int64_t offset();
-
-        // save the state to be loaded later (used to save the last known uncorrupted
-        // metablock)
-        void push();
-
-        //load a previously saved state (stack has max depth one)
-        void pop();
-    };
-
     void start_existing_callback(file_t *dbfile,
                                  bool *mb_found,
                                  log_serializer_metablock_t *mb_out,
@@ -98,8 +76,8 @@ private:
     // desirable thing, but that's how this type works.
     mutex_t write_lock;
 
-    // keeps track of where we are in the extents
-    head_t head;
+    // Which metablock slot we should write next.
+    size_t next_mb_slot;
 
     metablock_version_t next_version_number;
 

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -65,8 +65,8 @@ public:
 private:
     struct head_t {
     private:
-        uint32_t mb_slot;
-        uint32_t saved_mb_slot;
+        size_t mb_slot;
+        size_t saved_mb_slot;
     public:
         // whether or not we've wrapped around the edge (used during startup)
         bool wraparound;
@@ -107,8 +107,6 @@ private:
     metablock_version_t next_version_number;
 
     extent_manager_t *const extent_manager;
-
-    const std::vector<int64_t> metablock_offsets;
 
     enum state_t {
         state_unstarted,

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -68,9 +68,6 @@ private:
         size_t mb_slot;
         size_t saved_mb_slot;
     public:
-        // whether or not we've wrapped around the edge (used during startup)
-        bool wraparound;
-    public:
         explicit head_t(metablock_manager_t *mgr);
         metablock_manager_t *const mgr;
 

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -7,9 +7,6 @@
 
 #include <vector>
 
-#include "errors.hpp"
-#include <boost/crc.hpp>
-
 #include "arch/compiler.hpp"
 #include "arch/types.hpp"
 #include "concurrency/mutex.hpp"

--- a/src/serializer/log/static_header.cc
+++ b/src/serializer/log/static_header.cc
@@ -52,16 +52,20 @@ void co_static_header_write(file_t *file, void *data, size_t data_size) {
 
     // We want to follow up the static header write with a datasync, because... it's the
     // most important block in the file!
-    co_write(file, 0, DEVICE_BLOCK_SIZE, buffer.get(), DEFAULT_DISK_ACCOUNT, file_t::WRAP_IN_DATASYNCS);
+    co_write(file, 0, DEVICE_BLOCK_SIZE, buffer.get(), DEFAULT_DISK_ACCOUNT,
+             file_t::WRAP_IN_DATASYNCS);
 }
 
-void co_static_header_write_helper(file_t *file, static_header_write_callback_t *cb, void *data, size_t data_size) {
+void co_static_header_write_helper(file_t *file, static_header_write_callback_t *cb,
+                                   void *data, size_t data_size) {
     co_static_header_write(file, data, data_size);
     cb->on_static_header_write();
 }
 
-bool static_header_write(file_t *file, void *data, size_t data_size, static_header_write_callback_t *cb) {
-    coro_t::spawn_later_ordered(std::bind(co_static_header_write_helper, file, cb, data, data_size));
+bool static_header_write(file_t *file, void *data, size_t data_size,
+                         static_header_write_callback_t *cb) {
+    coro_t::spawn_later_ordered(std::bind(co_static_header_write_helper,
+                                          file, cb, data, data_size));
     return false;
 }
 

--- a/src/serializer/merger.cc
+++ b/src/serializer/merger.cc
@@ -23,7 +23,7 @@ merger_serializer_t::~merger_serializer_t() {
     rassert(outstanding_index_write_ops.empty());
 }
 
-counted_t<standard_block_token_t> merger_serializer_t::index_read(block_id_t block_id) {
+counted_t<block_token_t> merger_serializer_t::index_read(block_id_t block_id) {
     // First check if there is an updated entry for the block id...
     const auto write_op = outstanding_index_write_ops.find(block_id);
     if (write_op != outstanding_index_write_ops.end()) {

--- a/src/serializer/merger.hpp
+++ b/src/serializer/merger.hpp
@@ -54,7 +54,7 @@ public:
     }
 
     // Reading a block from the serializer.  Reads a block, blocks the coroutine.
-    buf_ptr_t block_read(const counted_t<standard_block_token_t> &token,
+    buf_ptr_t block_read(const counted_t<block_token_t> &token,
                        file_account_t *io_account) {
         return inner->block_read(token, io_account);
     }
@@ -83,7 +83,7 @@ public:
     bool get_delete_bit(block_id_t id) { return inner->get_delete_bit(id); }
 
     /* Reads the block's actual data */
-    counted_t<standard_block_token_t> index_read(block_id_t block_id);
+    counted_t<block_token_t> index_read(block_id_t block_id);
 
     /* index_write() applies all given index operations in an atomic way */
     /* This is where merger_serializer_t merges operations */
@@ -92,7 +92,7 @@ public:
                      const std::vector<index_write_op_t> &write_ops);
 
     // Returns block tokens in the same order as write_infos.
-    std::vector<counted_t<standard_block_token_t> >
+    std::vector<counted_t<block_token_t>>
     block_writes(const std::vector<buf_write_info_t> &write_infos,
                  UNUSED file_account_t *io_account,
                  iocallback_t *cb) {

--- a/src/serializer/serializer.hpp
+++ b/src/serializer/serializer.hpp
@@ -60,7 +60,7 @@ public:
 
     // Reading a block from the serializer.  Reads a block, blocks the coroutine.
     virtual buf_ptr_t block_read(const counted_t<standard_block_token_t> &token,
-                               file_account_t *io_account) = 0;
+                                 file_account_t *io_account) = 0;
 
     /* The index stores three pieces of information for each ID:
      * 1. A pointer to a data block on disk (which may be NULL)

--- a/src/serializer/serializer.hpp
+++ b/src/serializer/serializer.hpp
@@ -18,13 +18,13 @@ struct index_write_op_t {
     block_id_t block_id;
     // Buf to write.  r_nullopt if not to be modified.  Initialized to an empty
     // counted_t if the block is to be deleted.
-    optional<counted_t<standard_block_token_t> > token;
+    optional<counted_t<block_token_t>> token;
     // Recency, if it should be modified.  (It's unmodified when the data block
     // manager moves blocks around while garbage collecting.)
     optional<repli_timestamp_t> recency;
 
     explicit index_write_op_t(block_id_t _block_id,
-                              optional<counted_t<standard_block_token_t> > _token = r_nullopt,
+                              optional<counted_t<block_token_t>> _token = r_nullopt,
                               optional<repli_timestamp_t> _recency = r_nullopt)
         : block_id(_block_id), token(_token), recency(_recency) { }
 };
@@ -41,7 +41,7 @@ translator_serializer_t. */
 
 class serializer_t : public home_thread_mixin_t {
 public:
-    typedef standard_block_token_t block_token_type;
+    typedef block_token_t block_token_type;
 
     serializer_t() { }
     virtual ~serializer_t() { }
@@ -59,7 +59,7 @@ public:
     virtual void unregister_read_ahead_cb(serializer_read_ahead_callback_t *cb) = 0;
 
     // Reading a block from the serializer.  Reads a block, blocks the coroutine.
-    virtual buf_ptr_t block_read(const counted_t<standard_block_token_t> &token,
+    virtual buf_ptr_t block_read(const counted_t<block_token_t> &token,
                                  file_account_t *io_account) = 0;
 
     /* The index stores three pieces of information for each ID:
@@ -96,7 +96,7 @@ public:
     virtual bool get_delete_bit(block_id_t id) = 0;
 
     /* Reads the block's actual data */
-    virtual counted_t<standard_block_token_t> index_read(block_id_t block_id) = 0;
+    virtual counted_t<block_token_t> index_read(block_id_t block_id) = 0;
 
     // Applies all given index operations in an atomic way.  The mutex_acq is for a
     // mutex belonging to the _caller_, used by the caller for pipelining, for
@@ -109,7 +109,7 @@ public:
                              const std::vector<index_write_op_t> &write_ops) = 0;
 
     // Returns block tokens in the same order as write_infos.
-    virtual std::vector<counted_t<standard_block_token_t> >
+    virtual std::vector<counted_t<block_token_t>>
     block_writes(const std::vector<buf_write_info_t> &write_infos,
                  file_account_t *io_account,
                  iocallback_t *cb) = 0;

--- a/src/serializer/serializer.hpp
+++ b/src/serializer/serializer.hpp
@@ -49,11 +49,13 @@ public:
     /* Allocates a new io account for the underlying file.
     Use delete to free it. */
     file_account_t *make_io_account(int priority);
-    virtual file_account_t *make_io_account(int priority, int outstanding_requests_limit) = 0;
+    virtual file_account_t *make_io_account(int priority,
+                                            int outstanding_requests_limit) = 0;
 
     /* Some serializer implementations support read-ahead to speed up cache warmup.
-    This is supported through a serializer_read_ahead_callback_t which gets called whenever the serializer has read-ahead some buf.
-    The callee can then decide whether it wants to use the offered buffer of discard it.
+    This is supported through a serializer_read_ahead_callback_t which gets called
+    whenever the serializer has read-ahead some buf.  The callee can then decide whether
+    it wants to use the offered buffer of discard it.
     */
     virtual void register_read_ahead_cb(serializer_read_ahead_callback_t *cb) = 0;
     virtual void unregister_read_ahead_cb(serializer_read_ahead_callback_t *cb) = 0;

--- a/src/serializer/translator.cc
+++ b/src/serializer/translator.cc
@@ -26,13 +26,13 @@ int compute_mod_count(int32_t file_number, int32_t n_files, int32_t n_slices) {
     return n_slices / n_files + (n_slices % n_files > file_number);
 }
 
-counted_t<standard_block_token_t> serializer_block_write(serializer_t *ser, const buf_ptr_t &buf,
+counted_t<block_token_t> serializer_block_write(serializer_t *ser, const buf_ptr_t &buf,
                                                          block_id_t block_id, file_account_t *io_account) {
     struct : public cond_t, public iocallback_t {
         void on_io_complete() { pulse(); }
     } cb;
 
-    std::vector<counted_t<standard_block_token_t> > tokens
+    std::vector<counted_t<block_token_t>> tokens
         = ser->block_writes({ buf_write_info_t(buf.ser_buffer(), buf.block_size(),
                                                block_id) },
                             io_account, &cb);
@@ -246,7 +246,7 @@ void translator_serializer_t::index_write(
     inner->index_write(mutex_acq, on_writes_reflected, translated_ops);
 }
 
-std::vector<counted_t<standard_block_token_t> >
+std::vector<counted_t<block_token_t>>
 translator_serializer_t::block_writes(const std::vector<buf_write_info_t> &write_infos,
                                       file_account_t *io_account, iocallback_t *cb) {
     std::vector<buf_write_info_t> tmp;
@@ -261,12 +261,12 @@ translator_serializer_t::block_writes(const std::vector<buf_write_info_t> &write
 }
 
 
-buf_ptr_t translator_serializer_t::block_read(const counted_t<standard_block_token_t> &token,
+buf_ptr_t translator_serializer_t::block_read(const counted_t<block_token_t> &token,
                                             file_account_t *io_account) {
     return inner->block_read(token, io_account);
 }
 
-counted_t<standard_block_token_t> translator_serializer_t::index_read(block_id_t block_id) {
+counted_t<block_token_t> translator_serializer_t::index_read(block_id_t block_id) {
     return inner->index_read(translate_block_id(block_id));
 }
 
@@ -332,7 +332,7 @@ bool translator_serializer_t::get_delete_bit(block_id_t id) {
 void translator_serializer_t::offer_read_ahead_buf(
         block_id_t block_id,
         buf_ptr_t *buf,
-        const counted_t<standard_block_token_t> &token) {
+        const counted_t<block_token_t> &token) {
     inner->assert_thread();
 
     if (block_id <= CONFIG_BLOCK_ID.ser_id) {

--- a/src/serializer/translator.hpp
+++ b/src/serializer/translator.hpp
@@ -12,16 +12,16 @@ class translator_serializer_t;
 
 class serializer_multiplexer_t {
 public:
-    /* Blocking call. Assumes the given serializers are empty; initializes them such that they can
-    be treated as 'n_proxies' proxy-serializers. */
+    /* Blocking call. Assumes the given serializers are empty; initializes them such
+    that they can be treated as 'n_proxies' proxy-serializers. */
     static void create(const std::vector<serializer_t *> &underlying, int n_proxies);
 
-    /* Blocking call. Must give the same set of underlying serializers you gave to create(). (It
-    will abort if this is not the case.) */
+    /* Blocking call. Must give the same set of underlying serializers you gave to
+    create(). (It will abort if this is not the case.) */
     explicit serializer_multiplexer_t(const std::vector<serializer_t *> &underlying);
 
-    /* proxies.size() is the same as 'n_proxies' you passed to create(). Please do not mutate
-    'proxies'. */
+    /* proxies.size() is the same as 'n_proxies' you passed to create(). Please do not
+    mutate 'proxies'. */
     std::vector<translator_serializer_t *> proxies;
 
     /* Blocking call. */
@@ -30,8 +30,8 @@ public:
     creation_timestamp_t creation_timestamp;
 };
 
-/* The multiplex_serializer_t writes a multiplexer_config_block_t in block ID 0 of each of its
-underlying serializers. */
+/* The multiplex_serializer_t writes a multiplexer_config_block_t in block ID 0 of each
+of its underlying serializers. */
 
 struct config_block_id_t {
     /* This type is kind of silly. */
@@ -57,13 +57,13 @@ ATTR_PACKED(struct multiplexer_config_block_t {
     databases are mixed. */
     creation_timestamp_t creation_timestamp;
 
-    /* How many serializers the database is using (in case user creates the database with
-    some number of serializers and then specifies less than that many on a subsequent
-    run) */
+    /* How many serializers the database is using (in case user creates the database
+    with some number of serializers and then specifies less than that many on a
+    subsequent run) */
     int32_t n_files;
 
-    /* Which serializer this is, in case user specifies serializers in a different order from
-    run to run */
+    /* Which serializer this is, in case user specifies serializers in a different order
+    from run to run */
     int32_t this_serializer;
 
     /* How many sub-serializers this serializer group is acting as */
@@ -73,11 +73,12 @@ ATTR_PACKED(struct multiplexer_config_block_t {
 });
 
 /* The translator serializer is a wrapper around another serializer. It uses some subset
-of the block IDs available on the inner serializer, but presents the illusion of a complete
-serializer. It is used for splitting one serializer among several buffer caches on different
-threads. */
+of the block IDs available on the inner serializer, but presents the illusion of a
+complete serializer. It is used for splitting one serializer among several buffer caches
+on different threads. */
 
-class translator_serializer_t : public serializer_t, public serializer_read_ahead_callback_t {
+class translator_serializer_t : public serializer_t,
+                                public serializer_read_ahead_callback_t {
 public:
     typedef serializer_read_ahead_callback_t serializer_read_ahead_callback_t;
 
@@ -94,21 +95,28 @@ private:
 public:
     virtual ~translator_serializer_t() { }
 
-    // Translates a block id from external (meaningful to the translator_serializer_t) to internal
-    // (meaningful to the underlying inner serializer) given the particular parameters. This needs
-    // to be exposed in some way because recovery tools depend on it.
-    static block_id_t translate_block_id(block_id_t id, int mod_count, int mod_id, config_block_id_t cfgid);
+    // Translates a block id from external (meaningful to the translator_serializer_t)
+    // to internal (meaningful to the underlying inner serializer) given the particular
+    // parameters. This needs to be exposed in some way because recovery tools depend on
+    // it.
+    static block_id_t translate_block_id(block_id_t id, int mod_count, int mod_id,
+                                         config_block_id_t cfgid);
     block_id_t translate_block_id(block_id_t id) const;
 
-    // "Inverts" translate_block_id, converting inner_id back to mod_id (not back to id).
-    static int untranslate_block_id_to_mod_id(block_id_t inner_id, int mod_count, config_block_id_t cfgid);
+    // "Inverts" translate_block_id, converting inner_id back to mod_id (not back to
+    // id).
+    static int untranslate_block_id_to_mod_id(block_id_t inner_id, int mod_count,
+                                              config_block_id_t cfgid);
     // ... and this one converts inner_id back to id, given mod_id.
-    static block_id_t untranslate_block_id_to_id(block_id_t inner_id, int mod_count, int mod_id, config_block_id_t cfgid);
+    static block_id_t untranslate_block_id_to_id(block_id_t inner_id, int mod_count,
+                                                 int mod_id, config_block_id_t cfgid);
 
 public:
     /* The translator serializer will only use block IDs on the inner serializer that
-    are greater than or equal to 'min' and such that ((id - min) % mod_count) == mod_id. */
-    translator_serializer_t(serializer_t *inner, int mod_count, int mod_id, config_block_id_t cfgid);
+    are greater than or equal to 'min' and such that ((id - min) % mod_count) ==
+    mod_id. */
+    translator_serializer_t(serializer_t *inner, int mod_count, int mod_id,
+                            config_block_id_t cfgid);
 
     /* Allocates a new io account for the underlying file */
     file_account_t *make_io_account(int priority, int outstanding_requests_limit);
@@ -117,8 +125,9 @@ public:
                      const std::function<void()> &on_writes_reflected,
                      const std::vector<index_write_op_t> &write_ops);
 
-    std::vector<counted_t<block_token_t>>
-    block_writes(const std::vector<buf_write_info_t> &write_infos, file_account_t *io_account, iocallback_t *cb);
+    std::vector<counted_t<block_token_t> >
+    block_writes(const std::vector<buf_write_info_t> &write_infos,
+                 file_account_t *io_account, iocallback_t *cb);
 
     max_block_size_t max_block_size() const;
 

--- a/src/serializer/translator.hpp
+++ b/src/serializer/translator.hpp
@@ -117,7 +117,7 @@ public:
                      const std::function<void()> &on_writes_reflected,
                      const std::vector<index_write_op_t> &write_ops);
 
-    std::vector<counted_t<standard_block_token_t> >
+    std::vector<counted_t<block_token_t>>
     block_writes(const std::vector<buf_write_info_t> &write_infos, file_account_t *io_account, iocallback_t *cb);
 
     max_block_size_t max_block_size() const;
@@ -133,14 +133,14 @@ public:
                                                             block_id_t step);
     bool get_delete_bit(block_id_t id);
 
-    buf_ptr_t block_read(const counted_t<standard_block_token_t> &token,
+    buf_ptr_t block_read(const counted_t<block_token_t> &token,
                        file_account_t *io_account);
-    counted_t<standard_block_token_t> index_read(block_id_t block_id);
+    counted_t<block_token_t> index_read(block_id_t block_id);
 
 public:
     void offer_read_ahead_buf(block_id_t block_id,
                               buf_ptr_t *buf,
-                              const counted_t<standard_block_token_t> &token);
+                              const counted_t<block_token_t> &token);
 
 private:
     // Helper function for `end_block_id` and `end_aux_block_id`

--- a/src/serializer/types.hpp
+++ b/src/serializer/types.hpp
@@ -130,7 +130,7 @@ class repli_timestamp_t;
 
 class log_serializer_t;
 
-class standard_block_token_t {
+class block_token_t {
 public:
     int64_t offset() const { return offset_; }
     block_size_t block_size() const { return block_size_; }
@@ -139,12 +139,12 @@ private:
     friend class log_serializer_t;
     friend class dbm_read_ahead_fsm_t;  // For read-ahead tokens.
 
-    friend void counted_add_ref(standard_block_token_t *p);
-    friend void counted_release(standard_block_token_t *p);
+    friend void counted_add_ref(block_token_t *p);
+    friend void counted_release(block_token_t *p);
 
-    standard_block_token_t(log_serializer_t *serializer,
-                           int64_t initial_offset,
-                           block_size_t initial_ser_block_size);
+    block_token_t(log_serializer_t *serializer,
+                  int64_t initial_offset,
+                  block_size_t initial_ser_block_size);
 
     log_serializer_t *const serializer_;
     std::atomic<intptr_t> ref_count_;
@@ -157,14 +157,14 @@ private:
 
     void do_destroy();
 
-    DISABLE_COPYING(standard_block_token_t);
+    DISABLE_COPYING(block_token_t);
 };
 
 void debug_print(printf_buffer_t *buf,
-                 const counted_t<standard_block_token_t> &token);
+                 const counted_t<block_token_t> &token);
 
-void counted_add_ref(standard_block_token_t *p);
-void counted_release(standard_block_token_t *p);
+void counted_add_ref(block_token_t *p);
+void counted_release(block_token_t *p);
 
 
 class file_t;
@@ -200,7 +200,7 @@ public:
     // ownership, by leaving `*buf` untouched.
     virtual void offer_read_ahead_buf(block_id_t block_id,
                                       buf_ptr_t *buf,
-                                      const counted_t<standard_block_token_t> &token) = 0;
+                                      const counted_t<block_token_t> &token) = 0;
 };
 
 struct buf_write_info_t {

--- a/src/serializer/types.hpp
+++ b/src/serializer/types.hpp
@@ -128,11 +128,9 @@ private:
 
 class repli_timestamp_t;
 
-template <class serializer_type> struct serializer_traits_t;
-
 class log_serializer_t;
 
-class ls_block_token_pointee_t {
+class standard_block_token_t {
 public:
     int64_t offset() const { return offset_; }
     block_size_t block_size() const { return block_size_; }
@@ -141,10 +139,10 @@ private:
     friend class log_serializer_t;
     friend class dbm_read_ahead_fsm_t;  // For read-ahead tokens.
 
-    friend void counted_add_ref(ls_block_token_pointee_t *p);
-    friend void counted_release(ls_block_token_pointee_t *p);
+    friend void counted_add_ref(standard_block_token_t *p);
+    friend void counted_release(standard_block_token_t *p);
 
-    ls_block_token_pointee_t(log_serializer_t *serializer,
+    standard_block_token_t(log_serializer_t *serializer,
                              int64_t initial_offset,
                              block_size_t initial_ser_block_size);
 
@@ -159,19 +157,15 @@ private:
 
     void do_destroy();
 
-    DISABLE_COPYING(ls_block_token_pointee_t);
+    DISABLE_COPYING(standard_block_token_t);
 };
 
 void debug_print(printf_buffer_t *buf,
-                 const counted_t<ls_block_token_pointee_t> &token);
+                 const counted_t<standard_block_token_t> &token);
 
-void counted_add_ref(ls_block_token_pointee_t *p);
-void counted_release(ls_block_token_pointee_t *p);
+void counted_add_ref(standard_block_token_t *p);
+void counted_release(standard_block_token_t *p);
 
-template <>
-struct serializer_traits_t<log_serializer_t> {
-    typedef ls_block_token_pointee_t block_token_type;
-};
 
 class file_t;
 
@@ -189,24 +183,8 @@ public:
     virtual void unlink_serializer_file() = 0;
 };
 
-// TODO: This is a hack remaining from when we had the semantic checking serializer
-// and had to mask the implementation of a block token. We should check if we
-// can remove this indirection now.
-inline
-counted_t<ls_block_token_pointee_t>
-to_standard_block_token(UNUSED block_id_t block_id,
-                        counted_t<ls_block_token_pointee_t> tok) {
-    return tok;
-}
-
-typedef serializer_traits_t<log_serializer_t>::block_token_type standard_block_token_t;
-
 class serializer_t;
 
-template <>
-struct serializer_traits_t<serializer_t> {
-    typedef standard_block_token_t block_token_type;
-};
 
 // TODO: This is obsolete because the serializer multiplexer isn't used with multiple
 // files any more.

--- a/src/serializer/types.hpp
+++ b/src/serializer/types.hpp
@@ -143,10 +143,10 @@ private:
     friend void counted_release(standard_block_token_t *p);
 
     standard_block_token_t(log_serializer_t *serializer,
-                             int64_t initial_offset,
-                             block_size_t initial_ser_block_size);
+                           int64_t initial_offset,
+                           block_size_t initial_ser_block_size);
 
-    log_serializer_t *serializer_;
+    log_serializer_t *const serializer_;
     std::atomic<intptr_t> ref_count_;
 
     // The block's size.

--- a/src/unittest/disk_format_test.cc
+++ b/src/unittest/disk_format_test.cc
@@ -98,26 +98,26 @@ TEST(DiskFormatTest, LbaSuperblockT) {
 }
 
 TEST(DiskFormatTest, DataBlockManagerMetablockMixinT) {
-    EXPECT_EQ(0u, offsetof(data_block_manager::metablock_mixin_t, active_extent));
-    EXPECT_EQ(8u, sizeof(data_block_manager::metablock_mixin_t));
+    EXPECT_EQ(0u, offsetof(dbm_metablock_mixin_t, active_extent));
+    EXPECT_EQ(8u, sizeof(dbm_metablock_mixin_t));
 }
 
 TEST(DiskFormatTest, ExtentManagerMetablockMixinT) {
-    EXPECT_EQ(0u, offsetof(extent_manager_t::metablock_mixin_t, padding));
-    EXPECT_EQ(8u, sizeof(extent_manager_t::metablock_mixin_t));
+    EXPECT_EQ(0u, offsetof(extent_manager_metablock_mixin_t, padding));
+    EXPECT_EQ(8u, sizeof(extent_manager_metablock_mixin_t));
 }
 
 TEST(DiskFormatTest, LogSerializerMetablockT) {
     size_t n = 0;
     EXPECT_EQ(n, offsetof(log_serializer_metablock_t, extent_manager_part));
 
-    n += sizeof(extent_manager_t::metablock_mixin_t);
+    n += sizeof(extent_manager_metablock_mixin_t);
     EXPECT_EQ(n, offsetof(log_serializer_metablock_t, lba_index_part));
 
-    n += sizeof(lba_list_t::metablock_mixin_t);
+    n += sizeof(lba_metablock_mixin_t);
     EXPECT_EQ(n, offsetof(log_serializer_metablock_t, data_block_manager_part));
 
-    n += sizeof(data_block_manager::metablock_mixin_t);
+    n += sizeof(dbm_metablock_mixin_t);
     EXPECT_EQ(n, sizeof(log_serializer_metablock_t));
 
     EXPECT_EQ(3736, 8 + (128 + 8 + 3584) + 8);

--- a/src/unittest/disk_format_test.cc
+++ b/src/unittest/disk_format_test.cc
@@ -52,6 +52,7 @@ TEST(DiskFormatTest, LbaMetablockMixinT) {
     EXPECT_EQ(METABLOCK_SIZE - 512, LBA_INLINE_SIZE);
     EXPECT_EQ(32u, sizeof(lba_entry_t));
     EXPECT_EQ(32ul * LBA_SHARD_FACTOR + 8ul + LBA_INLINE_SIZE, sizeof(lba_metablock_mixin_t));
+    EXPECT_EQ(3720u, sizeof(lba_metablock_mixin_t));
 }
 
 TEST(DiskFormatTest, LbaEntryT) {

--- a/src/unittest/disk_format_test.cc
+++ b/src/unittest/disk_format_test.cc
@@ -125,6 +125,23 @@ TEST(DiskFormatTest, LogSerializerMetablockT) {
     EXPECT_EQ(3736u, sizeof(log_serializer_metablock_t));
 }
 
+TEST(DiskFormatTest, CrcMetablockT) {
+    size_t n = 0;
+    EXPECT_EQ(n, offsetof(crc_metablock_t, magic_marker));
+    n += 8;
+    EXPECT_EQ(n, offsetof(crc_metablock_t, disk_format_version));
+    n += 4;
+    EXPECT_EQ(n, offsetof(crc_metablock_t, _crc));
+    n += 4;
+    EXPECT_EQ(n, offsetof(crc_metablock_t, version));
+    n += 8;
+    EXPECT_EQ(24, n);
+    EXPECT_EQ(n, offsetof(crc_metablock_t, metablock));
+    n += 3736;
+    EXPECT_EQ(3760, n);
+    EXPECT_EQ(n, sizeof(crc_metablock_t));
+}
+
 TEST(DiskFormatTest, LogSerializerStaticConfigT) {
     EXPECT_EQ(0u, offsetof(log_serializer_on_disk_static_config_t, block_size_));
     EXPECT_EQ(8u, offsetof(log_serializer_on_disk_static_config_t, extent_size_));

--- a/src/unittest/serializer_test.cc
+++ b/src/unittest/serializer_test.cc
@@ -47,7 +47,7 @@ void run_AddDeleteRepeatedly(bool perform_index_write) {
             }
         } cb;
 
-        std::vector<counted_t<standard_block_token_t> > tokens
+        std::vector<counted_t<block_token_t>> tokens
             = ser.block_writes(infos, account.get(), &cb);
 
         // Wait for it to be written (because we're nice).
@@ -67,7 +67,7 @@ void run_AddDeleteRepeatedly(bool perform_index_write) {
             tokens.clear();
             {
                 std::vector<index_write_op_t> write_ops;
-                write_ops.push_back(index_write_op_t(block_id, make_optional(counted_t<standard_block_token_t>())));
+                write_ops.push_back(index_write_op_t(block_id, make_optional(counted_t<block_token_t>())));
 
                 // There are no other index_write operations to maintain ordering with.
                 new_mutex_in_line_t dummy_acq;


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
In making changes to the serializer, I put all the cleanup and janitorial commits up front.  So this is that set of commits.

I guess the commits fall into 5 categories:
- Non sequitur commits, don't really have much to do with the serializer
- Further cleanup as a result of the prior removal of the semantic checking serializer
- Moving stuff around so that changes can be tested or otherwise implemented
- Getting rid of all the silly little metablock typedefs
- Simplying some absolutely crazy way of doing stuff (e.g. metablock_manager_t::head_t)
