### PR TITLE
Add v8_2-HandleScope-protected.patch for OS X/modern clang

### DIFF
--- a/mk/support/pkg/patch/v8_2-HandleScope-protected.patch
+++ b/mk/support/pkg/patch/v8_2-HandleScope-protected.patch
@@ -1,0 +1,11 @@
+diff -ruN --label original original ./include/v8.h
+--- original
++++ ./include/v8.h	2017-04-17 21:54:30.000000000 -0700
+@@ -854,6 +854,7 @@
+ 
+   // Local::New uses CreateHandle with an Isolate* parameter.
+   template<class F> friend class Local;
++  template<class F> friend class Handle;
+ 
+   // Object::GetInternalField and Context::GetEmbedderData use CreateHandle with
+   // a HeapObject* in their shortcuts.


### PR DESCRIPTION
Edit: Disregard... somehow it seems this patch is now unnecessary.

Clang now complains about accessing a protected member function.
Maybe it now does this before instantiating.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
