### PR TITLE
Update gtest.sh

### DIFF
--- a/mk/support/pkg/gtest.sh
+++ b/mk/support/pkg/gtest.sh
@@ -1,5 +1,5 @@
 version=1.7.0
-src_url=https://googletest.googlecode.com/files/gtest-$version.zip
+src_url=https://github.com/google/googletest/archive/release-$version.zip
 src_url_sha1=f85f6d2481e2c6c4a18539e391aa4ea8ab0394af
 
 pkg_install () {


### PR DESCRIPTION
gtest repository seems to have moved to https://github.com/google/googletest/archive/release-1.8.0.zip

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
<Please fill in the description of your pull request here. Thank you for your contribution!>
