### PR TITLE
fix: keep multiple libs from catenating versions

### DIFF
--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -31,7 +31,7 @@ EOF
 
     ... () { command="$command $(for x in "$@"; do printf "%q " "$x"; done)"; }
 
-    GLIBC_VERSION=`rpm -qa --queryformat '%{VERSION}' glibc`
+    GLIBC_VERSION=`rpm -qa --queryformat '%{VERSION}\n' glibc | head -n1`
 
     command=fpm
     ... -t rpm                  # Build an RPM package


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
<Please fill in the description of your pull request here. Thank you for your contribution!>
From a slack conversation with "@atnnn"

tennis [1:34 PM] 
Hi Guys. I’ve compiled the rethink rpm package on CentOS 7.3 successfully (using this script: https://github.com/rethinkdb/rethinkdb/blob/next/scripts/build-rpm.sh).  Everything compiles fine.  But when I go to use the rpm to install on *exactly* the same machine, I get this error:
```--> Finished Dependency Resolution
Error: Package: rethinkdb-2.3.5_11_ga3b90f-29875.x86_64 (/rethinkdb)
           Requires: glibc >= 2.172.17
           Installed: glibc-2.17-157.el7_3.1.i686 (@updates)
               glibc = 2.17-157.el7_3.1
           Available: glibc-2.17-157.el7.i686 (base)
               glibc = 2.17-157.el7
```
Any ideas?

atnnn [2:19 PM] 
@tennis what is the result of `rpm -qa --queryformat '%{VERSION}' glibc`?

[2:19]  
@tennis Did you build an x86_64 rethinkdb for your i686 system?

tennis [2:21 PM] 
@atnnn  I Got it figured out.. There are multiple glibc libs on my machine (i.e. 32 *and* 64 bit).  So the output of `rpm -qa --queryformat '%{VERSION}\n' glibc` (note the `newline`) is:
```2.17
2.17
```

[2:21]  
Without the `\n`, the output is:
```2.172.17```

atnnn [2:22 PM] 
Oh, that's a sneaky bug.

tennis [2:23 PM] 
yup.  I have to confess I didn’t figure it out on my own. But either way, we know the problem now. I’m happy to issue a pull request against the rethinkdb repo.  Which branch should I request a pull into?

atnnn [2:25 PM] 
Either `v2.3.x` (future 2.3.6) or `next` (future 2.4)

tennis [2:26 PM] 
ok. Thanks