### PR TITLE
Support for packaging Ubuntu Zesty

### DIFF
--- a/mk/packaging.mk
+++ b/mk/packaging.mk
@@ -45,7 +45,7 @@ DIST_SUPPORT = $(foreach pkg, $(DIST_SUPPORT_PACKAGES), $(SUPPORT_SRC_DIR)/$(pkg
 DEB_BUILD_DEPENDS := libboost-dev, libssl-dev, curl, m4, debhelper
 DEB_BUILD_DEPENDS += , fakeroot, python, libncurses5-dev, libcurl4-openssl-dev, libssl-dev
 
-ifeq ($(UBUNTU_RELEASE),yakkety)
+ifneq ($(filter $(UBUNTU_RELEASE), yakkety zesty),)
   # RethinkDB fails to compile with GCC 6 (#5757)
   DEB_BUILD_DEPENDS += , g++-5
   DSC_CONFIGURE_DEFAULT += CXX=g++-5

--- a/mk/support/pkg/npm-pkg.inc
+++ b/mk/support/pkg/npm-pkg.inc
@@ -49,7 +49,7 @@ pkg_install () {
     mkdir -p "$install_dir/node_modules"
     local pkg
     pkg=$(niceabspath "$src_dir")
-    in_dir "$install_dir" npm --no-registry install "$pkg"
+    in_dir "$install_dir" npm install "$pkg"
 
     local bin_dir="$install_dir/node_modules/$full_npm_package/node_modules/.bin/"
     mkdir -p "$install_dir/bin"


### PR DESCRIPTION
* Removes `--no-registry` when invoking `npm` (backported from 2.4)
* Forces using GCC 5 on Zesty (like we already do on Yakkety)