### PR TITLE
Fix metadata migration for non-v2_3->v2_4.

### DIFF
--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -355,6 +355,9 @@ metadata_file_t::metadata_file_t(
             logNTC("Migrating cluster metadata to v2.3");
             migrate_metadata_v2_1_to_v2_3(
                 metadata_version, &write_txn, &non_interruptor);
+
+            // The metadata is now serialized using the latest serialization version
+            metadata_version = cluster_version_t::LATEST_DISK;
         } // fallthrough intentional
         case cluster_version_t::v2_3: {
             if (sb_lock.has()) {
@@ -366,6 +369,9 @@ metadata_file_t::metadata_file_t(
             logNTC("Migrating cluster metadata to v2.4");
             migrate_metadata_v2_3_to_v2_4(
                 metadata_version, &write_txn, &non_interruptor);
+
+            // The metadata is now serialized using the latest serialization version
+            metadata_version = cluster_version_t::LATEST_DISK;
         } // fallthrough intentional
         case cluster_version_t::v2_4_is_latest:
             break; // Up-to-date, do nothing

--- a/src/clustering/administration/persist/migrate/migrate_v2_1.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v2_1.cc
@@ -76,10 +76,10 @@ void migrate_metadata_v2_1_to_v2_3(cluster_version_t serialization_version,
         migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_2>(txn, interruptor);
         break;
     case cluster_version_t::v2_3:
-        // This only really needs to migrate auth data, but this should be fine
         migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_3>(txn, interruptor);
         break;
     case cluster_version_t::v2_4_is_latest:
+        migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_4>(txn, interruptor);
         break;
     case cluster_version_t::v1_14:
     case cluster_version_t::v1_15:


### PR DESCRIPTION
Two bugs.

1. The v2_1->v2_3 auth metadata migration was getting passed over.
All that "serialization_version" means in the function
migrate_metadata_v2_1_to_v2_3 is what version the structs were last
serialized at -- what cluster_version_t W parameter was used.  Auth
metadata _still_ needs to get migrated.

2. Because the v2_2 case in metadata_file_t::metadata_file_t did not
set metadata_version to the value cluster_version_t::LATEST_DISK, the
subsequent call to migrate_metadata_v2_3_to_v2_4 would hit
unreachable() in migrate_metadata_v2_3_to_v2_4.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

This should also be cherry-picked into the v2.4.x branch and make it into v2.4.
