### PR TITLE
Make set_file_size_at_least take the real extent size.

### DIFF
--- a/src/arch/io/disk.hpp
+++ b/src/arch/io/disk.hpp
@@ -71,7 +71,7 @@ public:
 
     int64_t get_file_size();
     void set_file_size(int64_t size);
-    void set_file_size_at_least(int64_t size);
+    void set_file_size_at_least(int64_t size, int64_t extent_size);
 
     void read_async(int64_t offset, size_t length, void *buf, file_account_t *account, linux_iocallback_t *cb);
     void write_async(int64_t offset, size_t length, const void *buf, file_account_t *account, linux_iocallback_t *cb,

--- a/src/arch/types.hpp
+++ b/src/arch/types.hpp
@@ -116,7 +116,7 @@ public:
     virtual ~file_t() { }
     virtual int64_t get_file_size() = 0;
     virtual void set_file_size(int64_t size) = 0;
-    virtual void set_file_size_at_least(int64_t size) = 0;
+    virtual void set_file_size_at_least(int64_t size, int64_t extent_size) = 0;
 
     virtual void read_async(int64_t offset, size_t length, void *buf,
                             file_account_t *account, linux_iocallback_t *cb) = 0;

--- a/src/serializer/log/extent_manager.cc
+++ b/src/serializer/log/extent_manager.cc
@@ -143,7 +143,7 @@ public:
             // the way it handles multi-threading.
             // So we calculate the *change* in file size and update it accordingly.
             const int64_t old_file_size = dbfile->get_file_size();
-            dbfile->set_file_size_at_least(extent + extent_size);
+            dbfile->set_file_size_at_least(extent + extent_size, extent_size);
             stats->pm_file_size_bytes += dbfile->get_file_size() - old_file_size;
         }
 

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -91,7 +91,8 @@ void metablock_manager_t<metablock_t>::create(file_t *dbfile, int64_t extent_siz
 
     std::vector<int64_t> metablock_offsets = initial_metablock_offsets(extent_size);
 
-    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE);
+    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE,
+                                   extent_size);
 
     /* Allocate a buffer for doing our writes */
     scoped_device_block_aligned_ptr_t<crc_metablock_t> buffer(METABLOCK_SIZE);
@@ -161,7 +162,8 @@ void metablock_manager_t<metablock_t>::co_start_existing(file_t *file, bool *mb_
 
     metablock_version_t latest_version = MB_BAD_VERSION;
 
-    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE);
+    dbfile->set_file_size_at_least(metablock_offsets[metablock_offsets.size() - 1] + METABLOCK_SIZE,
+                                   extent_manager->extent_size);
 
     // Reading metablocks by issuing one I/O request at a time is
     // slow. Read all of them in one batch, and check them later.

--- a/src/serializer/log/static_header.cc
+++ b/src/serializer/log/static_header.cc
@@ -37,7 +37,8 @@ void co_static_header_write(file_t *file, void *data, size_t data_size) {
     scoped_device_block_aligned_ptr_t<static_header_t> buffer(DEVICE_BLOCK_SIZE);
     rassert(sizeof(static_header_t) + data_size < DEVICE_BLOCK_SIZE);
 
-    file->set_file_size_at_least(DEVICE_BLOCK_SIZE);
+    // We don't know what the extent size is yet, and it doesn't really matter.
+    file->set_file_size_at_least(DEVICE_BLOCK_SIZE, DEFAULT_EXTENT_SIZE);
 
     memset(buffer.get(), 0, DEVICE_BLOCK_SIZE);
 

--- a/src/unittest/mock_file.cc
+++ b/src/unittest/mock_file.cc
@@ -23,7 +23,7 @@ void mock_file_t::set_file_size(int64_t size) {
     data_->resize(size, 0);
 }
 
-void mock_file_t::set_file_size_at_least(int64_t size) {
+void mock_file_t::set_file_size_at_least(int64_t size, UNUSED int64_t extent_size) {
     guarantee(0 <= size && static_cast<uint64_t>(size) <= SIZE_MAX);
     if (data_->size() < static_cast<uint64_t>(size)) {
         data_->resize(size, 0);

--- a/src/unittest/mock_file.hpp
+++ b/src/unittest/mock_file.hpp
@@ -22,7 +22,7 @@ public:
 
     int64_t get_file_size();
     void set_file_size(int64_t size);
-    void set_file_size_at_least(int64_t size);
+    void set_file_size_at_least(int64_t size, int64_t extent_size);
 
     void read_async(int64_t offset, size_t length, void *buf,
                     file_account_t *account, linux_iocallback_t *cb);


### PR DESCRIPTION
Instead of using DEFAULT_EXTENT_SIZE.  Note: All releases of RethinkDB
since 1.13 have had an extent size of 2.0 MB, with no option to
reconfigure.  (This is just a small code cleanup, don't read too much
into it.)
