### PR TITLE
fix zlib-1.2.8 source url

### DIFF
--- a/mk/support/pkg/zlib.sh
+++ b/mk/support/pkg/zlib.sh
@@ -1,7 +1,8 @@
 
 version=1.2.8
 
-src_url=http://zlib.net/zlib-$version.tar.gz
+src_url=http://www.zlib.net/fossils/zlib-$version.tar.gz
+src_url_sha1=a4d316c404ff54ca545ea71a27af7dbc29817088
 
 pkg_install-include () {
     mkdir -p "$install_dir/include"


### PR DESCRIPTION
The archive was moved, the current URL is now a 404

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/