### PR TITLE
Use cached dependencies in 2.3.x

### DIFF
--- a/mk/support/pkg/pkg.sh
+++ b/mk/support/pkg/pkg.sh
@@ -277,6 +277,12 @@ git_clone_tag () {
 
 # Download a file
 geturl () {
+    local cached=$external_dir/.cache/$(basename "$2")
+    if [[ -e "$cached" ]]; then
+        cp "$cached" "$2"
+	return
+    fi
+
     if [[ -n "${CURL:-}" ]]; then
         $CURL --silent -S --fail --location "$1" -o "$2"
     else


### PR DESCRIPTION
2.4.x and next store fetched tarballs in `external/.cache`. The CI server relies on this to avoid re-fetching dependencies and to isolate builds from the network.

This patch adds read-only support for the cache in 2.3.x

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/