### PR TITLE
Add missing shebang to admin/build.sh

### DIFF
--- a/admin/build.sh
+++ b/admin/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 watch=false


### PR DESCRIPTION
This should fix the `[[: not found` issue (https://github.com/rethinkdb/rethinkdb/issues/6358#issuecomment-300606330)