### PR TITLE
Bump version to 2_5 and other fixes.

### DIFF
--- a/src/arch/timer.hpp
+++ b/src/arch/timer.hpp
@@ -12,9 +12,10 @@ struct timer_callback_t {
     virtual ~timer_callback_t() { }
 };
 
-/* This timer class uses the underlying OS timer provider to get one-shot timing events. It then
- * manages a list of application timers based on that lower level interface. Everyone who needs a
- * timer should use this class (through the thread pool). */
+/* This timer class uses the underlying OS timer provider to get one-shot timing
+ * events. It then manages a list of application timers based on that lower level
+ * interface. Everyone who needs a timer should use this class (through the thread
+ * pool). */
 class timer_handler_t : private timer_provider_callback_t {
 public:
     explicit timer_handler_t(linux_event_queue_t *queue);
@@ -29,8 +30,8 @@ private:
     // The timer provider, a platform-dependent typedef for interfacing with the OS.
     timer_provider_t timer_provider;
 
-    // The expected time of the next on_oneshot call.  If the oneshot arrived earlier than this
-    // time, we pretend that it had arrived on time.
+    // The expected time of the next on_oneshot call.  If the oneshot arrived earlier
+    // than this time, we pretend that it had arrived on time.
     int64_t expected_oneshot_time_in_nanos;
 
     // A priority queue of timer tokens, ordered by the soonest.

--- a/src/btree/secondary_operations.cc
+++ b/src/btree/secondary_operations.cc
@@ -104,8 +104,12 @@ btree_sindex_block_magic_t<cluster_version_t::v2_3>::value
     = { { 's', 'i', 'n', 'k' } };
 template <>
 const block_magic_t
-btree_sindex_block_magic_t<cluster_version_t::v2_4_is_latest_disk>::value
+btree_sindex_block_magic_t<cluster_version_t::v2_4>::value
     = { { 's', 'i', 'n', 'l' } };
+template <>
+const block_magic_t
+btree_sindex_block_magic_t<cluster_version_t::v2_5_is_latest>::value
+    = { { 's', 'i', 'n', 'm' } };
 
 cluster_version_t sindex_block_version(const btree_sindex_block_t *data) {
     if (data->magic == v1_13_sindex_block_magic) {
@@ -136,8 +140,12 @@ cluster_version_t sindex_block_version(const btree_sindex_block_t *data) {
         return cluster_version_t::v2_3;
     } else if (data->magic
                == btree_sindex_block_magic_t<
-                   cluster_version_t::v2_4_is_latest_disk>::value) {
-        return cluster_version_t::v2_4_is_latest_disk;
+                   cluster_version_t::v2_4>::value) {
+        return cluster_version_t::v2_4;
+    } else if (data->magic
+               == btree_sindex_block_magic_t<
+                   cluster_version_t::v2_5_is_latest_disk>::value) {
+        return cluster_version_t::v2_5_is_latest_disk;
     } else {
         crash("Unexpected magic in btree_sindex_block_t.");
     }

--- a/src/buffer_cache/alt.hpp
+++ b/src/buffer_cache/alt.hpp
@@ -52,7 +52,7 @@ public:
     // cache account / priority thing is just one ghetto hack amidst a dozen other
     // throttling systems.  TODO: Come up with a consistent priority scheme,
     // i.e. define a "default" priority etc.  TODO: As soon as we can support it, we
-    // might consider supporting a mem_cap paremeter.
+    // might consider supporting a mem_cap parameter.
     cache_account_t create_cache_account(int priority);
 
 private:

--- a/src/buffer_cache/page.hpp
+++ b/src/buffer_cache/page.hpp
@@ -143,16 +143,16 @@ private:
     // This page_t's index into its eviction bag (managed by the page_cache_t -- one
     // of unevictable_pages_, etc).  Which bag we should be in:
     //
-    // if loader_ is non-null:  unevictable_pages_
-    // else if waiters_ is non-empty: unevictable_pages_
-    // else if buf_ is null: evicted_pages_ (and block_token_ is non-null)
-    // else if block_token_ is non-null: evictable_disk_backed_pages_
-    // else: evictable_unbacked_pages_ (buf_ is non-null, block_token_ is null)
+    // if loader_ is non-null:  unevictable_
+    // else if waiters_ is non-empty: unevictable_
+    // else if buf_ is null: evicted_ (and block_token_ is non-null)
+    // else if block_token_ is non-null: evictable_disk_backed_
+    // else: evictable_unbacked_ (buf_ is non-null, block_token_ is null)
     //
     // So, when loader_, waiters_, buf_, or block_token_ is touched, we might
     // need to change this page's eviction bag.
     //
-    // The logic above is implemented in page_cache_t::correct_eviction_category.
+    // The logic above is implemented in evicter_t::correct_eviction_category.
     backindex_bag_index_t eviction_index_;
 
     DISABLE_COPYING(page_t);
@@ -182,6 +182,7 @@ public:
     void init(page_t *page);
 
     page_t *get_page_for_read() const;
+    // Constructs a new page if there might be snapshot references.
     page_t *get_page_for_write(page_cache_t *page_cache,
                                cache_account_t *account);
 

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -26,6 +26,8 @@
 #include "repli_timestamp.hpp"
 #include "serializer/types.hpp"
 
+// HSI: unordered_map allocates too much, use a different hash table type.
+
 class alt_txn_throttler_t;
 class cache_balancer_t;
 class auto_drainer_t;

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -658,7 +658,7 @@ private:
     bool began_waiting_for_flush_;
     bool spawned_flush_;
 
-    enum mark_state_t {
+    enum mark_state_t : uint8_t {
         marked_not,
         marked_red,
         marked_blue,

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -27,7 +27,7 @@ ATTR_PACKED(struct metadata_disk_superblock_t {
 
 // Etymology: In version 1.13, the magic was 'RDmd', for "(R)ethink(D)B (m)eta(d)ata".
 // Every subsequent version, the last character has been incremented.
-static const block_magic_t metadata_sb_magic = { { 'R', 'D', 'm', 'l' } };
+static const block_magic_t metadata_sb_magic = { { 'R', 'D', 'm', 'm' } };
 
 void init_metadata_superblock(void *sb_void, size_t block_size) {
     memset(sb_void, 0, block_size);
@@ -57,14 +57,15 @@ cluster_version_t magic_to_version(block_magic_t magic) {
     case 'i': return cluster_version_t::v2_1;
     case 'j': return cluster_version_t::v2_2;
     case 'k': return cluster_version_t::v2_3;
-    case 'l': return cluster_version_t::v2_4_is_latest_disk;
+    case 'l': return cluster_version_t::v2_4;
+    case 'm': return cluster_version_t::v2_5_is_latest_disk;
     default:
         fail_due_to_user_error("You're trying to use an earlier version of RethinkDB "
             "to open a database created by a later version of RethinkDB.");
     }
     // This is here so you don't forget to add new versions above.
     // Please also update the value of metadata_sb_magic at the top of this file!
-    static_assert(cluster_version_t::LATEST_DISK == cluster_version_t::v2_4,
+    static_assert(cluster_version_t::LATEST_DISK == cluster_version_t::v2_5,
         "Please add new version to magic_to_version.");
 }
 
@@ -373,8 +374,10 @@ metadata_file_t::metadata_file_t(
             // The metadata is now serialized using the latest serialization version
             metadata_version = cluster_version_t::LATEST_DISK;
         } // fallthrough intentional
-        case cluster_version_t::v2_4_is_latest:
-            break; // Up-to-date, do nothing
+        case cluster_version_t::v2_4: {
+        } // fallthrough intentional
+        case cluster_version_t::v2_5_is_latest_disk:
+            break;  // up-to-date, do nothing
         default: unreachable();
         }
     }

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -57,7 +57,7 @@ cluster_version_t magic_to_version(block_magic_t magic) {
     case 'i': return cluster_version_t::v2_1;
     case 'j': return cluster_version_t::v2_2;
     case 'k': return cluster_version_t::v2_3;
-    case 'l': return cluster_version_t::v2_4;
+    case 'l': return cluster_version_t::v2_4_is_latest_disk;
     default:
         fail_due_to_user_error("You're trying to use an earlier version of RethinkDB "
             "to open a database created by a later version of RethinkDB.");

--- a/src/clustering/administration/persist/migrate/migrate_v1_16.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v1_16.cc
@@ -558,7 +558,8 @@ void migrate_cluster_metadata_to_v2_1(io_backender_t *io_backender,
                       case cluster_version_t::v2_1:
                       case cluster_version_t::v2_2:
                       case cluster_version_t::v2_3:
-                      case cluster_version_t::v2_4_is_latest:
+                      case cluster_version_t::v2_4:
+                      case cluster_version_t::v2_5_is_latest:
                       default:
                         unreachable();
                       }
@@ -578,7 +579,8 @@ void migrate_cluster_metadata_to_v2_1(io_backender_t *io_backender,
                       case cluster_version_t::v2_1:
                       case cluster_version_t::v2_2:
                       case cluster_version_t::v2_3:
-                      case cluster_version_t::v2_4_is_latest:
+                      case cluster_version_t::v2_4:
+                      case cluster_version_t::v2_5_is_latest:
                       default:
                         unreachable();
                       }
@@ -653,7 +655,8 @@ void migrate_auth_metadata_to_v2_1(io_backender_t *io_backender,
                       case cluster_version_t::v2_1:
                       case cluster_version_t::v2_2:
                       case cluster_version_t::v2_3:
-                      case cluster_version_t::v2_4_is_latest:
+                      case cluster_version_t::v2_4:
+                      case cluster_version_t::v2_5_is_latest:
                       default:
                           unreachable();
                       }
@@ -674,7 +677,8 @@ void migrate_auth_metadata_to_v2_1(io_backender_t *io_backender,
                       case cluster_version_t::v2_1:
                       case cluster_version_t::v2_2:
                       case cluster_version_t::v2_3:
-                      case cluster_version_t::v2_4_is_latest:
+                      case cluster_version_t::v2_4:
+                      case cluster_version_t::v2_5_is_latest:
                       default:
                           unreachable();
                       }

--- a/src/clustering/administration/persist/migrate/migrate_v2_1.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v2_1.cc
@@ -76,10 +76,11 @@ void migrate_metadata_v2_1_to_v2_3(cluster_version_t serialization_version,
         migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_2>(txn, interruptor);
         break;
     case cluster_version_t::v2_3:
-        migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_3>(txn, interruptor);
-        break;
-    case cluster_version_t::v2_4_is_latest:
-        migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_4>(txn, interruptor);
+    case cluster_version_t::v2_4:
+        unreachable();
+    case cluster_version_t::v2_5_is_latest_disk:
+        migrate_metadata_v2_1_to_v2_3<cluster_version_t::v2_5_is_latest_disk>(
+            txn, interruptor);
         break;
     case cluster_version_t::v1_14:
     case cluster_version_t::v1_15:

--- a/src/clustering/administration/persist/migrate/migrate_v2_3.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v2_3.cc
@@ -30,7 +30,7 @@ void migrate_metadata_v2_3_to_v2_4(cluster_version_t serialization_version,
     case cluster_version_t::v2_3:
         migrate_metadata_v2_3_to_v2_4<cluster_version_t::v2_3>(txn, interruptor);
         break;
-    case cluster_version_t::v2_4_is_latest:
+    case cluster_version_t::v2_5_is_latest:
         break;
     case cluster_version_t::v1_14:
     case cluster_version_t::v1_15:
@@ -38,6 +38,7 @@ void migrate_metadata_v2_3_to_v2_4(cluster_version_t serialization_version,
     case cluster_version_t::v2_0:
     case cluster_version_t::v2_1:
     case cluster_version_t::v2_2:
+    case cluster_version_t::v2_4:
     default:
         unreachable();
     }

--- a/src/clustering/administration/tables/table_metadata.cc
+++ b/src/clustering/administration/tables/table_metadata.cc
@@ -132,7 +132,10 @@ archive_result_t deserialize<cluster_version_t::v2_3>(
     return deserialize_table_config_pre_v2_4<cluster_version_t::v2_3>(s, tc);
 }
 
-template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(
+template archive_result_t deserialize<cluster_version_t::v2_4>(
+    read_stream_t *, table_config_t *);
+
+template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(
     read_stream_t *, table_config_t *);
 
 RDB_IMPL_EQUALITY_COMPARABLE_6(table_config_t,

--- a/src/containers/archive/versioned.hpp
+++ b/src/containers/archive/versioned.hpp
@@ -39,9 +39,8 @@ inline MUST_USE archive_result_t deserialize_cluster_version(
         obsolete_cb();
         crash("Outdated index handling did not crash or throw.");
     } else {
-        // This is the same rassert in `ARCHIVE_PRIM_MAKE_RANGED_SERIALIZABLE`.
         if (raw >= static_cast<int8_t>(cluster_version_t::v1_14)
-            && raw <= static_cast<int8_t>(cluster_version_t::v2_4_is_latest)) {
+            && raw <= static_cast<int8_t>(cluster_version_t::v2_5)) {
             *thing = static_cast<cluster_version_t>(raw);
         } else {
             throw archive_exc_t{"Unrecognized cluster serialization version."};
@@ -112,8 +111,10 @@ archive_result_t deserialize_for_version(cluster_version_t version,
         return deserialize<cluster_version_t::v2_2>(s, thing);
     case cluster_version_t::v2_3:
         return deserialize<cluster_version_t::v2_3>(s, thing);
-    case cluster_version_t::v2_4_is_latest:
-        return deserialize<cluster_version_t::v2_4_is_latest>(s, thing);
+    case cluster_version_t::v2_4:
+        return deserialize<cluster_version_t::v2_4>(s, thing);
+    case cluster_version_t::v2_5_is_latest:
+        return deserialize<cluster_version_t::v2_5_is_latest>(s, thing);
     default:
         unreachable("deserialize_for_version: unsupported cluster version");
     }
@@ -142,8 +143,10 @@ size_t serialized_size_for_version(cluster_version_t version,
         return serialized_size<cluster_version_t::v2_2>(thing);
     case cluster_version_t::v2_3:
         return serialized_size<cluster_version_t::v2_3>(thing);
-    case cluster_version_t::v2_4_is_latest:
-        return serialized_size<cluster_version_t::v2_4_is_latest>(thing);
+    case cluster_version_t::v2_4:
+        return serialized_size<cluster_version_t::v2_4>(thing);
+    case cluster_version_t::v2_5_is_latest:
+        return serialized_size<cluster_version_t::v2_5_is_latest>(thing);
     default:
         unreachable("serialize_size_for_version: unsupported version");
     }
@@ -197,7 +200,9 @@ size_t serialized_size_for_version(cluster_version_t version,
             read_stream_t *, typ *);                                             \
     template archive_result_t deserialize<cluster_version_t::v2_3>(              \
             read_stream_t *, typ *);                                             \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(    \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(              \
+            read_stream_t *, typ *);                                             \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(    \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v1_13(typ)        \
@@ -215,7 +220,9 @@ size_t serialized_size_for_version(cluster_version_t version,
             read_stream_t *, typ *);                                             \
     template archive_result_t deserialize<cluster_version_t::v2_3>(              \
             read_stream_t *, typ *);                                             \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(    \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(              \
+            read_stream_t *, typ *);                                             \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(    \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v1_16(typ)        \
@@ -229,7 +236,9 @@ size_t serialized_size_for_version(cluster_version_t version,
             read_stream_t *, typ *);                                             \
     template archive_result_t deserialize<cluster_version_t::v2_3>(              \
             read_stream_t *, typ *);                                             \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(    \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(              \
+            read_stream_t *, typ *);                                             \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(    \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v2_1(typ)         \
@@ -241,7 +250,9 @@ size_t serialized_size_for_version(cluster_version_t version,
             read_stream_t *, typ *);                                             \
     template archive_result_t deserialize<cluster_version_t::v2_3>(              \
             read_stream_t *, typ *);                                             \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(    \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(              \
+            read_stream_t *, typ *);                                             \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(    \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v2_2(typ)         \
@@ -251,7 +262,9 @@ size_t serialized_size_for_version(cluster_version_t version,
 #define INSTANTIATE_DESERIALIZE_SINCE_v2_3(typ)                                  \
     template archive_result_t deserialize<cluster_version_t::v2_3>(              \
             read_stream_t *, typ *);                                             \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(    \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(              \
+            read_stream_t *, typ *);                                             \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(    \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v2_3(typ)         \
@@ -259,7 +272,9 @@ size_t serialized_size_for_version(cluster_version_t version,
     INSTANTIATE_DESERIALIZE_SINCE_v2_3(typ)
 
 #define INSTANTIATE_DESERIALIZE_SINCE_v2_4(typ)                         \
-    template archive_result_t deserialize<cluster_version_t::v2_4_is_latest>( \
+    template archive_result_t deserialize<cluster_version_t::v2_4>(     \
+            read_stream_t *, typ *);                                    \
+    template archive_result_t deserialize<cluster_version_t::v2_5_is_latest>( \
             read_stream_t *, typ *)
 
 #define INSTANTIATE_SERIALIZABLE_SINCE_v2_4(typ)         \

--- a/src/containers/archive/versioned.hpp
+++ b/src/containers/archive/versioned.hpp
@@ -33,6 +33,7 @@ inline MUST_USE archive_result_t deserialize_cluster_version(
     *thing = cluster_version_t::LATEST_OVERALL;
     int8_t raw;
     archive_result_t res = deserialize<cluster_version_t::LATEST_OVERALL>(s, &raw);
+    if (bad(res)) { return res; }
     if (raw == static_cast<int8_t>(obsolete_cluster_version_t::v1_13)
         || raw == static_cast<int8_t>(obsolete_cluster_version_t::v1_13_2)) {
         obsolete_cb();
@@ -59,6 +60,7 @@ inline MUST_USE archive_result_t deserialize_reql_version(
     *thing = reql_version_t::LATEST;
     int8_t raw;
     archive_result_t res = deserialize_universal(s, &raw);
+    if (bad(res)) { return res; }
     if (raw < static_cast<int8_t>(reql_version_t::EARLIEST)) {
         guarantee(raw >= static_cast<int8_t>(obsolete_reql_version_t::EARLIEST)
                   && raw <= static_cast<int8_t>(obsolete_reql_version_t::LATEST));

--- a/src/containers/intrusive_priority_queue.hpp
+++ b/src/containers/intrusive_priority_queue.hpp
@@ -7,8 +7,7 @@
 
 #include "errors.hpp"
 
-// TODO: Make this type generally not be awful: Make intrusive_priority_queue_node_t not have
-// virtual functions, make it not use an O(n) vector.
+// TODO: For some reason I wanted this to not use an O(n) vector.
 
 template <class node_t>
 class intrusive_priority_queue_t;

--- a/src/rdb_protocol/btree.cc
+++ b/src/rdb_protocol/btree.cc
@@ -1653,7 +1653,8 @@ void deserialize_sindex_info(
     case cluster_version_t::v2_1:
     case cluster_version_t::v2_2:
     case cluster_version_t::v2_3:
-    case cluster_version_t::v2_4_is_latest:
+    case cluster_version_t::v2_4:
+    case cluster_version_t::v2_5_is_latest:
         success = deserialize_reql_version(
                 &read_stream,
                 &info_out->mapping_version_info.original_reql_version,
@@ -1690,7 +1691,8 @@ void deserialize_sindex_info(
     case cluster_version_t::v2_1: // fallthru
     case cluster_version_t::v2_2: // fallthru
     case cluster_version_t::v2_3: // fallthru
-    case cluster_version_t::v2_4_is_latest:
+    case cluster_version_t::v2_4: // fallthru
+    case cluster_version_t::v2_5_is_latest:
         success = deserialize_for_version(cluster_version, &read_stream, &info_out->geo);
         throw_if_bad_deserialization(success, "sindex description");
         break;

--- a/src/rdb_protocol/term_storage.cc
+++ b/src/rdb_protocol/term_storage.cc
@@ -610,5 +610,9 @@ void serialize_term_tree(write_message_t *wm, const raw_term_t &root_term) {
 
 template void serialize_term_tree<cluster_version_t::LATEST_OVERALL>(
         write_message_t *, const raw_term_t &);
+#ifndef CLUSTER_AND_DISK_VERSIONS_ARE_SAME
+template void serialize_term_tree<cluster_version_t::LATEST_DISK>(
+        write_message_t *, const raw_term_t &);
+#endif
 
 } // namespace ql

--- a/src/rdb_protocol/term_storage.cc
+++ b/src/rdb_protocol/term_storage.cc
@@ -546,7 +546,13 @@ MUST_USE archive_result_t deserialize_term_tree<cluster_version_t::v2_3>(
 }
 
 template <>
-MUST_USE archive_result_t deserialize_term_tree<cluster_version_t::v2_4_is_latest>(
+MUST_USE archive_result_t deserialize_term_tree<cluster_version_t::v2_4>(
+        read_stream_t *s, scoped_ptr_t<term_storage_t> *term_storage_out) {
+    return deserialize_term_tree<cluster_version_t::v2_2>(s, term_storage_out);
+}
+
+template <>
+MUST_USE archive_result_t deserialize_term_tree<cluster_version_t::v2_5_is_latest>(
         read_stream_t *s, scoped_ptr_t<term_storage_t> *term_storage_out) {
     return deserialize_term_tree<cluster_version_t::v2_2>(s, term_storage_out);
 }

--- a/src/rdb_protocol/var_types.cc
+++ b/src/rdb_protocol/var_types.cc
@@ -195,5 +195,7 @@ deserialize<cluster_version_t::v2_2>(read_stream_t *s, var_scope_t *);
 template archive_result_t
 deserialize<cluster_version_t::v2_3>(read_stream_t *s, var_scope_t *);
 template archive_result_t
-deserialize<cluster_version_t::v2_4_is_latest>(read_stream_t *s, var_scope_t *);
+deserialize<cluster_version_t::v2_4>(read_stream_t *s, var_scope_t *);
+template archive_result_t
+deserialize<cluster_version_t::v2_5_is_latest>(read_stream_t *s, var_scope_t *);
 }  // namespace ql

--- a/src/rdb_protocol/wire_func.cc
+++ b/src/rdb_protocol/wire_func.cc
@@ -237,9 +237,15 @@ archive_result_t deserialize<cluster_version_t::v2_3>(
 }
 
 template <>
-archive_result_t deserialize<cluster_version_t::v2_4_is_latest>(
+archive_result_t deserialize<cluster_version_t::v2_4>(
         read_stream_t *s, wire_func_t *wf) {
-    return deserialize_wire_func<cluster_version_t::v2_4_is_latest>(s, wf);
+    return deserialize_wire_func<cluster_version_t::v2_4>(s, wf);
+}
+
+template <>
+archive_result_t deserialize<cluster_version_t::v2_5_is_latest>(
+        read_stream_t *s, wire_func_t *wf) {
+    return deserialize_wire_func<cluster_version_t::v2_5_is_latest>(s, wf);
 }
 
 template <cluster_version_t W>

--- a/src/region/region_map.hpp
+++ b/src/region/region_map.hpp
@@ -267,7 +267,8 @@ void debug_print(printf_buffer_t *buf, const region_map_t<V> &map) {
 
 template<cluster_version_t W, class V>
 void serialize(write_message_t *wm, const region_map_t<V> &map) {
-    static_assert(W == cluster_version_t::v2_4_is_latest,
+    static_assert(W == cluster_version_t::LATEST_DISK
+                  || W == cluster_version_t::CLUSTER,
         "serialize() is only supported for the latest version");
     serialize<W>(wm, map.inner);
     serialize<W>(wm, map.hash_beg);
@@ -277,7 +278,8 @@ void serialize(write_message_t *wm, const region_map_t<V> &map) {
 template<cluster_version_t W, class V>
 MUST_USE archive_result_t deserialize(read_stream_t *s, region_map_t<V> *map) {
     switch (W) {
-        case cluster_version_t::v2_4_is_latest:
+        case cluster_version_t::v2_5_is_latest:
+        case cluster_version_t::v2_4:
         case cluster_version_t::v2_3:
         case cluster_version_t::v2_2:
         case cluster_version_t::v2_1: {

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -29,11 +29,11 @@
 #define MESSAGE_HANDLER_MAX_BATCH_SIZE           16
 
 // The cluster communication protocol version.
-static_assert(cluster_version_t::CLUSTER == cluster_version_t::v2_4_is_latest,
+static_assert(cluster_version_t::CLUSTER == cluster_version_t::v2_5_is_latest,
               "We need to update CLUSTER_VERSION_STRING when we add a new cluster "
               "version.");
 
-#define CLUSTER_VERSION_STRING "2.4.0"
+#define CLUSTER_VERSION_STRING "2.5.0"
 
 const std::string connectivity_cluster_t::cluster_proto_header("RethinkDB cluster\n");
 const std::string connectivity_cluster_t::cluster_version_string(CLUSTER_VERSION_STRING);

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -159,8 +159,9 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
         || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_1)
         || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_2)
         || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_3)
+        || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_4)
         || disk_format_version ==
-            static_cast<uint32_t>(cluster_version_t::v2_4_is_latest_disk);
+            static_cast<uint32_t>(cluster_version_t::v2_5_is_latest_disk);
 }
 
 

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -143,7 +143,9 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
     // cluster_version_t value and such changes have not happened, it is correct to
     // add the new cluster_version_t value to this list of recognized ones.
     if (disk_format_version
-        == static_cast<uint32_t>(obsolete_cluster_version_t::v1_13)) {
+        == static_cast<uint32_t>(obsolete_cluster_version_t::v1_13)
+     || disk_format_version
+        == static_cast<uint32_t>(obsolete_cluster_version_t::v1_13_2_is_latest)) {
         fail_due_to_user_error(
             "Data directory is from version 1.13 of RethinkDB, "
             "which is no longer supported.  "
@@ -158,7 +160,7 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
         || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_2)
         || disk_format_version == static_cast<uint32_t>(cluster_version_t::v2_3)
         || disk_format_version ==
-            static_cast<uint32_t>(cluster_version_t::v2_4_is_latest);
+            static_cast<uint32_t>(cluster_version_t::v2_4_is_latest_disk);
 }
 
 

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -44,7 +44,7 @@ enum class cluster_version_t {
     CLUSTER = LATEST_OVERALL,
 };
 
-// Uncomment this if cluster_version_t::LATEST_DISK != cluster_version_t::CLUSTER.
+// Uncomment this if cluster_version_t::LATEST_DISK == cluster_version_t::CLUSTER.
 // Comment it otherwise. This macro is used to avoid instantiating the same version
 // twice in the `INSTANTIATE_SERIALIZE_FOR_CLUSTER_AND_DISK` macro.
 #define CLUSTER_AND_DISK_VERSIONS_ARE_SAME

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -10,9 +10,8 @@ enum class obsolete_cluster_version_t {
     v1_13_2_is_latest = v1_13_2
 };
 enum class cluster_version_t {
-    // The versions are _currently_ contiguously numbered.  If this becomes untrue,
-    // be sure to carefully replace the ARCHIVE_PRIM_MAKE_RANGED_SERIALIZABLE line
-    // that implements serialization.
+    // Beware that adding/removing new values requires updates to the serialization
+    // function.
     v1_14 = 2,
     v1_15 = 3,
     v1_16 = 4,
@@ -21,23 +20,24 @@ enum class cluster_version_t {
     v2_2 = 7,
     v2_3 = 8,
     v2_4 = 9,
+    v2_5 = 10,
 
     // This is used in places where _something_ needs to change when a new cluster
     // version is created.  (Template instantiations, switches on version number,
     // etc.)
-    v2_4_is_latest = v2_4,
+    v2_5_is_latest = v2_5,
 
     // Like the *_is_latest version, but for code that's only concerned with disk
     // serialization. Must be changed whenever LATEST_DISK gets changed.
-    v2_4_is_latest_disk = v2_4,
+    v2_5_is_latest_disk = v2_5,
 
     // The latest version, max of CLUSTER and LATEST_DISK
-    LATEST_OVERALL = v2_4_is_latest,
+    LATEST_OVERALL = v2_5_is_latest,
 
     // The latest version for disk serialization can sometimes be different from the
     // version we use for cluster serialization.  This is also the latest version of
     // ReQL deterministic function behavior.
-    LATEST_DISK = v2_4,
+    LATEST_DISK = v2_5_is_latest_disk,
 
     // This exists as long as the clustering code only supports the use of one
     // version.  It uses cluster_version_t::CLUSTER wherever it uses this.
@@ -47,6 +47,7 @@ enum class cluster_version_t {
 // Uncomment this if cluster_version_t::LATEST_DISK == cluster_version_t::CLUSTER.
 // Comment it otherwise. This macro is used to avoid instantiating the same version
 // twice in the `INSTANTIATE_SERIALIZE_FOR_CLUSTER_AND_DISK` macro.
+
 #define CLUSTER_AND_DISK_VERSIONS_ARE_SAME
 
 #ifdef CLUSTER_AND_DISK_VERSIONS_ARE_SAME
@@ -67,8 +68,9 @@ static_assert(cluster_version_t::CLUSTER != cluster_version_t::LATEST_DISK,
 // metablock.
 //
 // At some point the set of cluster versions and disk versions that we support might
-// diverge.  It's likely that we'd support a larger window of serialization versions
-// in the on-disk format.
+// diverge.  It's likely that we'd support a larger window of serialization versions in
+// the on-disk format.  Or maybe, the cluster version marches forward, but as a
+// compatibility hack, the disk version remains the same.
 //
 // Also, note: it's possible that versions will not be linearly ordered: Suppose we
 // release v1.17 and then v1.18.  Perhaps v1.17 supports v1_16 and v1_17 and v1.18


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Bumps the cluster version to v2_5 and also contains some fixes, such as:

- Avoid quadratic growth in segmented_vector.
- Disallow obsolete disk format version 1.13.2.
- Check for bad deserialization of <stuff>
- Make a field mark_state_t use one byte
- Adjust some comments
