### PR TITLE
Metadata migration for RethinkDB 2.4

### DIFF
--- a/src/clustering/administration/persist/migrate/migrate_v2_3.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v2_3.cc
@@ -1,0 +1,44 @@
+// Copyright 2010-2017 RethinkDB, all rights reserved.
+#include "clustering/administration/persist/migrate/migrate_v2_3.hpp"
+
+#include "clustering/administration/metadata.hpp"
+#include "clustering/administration/persist/file_keys.hpp"
+#include "clustering/administration/persist/migrate/rewrite.hpp"
+#include "clustering/administration/persist/raft_storage_interface.hpp"
+#include "clustering/table_manager/table_metadata.hpp"
+
+// This will migrate all metadata from v2_3 to v2_4
+template <cluster_version_t W>
+void migrate_metadata_v2_3_to_v2_4(metadata_file_t::write_txn_t *txn,
+                                   signal_t *interruptor) {
+    // We simply need to rewrite the table metadata to update to the latest
+    // format.
+    rewrite_metadata_values<W>(mdprefix_table_active(), txn, interruptor);
+    rewrite_metadata_values<W>(mdprefix_table_inactive(), txn, interruptor);
+    rewrite_metadata_values<W>(mdprefix_table_raft_header(), txn, interruptor);
+    rewrite_metadata_values<W>(mdprefix_table_raft_snapshot(), txn, interruptor);
+    rewrite_metadata_values<W>(mdprefix_table_raft_log(), txn, interruptor);
+}
+
+
+
+// This will migrate all metadata from v2_3 to v2_4
+void migrate_metadata_v2_3_to_v2_4(cluster_version_t serialization_version,
+                                   metadata_file_t::write_txn_t *txn,
+                                   signal_t *interruptor) {
+    switch (serialization_version) {
+    case cluster_version_t::v2_3:
+        migrate_metadata_v2_3_to_v2_4<cluster_version_t::v2_3>(txn, interruptor);
+        break;
+    case cluster_version_t::v2_4_is_latest:
+        break;
+    case cluster_version_t::v1_14:
+    case cluster_version_t::v1_15:
+    case cluster_version_t::v1_16:
+    case cluster_version_t::v2_0:
+    case cluster_version_t::v2_1:
+    case cluster_version_t::v2_2:
+    default:
+        unreachable();
+    }
+}

--- a/src/clustering/administration/persist/migrate/migrate_v2_3.hpp
+++ b/src/clustering/administration/persist/migrate/migrate_v2_3.hpp
@@ -1,0 +1,15 @@
+// Copyright 2010-2016 RethinkDB, all rights reserved.
+#ifndef CLUSTERING_ADMINISTRATION_PERSIST_MIGRATE_MIGRATE_V2_3_HPP_
+#define CLUSTERING_ADMINISTRATION_PERSIST_MIGRATE_MIGRATE_V2_3_HPP_
+
+#include "clustering/administration/persist/file.hpp"
+#include "serializer/types.hpp"
+
+// These functions are used to migrate metadata from v2.3 to the v2.4 format
+
+// This will migrate all metadata from v2_3 to v2_4
+void migrate_metadata_v2_3_to_v2_4(cluster_version_t serialization_version,
+                                   metadata_file_t::write_txn_t *txn,
+                                   signal_t *interruptor);
+
+#endif /* CLUSTERING_ADMINISTRATION_PERSIST_MIGRATE_MIGRATE_V2_3_HPP_ */


### PR DESCRIPTION
- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

I signed it back in 2012 https://github.com/rethinkdb/rethinkdb/pull/57

### Description
This implements metadata migration from RethinkDB 2.3 metadata to version 2.4. It's fairly trivial: We just need to rewrite all metadata that contains `table_config_t`, since those have changed in 2.4. The deserialize method of `table_config_t` still supports reading the old format, so a simple rewrite suffices.

This fixes https://github.com/rethinkdb/rethinkdb/issues/6085 .


On a side note, I just fired up RethinkDB again for the first time in a few months to test this. And man, it's awesome! ReQL, the clustering, it's all a big joy to use. :) :(