### PR TITLE
jemalloc configure fails with missing --host option during cross compile

### DIFF
--- a/mk/support/pkg/jemalloc.sh
+++ b/mk/support/pkg/jemalloc.sh
@@ -7,10 +7,10 @@ src_url_sha1=450a2f0331cd4544140bb3be5d6e11cc82383cdf
 pkg_install () {
     configure_flags="--libdir=${install_dir}/lib"
     if [[ "$CROSS_COMPILING" = 1 ]]; then
-        configure_flags+="--host=$($CXX -dumpmachine)"
+        configure_flags+=" --host=$($CXX -dumpmachine)"
     fi
 
     pkg_copy_src_to_build
-    pkg_configure "${configure_flags:-}"
+    pkg_configure ${configure_flags:-}
     pkg_make install
 }


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This change adds a space between the --libdir and --host arguments and removes the surrounding quotes so that the jemalloc configure script will process both options correctly.

Prior to this change, when cross compiling the jemalloc package, there was no space between the --libdir and --host arguments to the configure script and they were surrounded in quotes (causing the jemalloc configure script to fail with missing --host option).
