### PR TITLE
Fix Node.js fetch address.

### DIFF
--- a/mk/support/pkg/node.sh
+++ b/mk/support/pkg/node.sh
@@ -1,5 +1,4 @@
 version=6.10.0
-major=${version%%.*}
 
-src_url=http://nodejs.org/dist/latest-v$major.x/node-v$version.tar.gz
+src_url=http://nodejs.org/dist/v$version/node-v$version.tar.gz
 src_url_sha1=3bb2629ed623f38b8c3011cf422333862d3653a3


### PR DESCRIPTION
The version of Node.js in the 'latest' directory changes over time.
Switch to using the version-specific directory.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
A new version of Node.js has been released and it has broken the link we were using. This change should fix that (and stop it happening again).