### PR TITLE
Add helper script for running clang-tidy

### DIFF
--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Runs clang-tidy on the c++ sources
+# Tested with LLVM 3.9.1
+#
+# How to use:
+#
+#  $ ./configure CXX=`pwd`/scripts/clang-tidy.sh
+#  $ make
+#
+# make must be called from the top level of the repo
+#
+# clang-tidy flags are prefixed with --tidy. For example, to
+# automatically fix some detected issues, pass `CXXFLAGS=--tidy-fix'
+#
+# List all possible checks:
+#
+#  clang-tidy --checks='*' --list-checks
+
+set -e
+
+checks=
+check () { checks="$checks,$1"; }
+
+check '*'
+check -clang-analyzer-alpha.'*'
+check -cppcoreguidelines-pro-type-reinterpret-cast
+check -cppcoreguidelines-pro-type-vararg
+check -modernize-use-bool-literals
+check -readability-else-after-return
+check -cppcoreguidelines-pro-bounds-'*'
+check -google-readability-todo
+
+clang_tidy_flags=
+cxx_flags=
+source=
+
+absdir () (
+    cd "$(dirname $1)"
+    pwd
+)
+
+src_dir=$(absdir $(dirname "$0"))/src
+
+for arg in "$@"; do
+    case "$arg" in
+	src/*.cc)
+	    case $(absdir $arg) in
+		 $src_dir/*) source="$arg"
+	    esac ;;
+	--tidy-*)
+	    clang_tidy_flags="$clang_tidy_flags $(printf "%q" "${arg#--tidy}")"
+	    continue ;;
+    esac
+    cxx_flags="$cxx_flags $(printf "%q" "$arg")"
+done
+
+extra_includes () {
+    set -- `clang++ '-###' -x c++ -c <(true) 2>&1 | tail -n 1`
+    while [ $# != 0 ]; do
+	case "$1" in
+	    *-isystem*) echo -n " -isystem" "$2"; shift ;;
+	    *-idirafter*) echo -n " -idirafter" "$2"; shift ;;
+	esac
+	shift
+    done
+}
+
+if [ "$source" != "" ]; then
+    eval clang-tidy -header-filter=$src_dir --checks="$checks" "$clang_tidy_flags" "$source" -- "$cxx_flags" "$(extra_includes)"
+else
+    eval "clang++ $cxx_flags"
+fi


### PR DESCRIPTION
`clang-tidy` can identify possible bugs and style issues in C++ code. This script makes it easy to run clang-tidy on the RethinkDB source code. It currently enables many style checks that we don't want, but some that could be useful.

```
$ ./configure CXX=`pwd`/scripts/clang-tidy.sh
$ make
/home/atnnn/code/rethinkdb/src/btree/keys.cc:194:9: warning: implicit cast 'const struct store_key_t *' -> bool [readability-implicit-bool-cast]
    if (k) {
        ^
          != nullptr
/home/atnnn/code/rethinkdb/src/btree/keys.cc:210:21: warning: statement should be inside braces [readability-braces-around-statements]
    if (a.unbounded) return false;
                    ^
/home/atnnn/code/rethinkdb/src/btree/keys.cc:229:14: warning: parameter 'a' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param]
    return !(a == b);
             ^
/home/atnnn/code/rethinkdb/src/btree/reql_specific.cc:419:5: warning: use auto when initializing with new to avoid duplicating the type name [modernize-use-auto]
    txn_t *txn = new txn_t(cache_conn, read_access_t::read);
    ^
/home/atnnn/code/rethinkdb/src/arch/runtime/thread_pool.cc:4:10: warning: inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno' instead [modernize-deprecated-headers]
#include <errno.h>
         ^
         <cerrno>
/home/atnnn/code/rethinkdb/src/arch/runtime/thread_pool.cc:457:1: warning: constructor does not initialize these fields: do_shutdown_mutex [cppcoreguidelines-pro-type-member-init]
linux_thread_t::linux_thread_t(linux_thread_pool_t *parent_pool, int thread_id)
^
...
```