### PR TITLE
Improve dirty check in gen-version

### DIFF
--- a/scripts/gen-version.sh
+++ b/scripts/gen-version.sh
@@ -75,8 +75,7 @@ git_gen_version () {
 }
 
 git_is_dirty () {
-    git update-index -q --refresh > /dev/null || true
-    [[ -n "$(git diff-index --name-only HEAD -- || true)" ]]
+    test -n "$(git status --porcelain)"
 }
 
 release_notes_version () {


### PR DESCRIPTION
The current check uses `update-index`, which doesn't work if `.git` is read-only

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/