### PR TITLE
Fixes #6296 InvalidStateError after cancelling a RethinkDB operation.

### DIFF
--- a/drivers/python/rethinkdb/asyncio_net/net_asyncio.py
+++ b/drivers/python/rethinkdb/asyncio_net/net_asyncio.py
@@ -230,7 +230,8 @@ class ConnectionInstance(object):
             cursor._error(err_message)
 
         for query, future in iter(self._user_queries.values()):
-            future.set_exception(ReqlDriverError(err_message))
+            if not future.done():
+                future.set_exception(ReqlDriverError(err_message))
 
         self._user_queries = { }
         self._cursor_cache = { }


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

Fixes #6296.

If a Python coroutine is cancelled while it is suspended inside a RethinkDB query, the query
future is cancelled. When the connection is later closed, the `close()` method tries to set the
future result, which throws `InvalidStateError` because the future was already cancelled. This
commit adds a guard condition to avoid this.