### PR TITLE
Make soft durability writes use a flush interval.

### DIFF
--- a/src/arch/timer.hpp
+++ b/src/arch/timer.hpp
@@ -2,13 +2,16 @@
 #ifndef ARCH_TIMER_HPP_
 #define ARCH_TIMER_HPP_
 
-#include "containers/intrusive_priority_queue.hpp"
 #include "arch/io/timer_provider.hpp"
+#include "containers/intrusive_priority_queue.hpp"
+#include "time.hpp"
 
 class timer_token_t;
 
 struct timer_callback_t {
-    virtual void on_timer() = 0;
+    // The same "ticks" value gets passed to multiple on_timer() callbacks, so it could
+    // become "old" if a callback is slow.
+    virtual void on_timer(ticks_t ticks) = 0;
     virtual ~timer_callback_t() { }
 };
 
@@ -21,7 +24,9 @@ public:
     explicit timer_handler_t(linux_event_queue_t *queue);
     ~timer_handler_t();
 
-    timer_token_t *add_timer_internal(int64_t ms, timer_callback_t *callback, bool once);
+    // If interval_ms is zero that means a non-repeating callback.
+    timer_token_t *add_timer_internal(ticks_t next_time, int64_t interval_ms,
+                                      timer_callback_t *callback);
     void cancel_timer(timer_token_t *timer);
 
 private:
@@ -45,6 +50,11 @@ private:
  * executed on the same thread that they were created on. Thus, non-thread-safe
  * (but coroutine-safe) concurrency primitives can be used where appropriate.
  */
+
+// Adds a repeating timer where the first ring starts at next_time (or immediately,
+// if that time was in the past).
+timer_token_t *add_timer2(ticks_t next_time, int64_t interval_ms,
+                          timer_callback_t *callback);
 timer_token_t *add_timer(int64_t ms, timer_callback_t *callback);
 timer_token_t *fire_timer_once(int64_t ms, timer_callback_t *callback);
 void cancel_timer(timer_token_t *timer);

--- a/src/arch/timing.hpp
+++ b/src/arch/timing.hpp
@@ -40,7 +40,7 @@ public:
     bool is_running() const;
 
 private:
-    void on_timer();
+    void on_timer(ticks_t ticks);
     timer_token_t *timer;
 };
 
@@ -62,8 +62,21 @@ public:
     repeating_timer_t(int64_t interval_ms, repeating_timer_callback_t *ringee);
     ~repeating_timer_t();
 
+    // Increases or decreases the interval.  The next ring of the timer will always be
+    // based on the minimum value of the timing interval held before that ring.
+    void change_interval(int64_t interval_ms);
+
+    // Makes next ring happen no later than delay_ms milliseconds from now (or slightly
+    // later).
+    void clamp_next_ring(int64_t delay_ms);
+
+    int64_t interval_ms() const { return interval; }
+
 private:
-    void on_timer();
+    void on_timer(ticks_t ticks);
+    int64_t interval;  // milliseconds
+    ticks_t last_ticks;
+    ticks_t expected_next_ticks;
     timer_token_t *timer;
     std::function<void()> ringee;
 

--- a/src/buffer_cache/cache_balancer.hpp
+++ b/src/buffer_cache/cache_balancer.hpp
@@ -138,8 +138,15 @@ private:
         explicit cache_data_t(alt::evicter_t *_evicter);
 
         alt::evicter_t *evicter;
+
         uint64_t new_size;
         uint64_t old_size;
+
+        // The three components of actual memory usage by the cache
+        uint64_t unevictable_size;
+        uint64_t evictable_disk_backed_size;
+        uint64_t evictable_unbacked_size;
+
         int64_t bytes_loaded;
         uint64_t access_count;
     };

--- a/src/buffer_cache/evicter.cc
+++ b/src/buffer_cache/evicter.cc
@@ -230,8 +230,9 @@ void evicter_t::evict_if_necessary() THROWS_NOTHING {
     evict_if_necessary_active_ = true;
     page_t *page;
     while (in_memory_size() > memory_limit_
-           && evictable_disk_backed_.remove_oldish(&page, access_time_counter_,
-                                                   page_cache_)) {
+           && eviction_bag_t::remove_oldish(
+                &evictable_disk_backed_, access_time_counter_,
+                page_cache_, &page)) {
         evicted_.add(page, page->hypothetical_memory_usage(page_cache_));
         page->evict_self(page_cache_);
         page_cache_->consider_evicting_current_page(page->block_id());

--- a/src/buffer_cache/evicter.hpp
+++ b/src/buffer_cache/evicter.hpp
@@ -10,6 +10,7 @@
 #include "concurrency/cache_line_padded.hpp"
 #include "concurrency/pubsub.hpp"
 #include "threading.hpp"
+#include "time.hpp"
 
 class cache_balancer_t;
 class alt_txn_throttler_t;
@@ -47,13 +48,36 @@ public:
                              bool read_ahead_ok);
 
     uint64_t next_access_time() {
-        guarantee(initialized_);
+        guarantee_initialized();
         return ++access_time_counter_;
     }
 
-    uint64_t memory_limit() const;
-    uint64_t access_count() const;
-    int64_t get_bytes_loaded() const;
+    uint64_t memory_limit() const {
+        guarantee_initialized();
+        return memory_limit_;
+    }
+    uint64_t access_count() const {
+        guarantee_initialized();
+        return access_count_counter_;
+    }
+    uint64_t unevictable_size() const {
+        guarantee_initialized();
+        return unevictable_.size();
+    }
+    uint64_t evictable_disk_backed_size() const {
+        guarantee_initialized();
+        return evictable_disk_backed_.size();
+    }
+    uint64_t evictable_unbacked_size() const {
+        guarantee_initialized();
+        return evictable_unbacked_.size();
+    }
+
+    int64_t get_bytes_loaded() const {
+        guarantee_initialized();
+        return bytes_loaded_counter_;
+    }
+
 
     uint64_t in_memory_size() const;
 
@@ -62,6 +86,11 @@ public:
     static const uint64_t INITIAL_ACCESS_TIME = UINT64_MAX - 100;
 
 private:
+    void guarantee_initialized() const {
+        assert_thread();
+        guarantee(initialized_);
+    }
+
     friend class usage_adjuster_t;
 
     // Tells the cache balancer about a page being loaded
@@ -97,6 +126,8 @@ private:
     eviction_bag_t evictable_disk_backed_;
     eviction_bag_t evictable_unbacked_;
     eviction_bag_t evicted_;
+
+    ticks_t last_force_flush_time_;
 
     auto_drainer_t drainer_;
 

--- a/src/buffer_cache/evicter.hpp
+++ b/src/buffer_cache/evicter.hpp
@@ -30,7 +30,6 @@ public:
     void move_unevictable_to_evictable(page_t *page);
     void change_to_correct_eviction_bag(eviction_bag_t *current_bag, page_t *page);
     eviction_bag_t *correct_eviction_category(page_t *page);
-    eviction_bag_t *unevictable_category() { return &unevictable_; }
     eviction_bag_t *evicted_category() { return &evicted_; }
     void remove_page(page_t *page);
     void reloading_page(page_t *page);

--- a/src/buffer_cache/eviction_bag.cc
+++ b/src/buffer_cache/eviction_bag.cc
@@ -38,8 +38,8 @@ bool eviction_bag_t::has_page(page_t *page) const {
     return bag_.has_element(page);
 }
 
-bool eviction_bag_t::remove_oldish(eviction_bag_t *eb, uint64_t access_time_offset,
-                                   page_cache_t *page_cache, page_t **page_out) {
+bool eviction_bag_t::select_oldish(eviction_bag_t *eb, uint64_t access_time_offset,
+                                   page_t **page_out) {
     if (eb->bag_.size() == 0) {
         return false;
     }
@@ -55,7 +55,6 @@ bool eviction_bag_t::remove_oldish(eviction_bag_t *eb, uint64_t access_time_offs
         }
     }
 
-    eb->remove(oldest, oldest->hypothetical_memory_usage(page_cache));
     *page_out = oldest;
     return true;
 }
@@ -71,9 +70,9 @@ T access_random2(const backindex_bag_t<T> &b1, const backindex_bag_t<T> &b2,
     }
 }
 
-bool eviction_bag_t::remove_oldish2(eviction_bag_t *eb1, eviction_bag_t *eb2,
+bool eviction_bag_t::select_oldish2(eviction_bag_t *eb1, eviction_bag_t *eb2,
                                     uint64_t access_time_offset,
-                                    page_cache_t *page_cache, page_t **page_out) {
+                                    page_t **page_out) {
     size_t total_size = eb1->bag_.size() + eb2->bag_.size();
     if (total_size == 0) {
         return false;
@@ -89,12 +88,7 @@ bool eviction_bag_t::remove_oldish2(eviction_bag_t *eb1, eviction_bag_t *eb2,
             oldest = page;
         }
     }
-    size_t oldest_mem_usage = oldest->hypothetical_memory_usage(page_cache);
-    if (eb1->bag_.has_element(oldest)) {
-        eb1->remove(oldest, oldest_mem_usage);
-    } else {
-        eb2->remove(oldest, oldest_mem_usage);
-    }
+
     *page_out = oldest;
     return true;
 }

--- a/src/buffer_cache/eviction_bag.hpp
+++ b/src/buffer_cache/eviction_bag.hpp
@@ -30,8 +30,13 @@ public:
 
     uint64_t size() const { return size_; }
 
-    bool remove_oldish(page_t **page_out, uint64_t access_time_offset,
-                       page_cache_t *page_cache);
+    static bool remove_oldish(
+        eviction_bag_t *eb, uint64_t access_time_offset,
+        page_cache_t *page_cache, page_t **page_out);
+
+    static bool remove_oldish2(
+        eviction_bag_t *eb1, eviction_bag_t *eb2, uint64_t access_time_offset,
+        page_cache_t *page_cache, page_t **page_out);
 
 private:
     backindex_bag_t<page_t *> bag_;

--- a/src/buffer_cache/eviction_bag.hpp
+++ b/src/buffer_cache/eviction_bag.hpp
@@ -30,13 +30,13 @@ public:
 
     uint64_t size() const { return size_; }
 
-    static bool remove_oldish(
+    static bool select_oldish(
         eviction_bag_t *eb, uint64_t access_time_offset,
-        page_cache_t *page_cache, page_t **page_out);
+        page_t **page_out);
 
-    static bool remove_oldish2(
+    static bool select_oldish2(
         eviction_bag_t *eb1, eviction_bag_t *eb2, uint64_t access_time_offset,
-        page_cache_t *page_cache, page_t **page_out);
+        page_t **page_out);
 
 private:
     backindex_bag_t<page_t *> bag_;

--- a/src/buffer_cache/page.cc
+++ b/src/buffer_cache/page.cc
@@ -607,14 +607,6 @@ page_acq_t::~page_acq_t() {
     }
 }
 
-bool page_acq_t::has() const {
-    return page_ != nullptr;
-}
-
-signal_t *page_acq_t::buf_ready_signal() {
-    return &buf_ready_signal_;
-}
-
 block_size_t page_acq_t::get_buf_size() {
     buf_ready_signal_.wait();
     return page_->get_page_buf_size();

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -1223,10 +1223,11 @@ struct ancillary_info_t {
     page_acq_t page_acq;
 };
 
-void page_cache_t::do_flush_changes(page_cache_t *page_cache,
-                                    std::unordered_map<block_id_t, block_change_t> &&changes,
-                                    const std::vector<page_txn_t *> &txns,
-                                    fifo_enforcer_write_token_t index_write_token) {
+void page_cache_t::do_flush_changes(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> &&changes,
+        const std::vector<page_txn_t *> &txns,
+        fifo_enforcer_write_token_t index_write_token) {
     rassert(!changes.empty());
     std::vector<block_token_tstamp_t> blocks_by_tokens;
     blocks_by_tokens.reserve(changes.size());
@@ -1418,9 +1419,10 @@ void page_cache_t::do_flush_changes(page_cache_t *page_cache,
     blocks_released_cond.wait();
 }
 
-void page_cache_t::do_flush_txn_set(page_cache_t *page_cache,
-                                    std::unordered_map<block_id_t, block_change_t> *changes_ptr,
-                                    const std::vector<page_txn_t *> &txns) {
+void page_cache_t::do_flush_txn_set(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> *changes_ptr,
+        const std::vector<page_txn_t *> &txns) {
     // This is called with spawn_now_dangerously!  The reason is partly so that we
     // don't put a zillion coroutines on the message loop when doing a bunch of
     // reads.  The other reason is that passing changes through a std::bind without

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -22,7 +22,7 @@ cache_conn_t::~cache_conn_t() {
     // need to tell the page_txn_t that we don't exist -- we do so by nullating its
     // cache_conn_ pointer (which it's capable of handling).
     if (newest_txn_ != nullptr) {
-        newest_txn_->cache_conn_ = nullptr;
+        newest_txn_->cache_conns_.remove(this);
         newest_txn_ = nullptr;
     }
 }
@@ -41,7 +41,9 @@ public:
 void throttler_acq_t::update_dirty_page_count(int64_t new_count) {
     rassert(
         block_changes_semaphore_acq_.count() == index_changes_semaphore_acq_.count());
-    if (new_count > block_changes_semaphore_acq_.count()) {
+    new_count = std::max<int64_t>(new_count, expected_change_count_);
+    if (pre_spawn_flush_ && new_count > block_changes_semaphore_acq_.count()
+        && !prevent_updates_) {
         block_changes_semaphore_acq_.change_count(new_count);
         index_changes_semaphore_acq_.change_count(new_count);
     }
@@ -49,6 +51,34 @@ void throttler_acq_t::update_dirty_page_count(int64_t new_count) {
 
 void throttler_acq_t::mark_dirty_pages_written() {
     block_changes_semaphore_acq_.change_count(0);
+}
+
+void throttler_acq_t::set_prevent_updates() {
+    prevent_updates_ = true;
+}
+
+
+void throttler_acq_t::merge(throttler_acq_t &&other) {
+    expected_change_count_ += other.expected_change_count_;
+    other.expected_change_count_ = 0;
+    // No need to worry about propagating pre_spawn_flush_.  (The two places we call
+    // this are for txn's that could belong in waiting_for_spawn_flush_, and txn's in
+    // compute_changes.)
+    rassert(pre_spawn_flush_ == other.pre_spawn_flush_);
+
+    // If a soft durability txn is flushing in combination with a hard durability txn, I
+    // guess we'll count its pages... if any more are acquired.
+    prevent_updates_ &= other.prevent_updates_;
+
+    if (!has_txn_throttler()) {
+        block_changes_semaphore_acq_ = std::move(other.block_changes_semaphore_acq_);
+        index_changes_semaphore_acq_ = std::move(other.index_changes_semaphore_acq_);
+    } else if (other.has_txn_throttler()) {
+        block_changes_semaphore_acq_.transfer_in(
+            std::move(other.block_changes_semaphore_acq_));
+        index_changes_semaphore_acq_.transfer_in(
+            std::move(other.index_changes_semaphore_acq_));
+    }
 }
 
 page_read_ahead_cb_t::page_read_ahead_cb_t(serializer_t *serializer,
@@ -119,6 +149,14 @@ void page_cache_t::consider_evicting_current_page(block_id_t block_id) {
         delete page_ptr;
     }
 }
+
+block_version_t page_cache_t::gen_block_version() {
+    block_version_t ret = next_block_version_;
+    next_block_version_ = next_block_version_.subsequent();
+    return ret;
+}
+
+
 
 void page_cache_t::add_read_ahead_buf(block_id_t block_id,
                                       scoped_device_block_aligned_ptr_t<ser_buffer_t> ptr,
@@ -206,6 +244,8 @@ page_cache_t::page_cache_t(serializer_t *_serializer,
                            alt_txn_throttler_t *throttler)
     : max_block_size_(_serializer->max_block_size()),
       serializer_(_serializer),
+      // Start the counter at 1 so we can distinguish empty values.
+      next_block_version_(block_version_t().subsequent()),
       free_list_(_serializer),
       evicter_(),
       read_ahead_cb_(nullptr),
@@ -244,6 +284,11 @@ page_cache_t::~page_cache_t() {
 
     have_read_ahead_cb_destroyed();
 
+    // Flush all pending soft-durability transactions.  All txn's must have had
+    // flush_and_destroy_txn called on them before we entered this destructor, so we
+    // know the entire set of txn's will be flushed.
+    begin_flush_pending_txns(true, ticks_t{0});
+
     drainer_.reset();
     size_t i = 0;
     for (auto &&page : current_pages_) {
@@ -267,79 +312,60 @@ page_cache_t::~page_cache_t() {
     }
 }
 
-// We go a bit old-school, with a self-destroying callback.
-class flush_and_destroy_txn_waiter_t : public signal_t::subscription_t {
-public:
-    flush_and_destroy_txn_waiter_t(auto_drainer_t::lock_t &&lock,
-                                   page_txn_t *txn,
-                                   std::function<void(throttler_acq_t *)> on_flush_complete)
-        : lock_(std::move(lock)),
-          txn_(txn),
-          on_flush_complete_(std::move(on_flush_complete)) { }
+void page_cache_t::begin_flush_pending_txns(bool asap, ticks_t soft_deadline) {
+    ASSERT_FINITE_CORO_WAITING;
+    std::vector<scoped_ptr_t<page_txn_t>> full_flush_set;
 
-private:
-    void run() {
-        // Tell everybody without delay that the flush is complete.
-        on_flush_complete_(&txn_->throttler_acq_);
-
-        // We have to do the rest _later_ because of signal_t::subscription_t not
-        // allowing reentrant signal_t::subscription_t::reset() calls, and the like,
-        // even though it would be valid.
-        // We are using `call_later_on_this_thread` instead of spawning a coroutine
-        // to reduce memory overhead.
-        class kill_later_t : public linux_thread_message_t {
-        public:
-            explicit kill_later_t(flush_and_destroy_txn_waiter_t *self) :
-                self_(self) { }
-            void on_thread_switch() {
-                self_->kill_ourselves();
-                delete this;
-            }
-        private:
-            flush_and_destroy_txn_waiter_t *self_;
-        };
-        call_later_on_this_thread(new kill_later_t(this));
+    if (!asap) {
+        for (page_txn_t *ptr = waiting_for_spawn_flush_.head(); ptr != nullptr;
+             ptr = waiting_for_spawn_flush_.next(ptr)) {
+            ptr->throttler_acq_.set_prevent_updates();
+        }
     }
 
-    void kill_ourselves() {
-        // We can't destroy txn_->flush_complete_cond_ until we've reset our
-        // subscription, because computers.
-        reset();
-        delete txn_;
-        delete this;
+    while (page_txn_t *ptr = waiting_for_spawn_flush_.head()) {
+        page_txn_t::propagate_pre_spawn_flush(ptr);
+        std::vector<scoped_ptr_t<page_txn_t>> flush_set
+            = page_cache_t::maximal_flushable_txn_set(ptr);
+        page_cache_t::remove_txn_set_from_graph(this, flush_set);
+        std::move(flush_set.begin(), flush_set.end(),
+                  std::back_inserter(full_flush_set));
     }
+    if (!full_flush_set.empty()) {
+        spawn_flush_flushables(std::move(full_flush_set), asap, soft_deadline);
+    }
+}
 
-    auto_drainer_t::lock_t lock_;
-    page_txn_t *txn_;
-    std::function<void(throttler_acq_t *)> on_flush_complete_;
-
-    DISABLE_COPYING(flush_and_destroy_txn_waiter_t);
-};
+void page_cache_t::soft_durability_interval_flush(ticks_t soft_deadline) {
+    // We only start a soft durability flush if one isn't already running.
+    if (num_active_asap_false_flushes_ == 0) {
+        begin_flush_pending_txns(false, soft_deadline);
+    }
+}
 
 void page_cache_t::flush_and_destroy_txn(
-        scoped_ptr_t<page_txn_t> txn,
-        std::function<void(throttler_acq_t *)> on_flush_complete) {
+        scoped_ptr_t<page_txn_t> &&txn,
+        write_durability_t durability,
+        page_txn_complete_cb_t *on_complete_or_null) {
     guarantee(txn->live_acqs_ == 0,
               "A current_page_acq_t lifespan exceeds its page_txn_t's.");
     guarantee(!txn->began_waiting_for_flush_);
 
-    txn->announce_waiting_for_flush();
+    rassert(txn->live_acqs_ == 0);
+    rassert(!txn->spawned_flush_);
 
-    page_txn_t *page_txn = txn.release();
-    flush_and_destroy_txn_waiter_t *sub
-        = new flush_and_destroy_txn_waiter_t(drainer_->lock(), page_txn,
-                                             std::move(on_flush_complete));
+    if (on_complete_or_null != nullptr) {
+        txn->flush_complete_waiters_.push_front(on_complete_or_null);
+    }
 
-    sub->reset(&page_txn->flush_complete_cond_);
+    begin_waiting_for_flush(std::move(txn), durability);
 }
 
 void page_cache_t::end_read_txn(scoped_ptr_t<page_txn_t> txn) {
-    guarantee(txn->touched_pages_.empty());
+    guarantee(txn->changes_.empty());
     guarantee(txn->live_acqs_ == 0,
         "A current_page_acq_t lifespan exceeds its page_txn_t's.");
     guarantee(!txn->began_waiting_for_flush_);
-
-    txn->flush_complete_cond_.pulse();
 }
 
 
@@ -354,7 +380,7 @@ current_page_t *page_cache_t::page_for_block_id(block_id_t block_id) {
                 "(should you have used alt_create_t::create?).",
                 block_id);
         page_it = current_pages_.insert(
-            page_it, std::make_pair(block_id, new current_page_t(block_id)));
+            page_it, std::make_pair(block_id, new current_page_t(block_id, this)));
     } else {
         rassert(!page_it->second->is_deleted());
     }
@@ -613,13 +639,53 @@ repli_timestamp_t current_page_acq_t::recency() {
     return page_cache_->recency_for_block_id(block_id_);
 }
 
+// Doesn't do everything -- caller will need to disconnect dirtier->pages_dirtied_last_.
+void page_cache_t::help_take_snapshotted_dirtied_page(
+        current_page_t *cp, block_id_t block_id, page_txn_t *dirtier) {
+    rassert(cp->last_dirtier_ == dirtier);
+    dirtier->add_snapshotted_dirtied_page(
+        block_id, cp->last_dirtier_version_,
+        cp->last_dirtier_recency_,
+        page_ptr_t(cp->the_page_for_read_or_deleted(current_page_help_t(block_id, this))));
+}
+
+void current_page_acq_t::dirty_the_page() {
+    dirtied_page_ = true;
+    page_txn_t *prec = current_page_->last_dirtier_;
+    if (prec != the_txn_) {
+
+        if (prec != nullptr) {
+            prec->pages_dirtied_last_.remove(current_page_dirtier_t{current_page_});
+            if (prec->throttler_acq_.pre_spawn_flush()) {
+                page_cache_->help_take_snapshotted_dirtied_page(
+                    current_page_, block_id_, prec);
+            } else {
+                // prec is already a preceder of the_txn_, transitively.  Now prec is a
+                // subseqer too, and we have to flush them at the same time.  This is
+                // fitting and proper because prec has no snapshot of its buf to flush.
+                prec->connect_preceder(the_txn_);
+            }
+        }
+        // We increase the_txn_'s dirty_page_count(), so we update its throttler_acq_
+        // first, before we update prec's (which may decrease back down).
+        the_txn_->pages_dirtied_last_.add(current_page_dirtier_t{current_page_});
+        the_txn_->throttler_acq_.update_dirty_page_count(the_txn_->dirtied_page_count());
+        if (prec != nullptr) {
+            prec->throttler_acq_.update_dirty_page_count(prec->dirtied_page_count());
+        }
+    }
+    current_page_->last_dirtier_ = the_txn_;
+    current_page_->last_dirtier_recency_ = page_cache_->recency_for_block_id(block_id_);
+    current_page_->last_dirtier_version_ = block_version_;
+}
+
 page_t *current_page_acq_t::current_page_for_write(cache_account_t *account) {
     assert_thread();
     rassert(access_ == access_t::write);
     rassert(current_page_ != nullptr);
     write_cond_.wait();
     rassert(current_page_ != nullptr);
-    dirtied_page_ = true;
+    dirty_the_page();
     return current_page_->the_page_for_write(help(), account);
 }
 
@@ -631,6 +697,9 @@ void current_page_acq_t::set_recency(repli_timestamp_t _recency) {
     rassert(current_page_ != nullptr);
     touched_page_ = true;
     page_cache_->set_recency_for_block_id(block_id_, _recency);
+    if (current_page_->last_dirtier_ == the_txn_) {
+        current_page_->last_dirtier_recency_ = _recency;
+    }
 }
 
 void current_page_acq_t::mark_deleted() {
@@ -639,8 +708,12 @@ void current_page_acq_t::mark_deleted() {
     rassert(current_page_ != nullptr);
     write_cond_.wait();
     rassert(current_page_ != nullptr);
-    dirtied_page_ = true;
+    dirty_the_page();
     current_page_->mark_deleted(help());
+    // HSI: This is gross and fragile that we need this knowledge here.
+    if (current_page_->last_dirtier_ == the_txn_) {
+        current_page_->last_dirtier_recency_ = repli_timestamp_t::invalid;
+    }
     // No need to call consider_evicting_current_page here -- there's a
     // current_page_acq_t for it: ourselves.
 }
@@ -653,17 +726,6 @@ bool current_page_acq_t::dirtied_page() const {
 bool current_page_acq_t::touched_page() const {
     assert_thread();
     return touched_page_;
-}
-
-block_version_t current_page_acq_t::block_version() const {
-    assert_thread();
-    return block_version_;
-}
-
-
-page_cache_t *current_page_acq_t::page_cache() const {
-    assert_thread();
-    return page_cache_;
 }
 
 current_page_help_t current_page_acq_t::help() const {
@@ -681,16 +743,13 @@ void current_page_acq_t::pulse_write_available() {
     write_cond_.pulse_if_not_already_pulsed();
 }
 
-current_page_t::current_page_t(block_id_t block_id)
+current_page_t::current_page_t(block_id_t block_id, page_cache_t *page_cache)
     : block_id_(block_id),
       is_deleted_(false),
       last_write_acquirer_(nullptr),
-      num_keepalives_(0) {
-    // Increment the block version so that we can distinguish between unassigned
-    // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
-    rassert(last_write_acquirer_version_.debug_value() == 0);
-    last_write_acquirer_version_ = last_write_acquirer_version_.subsequent();
-}
+      last_write_acquirer_version_(page_cache->gen_block_version()),
+      last_dirtier_(nullptr),
+      num_keepalives_(0) { }
 
 current_page_t::current_page_t(block_id_t block_id,
                                buf_ptr_t buf,
@@ -699,12 +758,9 @@ current_page_t::current_page_t(block_id_t block_id,
       page_(new page_t(block_id, std::move(buf), page_cache)),
       is_deleted_(false),
       last_write_acquirer_(nullptr),
-      num_keepalives_(0) {
-    // Increment the block version so that we can distinguish between unassigned
-    // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
-    rassert(last_write_acquirer_version_.debug_value() == 0);
-    last_write_acquirer_version_ = last_write_acquirer_version_.subsequent();
-}
+      last_write_acquirer_version_(page_cache->gen_block_version()),
+      last_dirtier_(nullptr),
+      num_keepalives_(0) { }
 
 current_page_t::current_page_t(block_id_t block_id,
                                buf_ptr_t buf,
@@ -714,12 +770,9 @@ current_page_t::current_page_t(block_id_t block_id,
       page_(new page_t(block_id, std::move(buf), token, page_cache)),
       is_deleted_(false),
       last_write_acquirer_(nullptr),
-      num_keepalives_(0) {
-    // Increment the block version so that we can distinguish between unassigned
-    // current_page_acq_t::block_version_ values (which are 0) and assigned ones.
-    rassert(last_write_acquirer_version_.debug_value() == 0);
-    last_write_acquirer_version_ = last_write_acquirer_version_.subsequent();
-}
+      last_write_acquirer_version_(page_cache->gen_block_version()),
+      last_dirtier_(nullptr),
+      num_keepalives_(0) { }
 
 current_page_t::~current_page_t() {
     // Check that reset() has been called.
@@ -739,6 +792,9 @@ void current_page_t::reset(page_cache_t *page_cache) {
     // newer in compute_changes.  current_page_t::should_be_evicted tests for this being
     // null.
     rassert(last_write_acquirer_ == nullptr);
+
+    // HSI: Should this be null, or might it need to snapshot the dirtied page?
+    rassert(last_dirtier_ == nullptr);
 
     page_.reset_page_ptr(page_cache);
     // No need to call consider_evicting_current_page here -- we're already getting
@@ -766,7 +822,12 @@ bool current_page_t::should_be_evicted() const {
         return false;
     }
 
-    // A reason: The current_page_t is kept alive for another reason.  (Important.)
+    // A reason: We have a last dirtier.
+    if (last_dirtier_ != nullptr) {
+        return false;
+    }
+
+    // A reason: The current_page_t has snapshotted ex-acquirers.  (Important.)
     if (num_keepalives_ > 0) {
         return false;
     }
@@ -791,7 +852,7 @@ void current_page_t::add_acquirer(current_page_acq_t *acq) {
     const block_version_t prev_version = last_write_acquirer_version_;
 
     if (acq->access_ == access_t::write) {
-        block_version_t v = prev_version.subsequent();
+        block_version_t v = acq->page_cache_->gen_block_version();
         acq->block_version_ = v;
 
         rassert(acq->the_txn_ != nullptr);
@@ -961,20 +1022,59 @@ page_t *current_page_t::the_page_for_write(current_page_help_t help,
 page_txn_t::page_txn_t(page_cache_t *_page_cache,
                        throttler_acq_t throttler_acq,
                        cache_conn_t *cache_conn)
-    : page_cache_(_page_cache),
-      cache_conn_(cache_conn),
+    : drainer_lock_(_page_cache->drainer_lock()),
+      page_cache_(_page_cache),
       throttler_acq_(std::move(throttler_acq)),
       live_acqs_(0),
+      dirty_changes_pages_(0),
       began_waiting_for_flush_(false),
       spawned_flush_(false),
-      mark_(marked_not) {
+      mark_(marked_not),
+      flush_complete_waiters_() {
     if (cache_conn != nullptr) {
         page_txn_t *old_newest_txn = cache_conn->newest_txn_;
         cache_conn->newest_txn_ = this;
         if (old_newest_txn != nullptr) {
-            rassert(old_newest_txn->cache_conn_ == cache_conn);
-            old_newest_txn->cache_conn_ = nullptr;
+            old_newest_txn->cache_conns_.remove(cache_conn);
+        }
+        cache_conns_.push_front(cache_conn);
+        if (old_newest_txn != nullptr) {
             connect_preceder(old_newest_txn);
+        }
+    }
+}
+
+bool page_txn_t::set_pre_spawn_flush() {
+    ASSERT_NO_CORO_WAITING;
+    if (throttler_acq_.pre_spawn_flush()) {
+        return false;
+    }
+    throttler_acq_.set_pre_spawn_flush(dirtied_page_count());
+    if (in_a_list()) {
+        rassert(began_waiting_for_flush_);
+        page_cache_->waiting_for_spawn_flush_.remove(this);
+        page_cache_->want_to_spawn_flush_.push_back(this);
+    } else {
+        rassert(!began_waiting_for_flush_);
+    }
+    return true;
+}
+
+void page_txn_t::propagate_pre_spawn_flush(page_txn_t *base) {
+    ASSERT_NO_CORO_WAITING;
+    if (!base->set_pre_spawn_flush()) {
+        return;
+    }
+    // All elements of stack have pre_spawn_flush_ freshly set.  (Thus, we never push a
+    // page_txn_t onto this stack more than once.)
+    std::vector<page_txn_t *> stack = {base};
+    while (!stack.empty()) {
+        page_txn_t *txn = stack.back();
+        stack.pop_back();
+        for (page_txn_t *p : txn->preceders_) {
+            if (p->set_pre_spawn_flush()) {
+                stack.push_back(p);
+            }
         }
     }
 }
@@ -984,15 +1084,18 @@ void page_txn_t::connect_preceder(page_txn_t *preceder) {
     rassert(preceder->page_cache_ == page_cache_);
     // We can't add ourselves as a preceder, we have to avoid that.
     rassert(preceder != this);
-    // The flush_complete_cond_ is pulsed at the same time that this txn is removed
-    // entirely from the txn graph, so we can't be adding preceders after that point.
-    rassert(!preceder->flush_complete_cond_.is_pulsed());
+    // spawned_flush_ is set at the same time that this txn is removed entirely from the
+    // txn graph, so we can't be adding preceders after that point.
+    rassert(!preceder->spawned_flush_);
 
     // See "PERFORMANCE(preceders_)".
     if (std::find(preceders_.begin(), preceders_.end(), preceder)
         == preceders_.end()) {
         preceders_.push_back(preceder);
         preceder->subseqers_.push_back(this);
+        if (throttler_acq_.pre_spawn_flush()) {
+            page_txn_t::propagate_pre_spawn_flush(preceder);
+        }
     }
 }
 
@@ -1011,12 +1114,12 @@ void page_txn_t::remove_subseqer(page_txn_t *subseqer) {
 }
 
 page_txn_t::~page_txn_t() {
-    guarantee(flush_complete_cond_.is_pulsed());
+    guarantee(flush_complete_waiters_.empty());
 
     guarantee(preceders_.empty());
     guarantee(subseqers_.empty());
 
-    guarantee(snapshotted_dirtied_pages_.empty());
+    guarantee(changes_.empty());
 }
 
 void page_txn_t::add_acquirer(DEBUG_VAR current_page_acq_t *acq) {
@@ -1043,113 +1146,256 @@ void page_txn_t::remove_acquirer(current_page_acq_t *acq) {
         // We know we hold an exclusive lock.
         rassert(acq->write_cond_.is_pulsed());
 
-        // Declare readonly (so that we may declare acq snapshotted).
-        acq->declare_readonly();
-        acq->declare_snapshotted();
-
-        // Steal the snapshotted page_ptr_t.
-        timestamped_page_ptr_t local = std::move(acq->snapshotted_page_);
-        // It's okay to have two dirtied_page_t's or touched_page_t's for the
-        // same block id -- compute_changes handles this.
-        snapshotted_dirtied_pages_.push_back(dirtied_page_t(block_version,
-                                                            acq->block_id(),
-                                                            std::move(local)));
-        // If you keep writing and reacquiring the same page, though, the count
-        // might be off and you could excessively throttle new operations.
-
-        // LSI: We could reacquire the same block and update the dirty page count
-        // with a _correct_ value indicating that we're holding redundant dirty
-        // pages for the same block id.
-        throttler_acq_.update_dirty_page_count(snapshotted_dirtied_pages_.size());
     } else if (acq->touched_page()) {
-        // It's okay to have two dirtied_page_t's or touched_page_t's for the
-        // same block id -- compute_changes handles this.
-        touched_pages_.push_back(touched_page_t(block_version, acq->block_id(),
-                                                acq->recency()));
+        add_touched_page(acq->block_id(), block_version, acq->recency());
     }
 }
 
-void page_txn_t::announce_waiting_for_flush() {
-    rassert(live_acqs_ == 0);
-    rassert(!began_waiting_for_flush_);
-    rassert(!spawned_flush_);
-    began_waiting_for_flush_ = true;
-    page_cache_->im_waiting_for_flush(this);
+template <class T>
+void remove_unique(std::vector<T> *vec, T removee) {
+    auto it = std::find(vec->begin(), vec->end(), removee);
+    rassert(it != vec->end());
+    *it = std::move(vec->back());
+    vec->pop_back();
 }
 
-std::unordered_map<block_id_t, page_cache_t::block_change_t>
-page_cache_t::compute_changes(const std::vector<page_txn_t *> &txns) {
+// This removes replacee from *vec.  It adds replacement to *vec, unless replacement is
+// already present.  Returns true if replacement was not already present.  This can
+// reorder *vec however it wants to.
+template <class T>
+bool merge_replace(std::vector<T> *vec, T replacee, T replacement) {
+    // HSI: We could do this in one traversal.
+    auto it = std::find(vec->begin(), vec->end(), replacee);
+    rassert(it != vec->end());
+    auto jt = std::find(vec->begin(), vec->end(), replacement);
+    if (jt == vec->end()) {
+        *it = replacement;
+        return true;
+    } else {
+        *it = std::move(vec->back());
+        vec->pop_back();
+        return false;
+    }
+}
+
+void update_backindex_back_pointer(current_page_t *cp, page_txn_t *txn) {
+    cp->last_write_acquirer_ = txn;
+}
+
+void update_backindex_back_pointer(current_page_dirtier_t cp, page_txn_t *txn) {
+    cp.current_page->last_dirtier_ = txn;
+}
+
+template <class T, size_t N>
+void move_elements(page_txn_t *ptr,
+                   backindex_bag_t<T, N> *dest, backindex_bag_t<T, N> *src) {
+    rassert(dest != src);
+    while (!src->empty()) {
+        T elem = src->access_random(0);
+        src->remove(elem);
+        dest->add(elem);
+        update_backindex_back_pointer(elem, ptr);
+    }
+}
+
+void page_txn_t::merge(scoped_ptr_t<page_txn_t> &&scoped_other) {
+    page_txn_t *other = scoped_other.get();
+
+    // Skip drainer lock -- nothing to merge there.
+
+    // Merge page cache?  No need.
+    rassert(page_cache_ == other->page_cache_);
+
+    // Merge cache conns.
+    while (cache_conn_t *conn = other->cache_conns_.head()) {
+        other->cache_conns_.pop_front();
+        rassert(conn->newest_txn_ == other);
+        conn->newest_txn_ = this;
+        cache_conns_.push_front(conn);
+    }
+
+    // Merge throttler acqs.
+    throttler_acq_.merge(std::move(other->throttler_acq_));
+
+    // HSI: Add back/forward indices to preceders_/subseqers_ instead.
+    for (page_txn_t *o_prec : other->preceders_) {
+        if (o_prec == this) {
+            remove_unique(&subseqers_, other);
+        } else {
+            if (merge_replace(&o_prec->subseqers_, other, this)) {
+                preceders_.push_back(o_prec);
+            }
+        }
+    }
+    other->preceders_.clear();
+
+    for (page_txn_t *o_subseq : other->subseqers_) {
+        if (o_subseq == this) {
+            remove_unique(&preceders_, other);
+        } else {
+            if (merge_replace(&o_subseq->preceders_, other, this)) {
+                subseqers_.push_back(o_subseq);
+            }
+        }
+    }
+    other->subseqers_.clear();
+
+    move_elements(this, &pages_write_acquired_last_,
+                  &other->pages_write_acquired_last_);
+    move_elements(this, &pages_dirtied_last_, &other->pages_dirtied_last_);
+
+    rassert(live_acqs_ == 0 && other->live_acqs_ == 0);
+    live_acqs_ += other->live_acqs_;
+    other->live_acqs_ = 0;
+
+    // net_dirty is 0 or -1.
+    int net_dirty = page_cache_t::merge_changes(
+        page_cache_, &changes_, std::move(other->changes_));
+
+    dirty_changes_pages_ += other->dirty_changes_pages_ + net_dirty;
+    other->dirty_changes_pages_ = 0;
+
+    // No need to worry about propagating began_waiting_for_flush_, spawned_flush_, or
+    // mark_.
+    rassert(began_waiting_for_flush_ && other->began_waiting_for_flush_);
+    rassert(!spawned_flush_ && !other->spawned_flush_);
+    rassert(mark_ == marked_not && other->mark_ == marked_not);
+
+    // Now the waiters wait on us...
+    flush_complete_waiters_.append_and_clear(&other->flush_complete_waiters_);
+
+    scoped_other.reset();
+
+    throttler_acq_.update_dirty_page_count(dirtied_page_count());
+}
+
+block_change_t make_block_change(block_version_t version,
+                                 repli_timestamp_t tstamp,
+                                 page_ptr_t &&ptr) {
+    return block_change_t(version, true, std::move(ptr), tstamp);
+}
+
+void page_txn_t::add_snapshotted_dirtied_page(
+        block_id_t block_id, block_version_t version,
+        repli_timestamp_t tstamp, page_ptr_t &&ptr) {
+    rassert(!ptr.has() || tstamp != repli_timestamp_t::invalid
+        || is_aux_block_id(block_id));
+
+    auto res = changes_.emplace(block_id, block_change_t());
+    auto const jt = res.first;
+    if (res.second) {
+        dirty_changes_pages_ += ptr.has();
+        jt->second = make_block_change(version, tstamp, std::move(ptr));
+    } else {
+        dirty_changes_pages_ += jt->second.merge(page_cache_,
+            make_block_change(version, tstamp, std::move(ptr)));
+    }
+}
+
+void page_txn_t::add_touched_page(
+        block_id_t block_id, block_version_t version, repli_timestamp_t tstamp) {
+    auto res = changes_.emplace(block_id, block_change_t(version, tstamp));
+    if (!res.second) {
+        auto jt = res.first;
+        rassert(jt->second.version != version);
+        if (jt->second.version < version) {
+            jt->second.version = version;
+            jt->second.tstamp = tstamp;
+        }
+    }
+}
+
+int block_change_t::merge(page_cache_t *page_cache, block_change_t &&other) {
+    rassert(version != other.version);
+    int old_pages_count = page.has() + other.page.has();
+    // This function is commutative -- changes from the later version supercede those of
+    // the earlier version.  (Both branches here do the same thing.)
+    if (version < other.version) {
+        if (other.modified) {
+            modified = true;
+            page.reset_page_ptr(page_cache);
+            page = std::move(other.page);
+        }
+        tstamp = other.tstamp;
+    } else {
+        // Move in other's page unless we supercede.
+        if (!modified) {
+            modified = other.modified;
+            page = std::move(other.page);
+        } else {
+            other.page.reset_page_ptr(page_cache);
+        }
+    }
+    return page.has() - old_pages_count;
+}
+
+int64_t page_cache_t::merge_changes(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> *onto,
+        std::unordered_map<block_id_t, block_change_t> &&from) {
+    int64_t total_net_dirty = 0;
+    for (auto &p : from) {
+        auto res = onto->emplace(p.first, block_change_t());
+        auto const jt = res.first;
+        if (res.second) {
+            jt->second = std::move(p.second);
+        } else {
+            total_net_dirty += jt->second.merge(page_cache, std::move(p.second));
+        }
+    }
+    from.clear();
+    return total_net_dirty;
+}
+
+page_cache_t::collapsed_txns_t
+page_cache_t::compute_changes(page_cache_t *page_cache,
+                              std::vector<scoped_ptr_t<page_txn_t>> &&txns) {
+    ASSERT_NO_CORO_WAITING;
     // We combine changes, using the block_version_t value to see which change
     // happened later.  This even works if a single transaction acquired the same
     // block twice.
 
-    // The map of changes we make.
-    std::unordered_map<block_id_t, block_change_t> changes;
+    rassert(!txns.empty());
 
-    for (auto it = txns.begin(); it != txns.end(); ++it) {
-        page_txn_t *txn = *it;
-        for (size_t i = 0, e = txn->snapshotted_dirtied_pages_.size(); i < e; ++i) {
-            const dirtied_page_t &d = txn->snapshotted_dirtied_pages_[i];
+    page_txn_t *first = txns.front().get();
 
-            block_change_t change(d.block_version, true,
-                                  d.ptr.has() ? d.ptr.get_page_for_read() : nullptr,
-                                  d.ptr.has() ? d.ptr.timestamp() : repli_timestamp_t::invalid);
+    collapsed_txns_t ret {
+        std::move(first->drainer_lock_),
+        std::move(first->throttler_acq_),
+        std::move(first->changes_),
+        std::move(first->flush_complete_waiters_)
+    };
 
-            auto res = changes.insert(std::make_pair(d.block_id, change));
+    // We merge out the throttler_acq's of the txn's.
+    int64_t dirty_changes_pages = first->dirty_changes_pages_;
 
-            if (!res.second) {
-                // The insertion failed -- we need to use the newer version.
-                auto const jt = res.first;
-                // The versions can't be the same for different write operations.
-                rassert(jt->second.version != change.version,
-                        "equal versions on block %" PRIi64 ": %" PRIu64,
-                        d.block_id,
-                        change.version.debug_value());
-                if (jt->second.version < change.version) {
-                    jt->second = change;
-                }
-            }
-        }
+    for (auto it = txns.begin() + 1; it != txns.end(); ++it) {
+        page_txn_t *txn = it->get();
+        ret.acq.merge(std::move(txn->throttler_acq_));
+
+        int64_t net_dirty = page_cache_t::merge_changes(
+            page_cache, &ret.changes, std::move(txn->changes_));
+        dirty_changes_pages += net_dirty;
+        ret.acq.update_dirty_page_count(dirty_changes_pages);
+        ret.flush_complete_waiters.append_and_clear(&txn->flush_complete_waiters_);
     }
 
-    for (auto it = txns.begin(); it != txns.end(); ++it) {
-        page_txn_t *txn = *it;
-        for (size_t i = 0, e = txn->touched_pages_.size(); i < e; ++i) {
-            const touched_page_t &t = txn->touched_pages_[i];
+    txns.clear();
 
-            auto res = changes.insert(std::make_pair(t.block_id,
-                                                     block_change_t(t.block_version,
-                                                                    false,
-                                                                    nullptr,
-                                                                    t.tstamp)));
-            if (!res.second) {
-                // The insertion failed.  We need to combine the versions.
-                auto const jt = res.first;
-                // The versions can't be the same for different write operations.
-                rassert(jt->second.version != t.block_version);
-                if (jt->second.version < t.block_version) {
-                    rassert(t.tstamp ==
-                            superceding_recency(jt->second.tstamp, t.tstamp));
-                    jt->second.tstamp = t.tstamp;
-                    jt->second.version = t.block_version;
-                }
-            }
-        }
-    }
-
-    return changes;
+    return ret;
 }
 
-void page_cache_t::remove_txn_set_from_graph(page_cache_t *page_cache,
-                                             const std::vector<page_txn_t *> &txns) {
+void page_cache_t::remove_txn_set_from_graph(
+        page_cache_t *page_cache,
+        const std::vector<scoped_ptr_t<page_txn_t>> &txns) {
+    // We want detaching the subseqers and preceders to happen at the same time
+    // spawned_flush_ is set.  That way connect_preceder can use it to check it's not
+    // called on an already disconnected part of the graph.
+    ASSERT_FINITE_CORO_WAITING;
     page_cache->assert_thread();
 
     for (auto it = txns.begin(); it != txns.end(); ++it) {
-        // We want detaching the subsequers and preceders to happen at the same time
-        // that the flush_complete_cond_ is pulsed.  That way connect_preceder can
-        // check if flush_complete_cond_ has been pulsed.
-        ASSERT_FINITE_CORO_WAITING;
-        page_txn_t *txn = *it;
+        page_txn_t *txn = it->get();
         {
             for (auto jt = txn->subseqers_.begin(); jt != txn->subseqers_.end(); ++jt) {
                 (*jt)->remove_preceder(txn);
@@ -1166,8 +1412,6 @@ void page_cache_t::remove_txn_set_from_graph(page_cache_t *page_cache,
         }
         txn->preceders_.clear();
 
-        // KSI: Maybe we could remove pages_write_acquired_last_ earlier?  Like when
-        // we begin the index write (but that's on the wrong thread) or earlier?
         while (txn->pages_write_acquired_last_.size() != 0) {
             current_page_t *current_page
                 = txn->pages_write_acquired_last_.access_random(0);
@@ -1189,13 +1433,37 @@ void page_cache_t::remove_txn_set_from_graph(page_cache_t *page_cache,
             page_cache->consider_evicting_current_page(current_page->block_id_);
         }
 
-        if (txn->cache_conn_ != nullptr) {
-            rassert(txn->cache_conn_->newest_txn_ == txn);
-            txn->cache_conn_->newest_txn_ = nullptr;
-            txn->cache_conn_ = nullptr;
+        while (txn->pages_dirtied_last_.size() != 0) {
+            current_page_dirtier_t dirtier
+                = txn->pages_dirtied_last_.access_random(0);
+
+            page_cache->help_take_snapshotted_dirtied_page(
+                dirtier.current_page, dirtier.current_page->block_id_, txn);
+
+            txn->pages_dirtied_last_.remove(dirtier);
+            dirtier.current_page->last_dirtier_ = nullptr;
+
+            page_cache->consider_evicting_current_page(dirtier.current_page->block_id_);
         }
 
-        txn->flush_complete_cond_.pulse();
+        while (!txn->cache_conns_.empty()) {
+            cache_conn_t *conn = txn->cache_conns_.head();
+            rassert(conn->newest_txn_ == txn);
+            txn->cache_conns_.remove(conn);
+            conn->newest_txn_ = nullptr;
+        }
+
+        // We only do this propagation to keep down the number of possible states a
+        // txn's variables can be in.  This way spawned_flush_ is true only if both
+        // began_waiting_for_flush_ and pre_spawn_flush_ are true.  It doesn't actually
+        // propagate anywhere, either, because we just disconnected the txn from the
+        // graph.
+        if (!txn->throttler_acq_.pre_spawn_flush()) {
+            page_txn_t::propagate_pre_spawn_flush(txn);
+        }
+        rassert(!txn->spawned_flush_);
+        txn->spawned_flush_ = true;
+        page_cache->want_to_spawn_flush_.remove(txn);
     }
 }
 
@@ -1223,134 +1491,268 @@ struct ancillary_info_t {
     page_acq_t page_acq;
 };
 
-void page_cache_t::do_flush_changes(
-        page_cache_t *page_cache,
-        std::unordered_map<block_id_t, block_change_t> &&changes,
-        const std::vector<page_txn_t *> &txns,
-        fifo_enforcer_write_token_t index_write_token) {
-    rassert(!changes.empty());
+struct flush_prep_t {
     std::vector<block_token_tstamp_t> blocks_by_tokens;
-    blocks_by_tokens.reserve(changes.size());
 
     // ancillary_infos holds a page_acq_t for any page we need to write, to prevent its
     // buf from getting freed out from under us (by a force-eviction operation, or
     // anything else).
     std::vector<ancillary_info_t> ancillary_infos;
     std::vector<buf_write_info_t> write_infos;
-    ancillary_infos.reserve(changes.size());
-    write_infos.reserve(changes.size());
 
-    {
-        ASSERT_NO_CORO_WAITING;
+    void reserve(size_t size) {
+        blocks_by_tokens.reserve(size);
+        ancillary_infos.reserve(size);
+        write_infos.reserve(size);
+    }
+};
 
-        for (auto it = changes.begin(); it != changes.end(); ++it) {
-            if (it->second.modified) {
-                if (it->second.page == nullptr) {
-                    // The block is deleted.
-                    blocks_by_tokens.push_back(block_token_tstamp_t(
-                        it->first,
-                        true,
-                        counted_t<block_token_t>(),
-                        repli_timestamp_t::invalid,
-                        nullptr));
-                } else {
-                    page_t *page = it->second.page;
-                    if (page->block_token().has()) {
-                        // It's already on disk, we're not going to flush it.
-                        blocks_by_tokens.push_back(block_token_tstamp_t(
-                            it->first,
-                            false,
-                            page->block_token(),
-                            it->second.tstamp,
-                            page));
-                    } else {
-                        // We can't be in the process of loading a block we're going
-                        // to write for which we don't have a block token.  That's
-                        // because we _actually dirtied the page_.  We had to have
-                        // acquired the buf, and the only way to get rid of the buf
-                        // is for it to be evicted, in which case the block token
-                        // would be non-empty.
+flush_prep_t page_cache_t::prep_flush_changes(
+        page_cache_t *page_cache,
+        const std::unordered_map<block_id_t, block_change_t> &changes) {
+    ASSERT_NO_CORO_WAITING;
 
-                        rassert(page->is_loaded());
+    flush_prep_t prep;
+    prep.reserve(changes.size());
 
-                        write_infos.push_back(buf_write_info_t(
-                            page->get_loaded_ser_buffer(),
-                            page->get_page_buf_size(),
-                            it->first));
-                        ancillary_infos.push_back(ancillary_info_t(it->second.tstamp));
-                        // The account doesn't matter because the page is already
-                        // loaded.
-                        ancillary_infos.back().page_acq.init(
-                            page, page_cache, page_cache->default_reads_account());
-                    }
-                }
-            } else {
-                // We only touched the page.
-                blocks_by_tokens.push_back(block_token_tstamp_t(
+    for (auto it = changes.begin(); it != changes.end(); ++it) {
+        if (it->second.modified) {
+            if (!it->second.page.has()) {
+                // The block is deleted.
+                prep.blocks_by_tokens.emplace_back(
                     it->first,
-                    false,
+                    true,
                     counted_t<block_token_t>(),
-                    it->second.tstamp,
-                    nullptr));
+                    repli_timestamp_t::invalid,
+                    nullptr);
+            } else {
+                page_t *page = it->second.page.get_page_for_read();
+                if (page->block_token().has()) {
+                    // It's already on disk, we're not going to flush it.
+                    prep.blocks_by_tokens.emplace_back(
+                        it->first,
+                        false,
+                        page->block_token(),
+                        it->second.tstamp,
+                        page);
+                } else {
+                    // We can't be in the process of loading a block we're going
+                    // to write for which we don't have a block token.  That's
+                    // because we _actually dirtied the page_.  We had to have
+                    // acquired the buf, and the only way to get rid of the buf
+                    // is for it to be evicted, in which case the block token
+                    // would be non-empty.
+
+                    rassert(page->is_loaded());
+
+                    prep.write_infos.emplace_back(
+                        page->get_loaded_ser_buffer(),
+                        page->get_page_buf_size(),
+                        it->first);
+                    prep.ancillary_infos.emplace_back(it->second.tstamp);
+                    // The account doesn't matter because the page is already
+                    // loaded.
+                    prep.ancillary_infos.back().page_acq.init(
+                        page, page_cache, page_cache->default_reads_account());
+                }
             }
+        } else {
+            // We only touched the page.
+            prep.blocks_by_tokens.emplace_back(
+                it->first,
+                false,
+                counted_t<block_token_t>(),
+                it->second.tstamp,
+                nullptr);
         }
     }
 
-    cond_t blocks_released_cond;
-    {
-        on_thread_t th(page_cache->serializer_->home_thread());
+    return prep;
+}
 
-        struct : public iocallback_t, public cond_t {
-            void on_io_complete() {
-                pulse();
+template <class T>
+void vec_move_append(std::vector<T> *onto, std::vector<T> &&from) {
+    if (onto->empty()) {
+        *onto = std::move(from);
+    } else {
+        std::move(from.begin(), from.end(), std::back_inserter(*onto));
+    }
+}
+
+size_t decent_sized_write(const std::vector<buf_write_info_t> &write_infos, size_t pos) {
+    const size_t bound = 4 * MEGABYTE;
+    const size_t n = write_infos.size();
+    size_t acc = 0;
+    while (pos < n) {
+        size_t bs = write_infos[pos].block_size.ser_value();
+        if (bound - acc < bs) {
+            return pos;
+        } else {
+            acc += bs;
+            ++pos;
+        }
+    }
+    return pos;
+}
+
+struct iocallback_cond_t : public iocallback_t, public cond_t {
+    void on_io_complete() {
+        pulse();
+    }
+};
+
+std::vector<counted_t<block_token_t>> page_cache_t::do_write_blocks(
+        page_cache_t *page_cache,
+        const std::vector<buf_write_info_t> &write_infos,
+        state_timestamp_t our_write_number,
+        ticks_t soft_deadline) {
+
+    size_t pos = 0;
+
+    std::vector<counted_t<block_token_t> > tokens;
+
+    while (pos < write_infos.size() &&
+           our_write_number > page_cache->ser_thread_max_asap_write_token_timestamp_) {
+
+        ticks_t before = get_ticks();
+
+        size_t end_pos = decent_sized_write(write_infos, pos);
+
+        iocallback_cond_t blocks_written_cb;
+        std::vector<counted_t<block_token_t> > tmp
+            = page_cache->serializer_->block_writes(write_infos.data() + pos,
+                                                    end_pos - pos,
+                                                    /* disk account is overridden
+                                                     * by merger_serializer_t */
+                                                    DEFAULT_DISK_ACCOUNT,
+                                                    &blocks_written_cb);
+        vec_move_append(&tokens, std::move(tmp));
+        tokens.reserve(write_infos.size());
+        blocks_written_cb.wait();
+
+        ticks_t after = get_ticks();
+        ticks_t duration{after.nanos - before.nanos};
+
+        if (after.nanos < soft_deadline.nanos) {
+            /* Our naptime algo is kind of hacky.
+            (Assuming equal block sizes, because whatever.)
+            - Proportion written is (end_pos - pos) / (size - pos).
+            - We want this to equal (after + naptime - before) / (soft_deadline -
+            before).
+            So:
+
+            (end_pos - pos) / (size - pos) = (after + naptime - before) /
+                (soft_deadline - before)
+
+            (soft_deadline - before) * (end_pos - pos) / (size - pos)
+                 = (after + naptime - before)
+
+            (soft_deadline - before) * (end_pos - pos) / (size - pos) - (after - before)
+                 = naptime
+
+            The units match.
+            */
+
+            ticks_t wakeup_time{int64_t((soft_deadline.nanos - before.nanos) * (end_pos - pos) / (write_infos.size() - pos))};
+
+            if (wakeup_time.nanos > duration.nanos) {
+                int64_t naptime = wakeup_time.nanos - duration.nanos;
+                // But don't nap more than 7/8 of the time.  We'll finish our smear early.
+                naptime = std::min<int64_t>(naptime, duration.nanos * 7);
+
+                // This smearing logic is so bad.  Much nicer would be if we could
+                // update the priority of writes in-flight.  I don't know if anything is
+                // stopping that, it would take some engineering time.
+
+                nap(naptime / MILLION);
+            } else {
+                // We're not flushing fast enough to keep up with our smear interval.
+                // That's okay.
             }
-        } blocks_written_cb;
 
-        std::vector<counted_t<block_token_t>> tokens
-            = page_cache->serializer_->block_writes(write_infos,
+
+        }
+
+        pos = end_pos;
+    }
+
+    if (pos < write_infos.size()) {
+        iocallback_cond_t blocks_written_cb;
+        std::vector<counted_t<block_token_t> > tmp
+            = page_cache->serializer_->block_writes(write_infos.data() + pos,
+                                                    write_infos.size() - pos,
                                                     /* disk account is overridden
                                                      * by merger_serializer_t */
                                                     DEFAULT_DISK_ACCOUNT,
                                                     &blocks_written_cb);
 
-        rassert(tokens.size() == write_infos.size());
-        rassert(write_infos.size() == ancillary_infos.size());
-        for (size_t i = 0; i < write_infos.size(); ++i) {
-            blocks_by_tokens.push_back(block_token_tstamp_t(
-                write_infos[i].block_id,
+        vec_move_append(&tokens, std::move(tmp));
+        blocks_written_cb.wait();
+    }
+
+    // Note: There is some reason related to fixing issue 4545 (see efec93e092c1)
+    // why we don't just update pages' block tokens during writing, or after, and
+    // instead wait for index writes to be reflected below.
+    return tokens;
+}
+
+void page_cache_t::do_flush_changes(
+        page_cache_t *page_cache,
+        collapsed_txns_t *coltx,
+        fifo_enforcer_write_token_t index_write_token,
+        bool asap,
+        ticks_t soft_deadline) {
+    std::unordered_map<block_id_t, block_change_t> &changes = coltx->changes;
+    rassert(!changes.empty());
+    flush_prep_t prep = page_cache_t::prep_flush_changes(page_cache, changes);
+
+    cond_t blocks_released_cond;
+    {
+        on_thread_t th(page_cache->serializer_->home_thread());
+
+        if (asap) {
+            page_cache->ser_thread_max_asap_write_token_timestamp_
+                = index_write_token.timestamp;
+        }
+
+        std::vector<counted_t<block_token_t>> tokens
+            = page_cache_t::do_write_blocks(page_cache, prep.write_infos,
+                                            index_write_token.timestamp,
+                                            soft_deadline);
+
+        rassert(tokens.size() == prep.write_infos.size());
+        rassert(prep.write_infos.size() == prep.ancillary_infos.size());
+        for (size_t i = 0; i < prep.write_infos.size(); ++i) {
+            prep.blocks_by_tokens.emplace_back(
+                prep.write_infos[i].block_id,
                 false,
                 std::move(tokens[i]),
-                ancillary_infos[i].tstamp,
-                ancillary_infos[i].page_acq.page()));
+                prep.ancillary_infos[i].tstamp,
+                prep.ancillary_infos[i].page_acq.page());
         }
 
         // KSI: Unnecessary copying between blocks_by_tokens and write_ops, inelegant
         // representation of deletion/touched blocks in blocks_by_tokens.
         std::vector<index_write_op_t> write_ops;
-        write_ops.reserve(blocks_by_tokens.size());
+        write_ops.reserve(prep.blocks_by_tokens.size());
 
-        for (auto it = blocks_by_tokens.begin(); it != blocks_by_tokens.end();
+        for (auto it = prep.blocks_by_tokens.begin(); it != prep.blocks_by_tokens.end();
              ++it) {
             if (it->is_deleted) {
-                write_ops.push_back(index_write_op_t(
+                write_ops.emplace_back(
                     it->block_id,
                     make_optional(counted_t<block_token_t>()),
-                    make_optional(repli_timestamp_t::invalid)));
+                    make_optional(repli_timestamp_t::invalid));
             } else if (it->block_token.has()) {
-                write_ops.push_back(index_write_op_t(it->block_id,
-                                                     make_optional(it->block_token),
-                                                     make_optional(it->tstamp)));
+                write_ops.emplace_back(it->block_id,
+                                       make_optional(it->block_token),
+                                       make_optional(it->tstamp));
             } else {
-                write_ops.push_back(index_write_op_t(it->block_id,
-                                                     r_nullopt,
-                                                     make_optional(it->tstamp)));
+                write_ops.emplace_back(it->block_id,
+                                       r_nullopt,
+                                       make_optional(it->tstamp));
             }
         }
-
-        blocks_written_cb.wait();
-        // Note: There is some reason related to fixing issue 4545 (see efec93e092c1)
-        // why we don't just update pages' block tokens here, and instead wait for index
-        // writes to be reflected below.
 
         fifo_enforcer_sink_t::exit_write_t exiter(&page_cache->index_write_sink_->sink,
                                                   index_write_token);
@@ -1368,10 +1770,10 @@ void page_cache_t::do_flush_changes(
                 // until the index changes have been written to disk).
                 coro_t::spawn_on_thread([&]() {
                     // Update the block tokens of the written blocks
-                    for (auto &block : blocks_by_tokens) {
+                    for (auto &block : prep.blocks_by_tokens) {
                         if (block.block_token.has() && block.page != nullptr) {
                             // We know page is still a valid pointer because of the
-                            // page_ptr_t in snapshotted_dirtied_pages_.
+                            // page_ptr_t in changes.
 
                             // HSI: This assertion would fail if we try to force-evict
                             // the page simultaneously as this write.
@@ -1388,26 +1790,19 @@ void page_cache_t::do_flush_changes(
                         }
                     }
 
-                    // Clear `changes`, since we are going to evict the pages
-                    // that it has pointers to in the next step.
-                    changes.clear();
-
                     // Clear the page acqs before we reset their associated page ptr's
                     // below.
-                    ancillary_infos.clear();
+                    prep.ancillary_infos.clear();
 
-                    for (auto &txn : txns) {
-                        for (size_t i = 0, e = txn->snapshotted_dirtied_pages_.size();
-                             i < e;
-                             ++i) {
-                            txn->snapshotted_dirtied_pages_[i].ptr.reset_page_ptr(
-                                page_cache);
-                            page_cache->consider_evicting_current_page(
-                                txn->snapshotted_dirtied_pages_[i].block_id);
-                        }
-                        txn->snapshotted_dirtied_pages_.clear();
-                        txn->throttler_acq_.mark_dirty_pages_written();
+                    // Really this is what clears the changes -- the txn->changes_
+                    // should already be reset.
+                    for (auto &change_pair : changes) {
+                        change_pair.second.page.reset_page_ptr(page_cache);
+                        page_cache->consider_evicting_current_page(change_pair.first);
                     }
+                    changes.clear();
+                    coltx->acq.mark_dirty_pages_written();
+
                     blocks_released_cond.pulse();
                 }, page_cache->home_thread());
             }, write_ops);
@@ -1419,10 +1814,21 @@ void page_cache_t::do_flush_changes(
     blocks_released_cond.wait();
 }
 
+void page_cache_t::pulse_flush_complete(collapsed_txns_t &&coltx) {
+    for (page_txn_complete_cb_t *p = coltx.flush_complete_waiters.head();
+         p != nullptr; ) {
+        page_txn_complete_cb_t *tmp = p;
+            p = coltx.flush_complete_waiters.next(p);
+        coltx.flush_complete_waiters.remove(tmp);
+        tmp->cond.pulse();
+    }
+}
+
 void page_cache_t::do_flush_txn_set(
         page_cache_t *page_cache,
-        std::unordered_map<block_id_t, block_change_t> *changes_ptr,
-        const std::vector<page_txn_t *> &txns) {
+        collapsed_txns_t *coltx_ptr,
+        bool asap,
+        ticks_t soft_deadline) {
     // This is called with spawn_now_dangerously!  The reason is partly so that we
     // don't put a zillion coroutines on the message loop when doing a bunch of
     // reads.  The other reason is that passing changes through a std::bind without
@@ -1433,24 +1839,28 @@ void page_cache_t::do_flush_txn_set(
     // set of changes we're actually doing is, since any transaction may have touched
     // the same blocks.
 
-    std::unordered_map<block_id_t, block_change_t> changes = std::move(*changes_ptr);
-    rassert(!changes.empty());
+    collapsed_txns_t coltx = std::move(*coltx_ptr);
+
+    rassert(!coltx.changes.empty());
 
     fifo_enforcer_write_token_t index_write_token
         = page_cache->index_write_source_.enter_write();
 
+    page_cache->num_active_asap_false_flushes_ += (asap ? 0 : 1);
+
     // Okay, yield, thank you.
     coro_t::yield();
-    do_flush_changes(page_cache, std::move(changes), txns, index_write_token);
+
+    do_flush_changes(page_cache, &coltx, index_write_token, asap, soft_deadline);
+
+    page_cache->num_active_asap_false_flushes_ -= (asap ? 0 : 1);
 
     // Flush complete.
-
-    // KSI: Can't we remove_txn_set_from_graph before flushing?  It would make some
-    // data structures smaller.
-    page_cache_t::remove_txn_set_from_graph(page_cache, txns);
+    page_cache_t::pulse_flush_complete(std::move(coltx));
 }
 
-std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *base) {
+std::vector<scoped_ptr_t<page_txn_t>>
+page_cache_t::maximal_flushable_txn_set(page_txn_t *base) {
     // Returns all transactions that can presently be flushed, given the newest
     // transaction that has had began_waiting_for_flush_ set.  (We assume all
     // previous such sets of transactions had flushing begin on them.)
@@ -1482,15 +1892,17 @@ std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *ba
     // An element is marked blue iff it's in `blue`.
     std::vector<page_txn_t *> blue;
     // All elements marked red, green, or blue are in `colored` -- we unmark them and
-    // construct the return vector at the end of the function.
-    std::vector<page_txn_t *> colored;
+    // construct the return vector at the end of the function.  Those which aren't
+    // included in the return value are only "temporarily" owned by the scoped_ptr_t --
+    // they'll get .release()d.
+    std::vector<scoped_ptr_t<page_txn_t>> colored;
 
     rassert(!base->spawned_flush_);
     rassert(base->began_waiting_for_flush_);
     rassert(base->mark_ == page_txn_t::marked_not);
     base->mark_ = page_txn_t::marked_blue;
     blue.push_back(base);
-    colored.push_back(base);
+    colored.emplace_back(base);
 
     while (!blue.empty()) {
         page_txn_t *txn = blue.back();
@@ -1503,15 +1915,14 @@ std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *ba
         bool poisoned = false;
         for (auto it = txn->preceders_.begin(); it != txn->preceders_.end(); ++it) {
             page_txn_t *prec = *it;
-            if (prec->spawned_flush_) {
-                rassert(prec->mark_ == page_txn_t::marked_not);
-            } else if (!prec->began_waiting_for_flush_
-                       || prec->mark_ == page_txn_t::marked_red) {
+            rassert(!prec->spawned_flush_);
+            if (!prec->began_waiting_for_flush_
+                || prec->mark_ == page_txn_t::marked_red) {
                 poisoned = true;
             } else if (prec->mark_ == page_txn_t::marked_not) {
                 prec->mark_ = page_txn_t::marked_blue;
                 blue.push_back(prec);
-                colored.push_back(prec);
+                colored.emplace_back(prec);
             } else {
                 rassert(prec->mark_ == page_txn_t::marked_green
                         || prec->mark_ == page_txn_t::marked_blue);
@@ -1529,7 +1940,7 @@ std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *ba
                 if (!poisoned) {
                     subs->mark_ = page_txn_t::marked_blue;
                     blue.push_back(subs);
-                    colored.push_back(subs);
+                    colored.emplace_back(subs);
                 }
             } else if (subs->mark_ == page_txn_t::marked_green) {
                 if (poisoned) {
@@ -1550,9 +1961,11 @@ std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *ba
         page_txn_t::mark_state_t mark = (*jt)->mark_;
         (*jt)->mark_ = page_txn_t::marked_not;
         if (mark == page_txn_t::marked_green) {
-            *it++ = *jt++;
+            *it++ = std::move(*jt++);
         } else {
             rassert(mark == page_txn_t::marked_red);
+            // Release page_txn_t that we don't really own yet.
+            UNUSED page_txn_t *ignore = jt->release();
             ++jt;
         }
     }
@@ -1561,31 +1974,64 @@ std::vector<page_txn_t *> page_cache_t::maximal_flushable_txn_set(page_txn_t *ba
     return colored;
 }
 
-void page_cache_t::im_waiting_for_flush(page_txn_t *base) {
+void page_cache_t::spawn_flush_flushables(
+        std::vector<scoped_ptr_t<page_txn_t>> &&flush_set,
+        bool asap,
+        ticks_t soft_deadline) {
+    rassert(!flush_set.empty());
+    // The flush set's txn's are already disconnected from the graph.
+
+    collapsed_txns_t coltx
+        = page_cache_t::compute_changes(this, std::move(flush_set));
+
+    if (!coltx.changes.empty()) {
+        coro_t::spawn_now_dangerously(std::bind(&page_cache_t::do_flush_txn_set,
+                                                this,
+                                                &coltx,
+                                                asap,
+                                                soft_deadline));
+    } else {
+        // Flush complete.  do_flush_txn_set does this in the write case.
+        page_cache_t::pulse_flush_complete(std::move(coltx));
+    }
+}
+
+void page_cache_t::merge_into_waiting_for_spawn_flush(scoped_ptr_t<page_txn_t> &&base) {
+    if (waiting_for_spawn_flush_.empty()) {
+        waiting_for_spawn_flush_.push_back(base.release());
+        return;
+    }
+
+    page_txn_t *last = waiting_for_spawn_flush_.tail();
+    last->merge(std::move(base));
+}
+
+void page_cache_t::begin_waiting_for_flush(
+        scoped_ptr_t<page_txn_t> &&base, write_durability_t durability) {
     assert_thread();
-    rassert(base->began_waiting_for_flush_);
-    rassert(!base->spawned_flush_);
     ASSERT_FINITE_CORO_WAITING;
+    rassert(!base->began_waiting_for_flush_);
+    rassert(!base->spawned_flush_);
 
-    std::vector<page_txn_t *> flush_set
-        = page_cache_t::maximal_flushable_txn_set(base);
-    if (!flush_set.empty()) {
-        for (auto it = flush_set.begin(); it != flush_set.end(); ++it) {
-            rassert(!(*it)->spawned_flush_);
-            (*it)->spawned_flush_ = true;
-        }
+    // This is redundant because we pass the durability in the throttler_acq_
+    // constructor anyway.
+    if (durability == write_durability_t::HARD) {
+        page_txn_t::propagate_pre_spawn_flush(base.get());
+    }
 
-        std::unordered_map<block_id_t, block_change_t> changes
-            = page_cache_t::compute_changes(flush_set);
+    base->began_waiting_for_flush_ = true;
+    if (!base->throttler_acq_.pre_spawn_flush()) {
+        merge_into_waiting_for_spawn_flush(std::move(base));
+    } else {
+        page_txn_t *base_unscoped = base.release();
+        want_to_spawn_flush_.push_back(base_unscoped);
 
-        if (!changes.empty()) {
-            coro_t::spawn_now_dangerously(std::bind(&page_cache_t::do_flush_txn_set,
-                                                    this,
-                                                    &changes,
-                                                    flush_set));
-        } else {
-            // Flush complete.  do_flush_txn_set does this in the write case.
+        std::vector<scoped_ptr_t<page_txn_t>> flush_set
+            = page_cache_t::maximal_flushable_txn_set(base_unscoped);
+
+        if (!flush_set.empty()) {
             page_cache_t::remove_txn_set_from_graph(this, flush_set);
+            spawn_flush_flushables(std::move(flush_set), true, ticks_t{0} /* no soft deadline */);
         }
     }
 }

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -403,13 +403,15 @@ private:
     };
 
     friend class page_txn_t;
-    static void do_flush_changes(page_cache_t *page_cache,
-                                 std::unordered_map<block_id_t, block_change_t> &&changes,
-                                 const std::vector<page_txn_t *> &txns,
-                                 fifo_enforcer_write_token_t index_write_token);
-    static void do_flush_txn_set(page_cache_t *page_cache,
-                                 std::unordered_map<block_id_t, block_change_t> *changes_ptr,
-                                 const std::vector<page_txn_t *> &txns);
+    static void do_flush_changes(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> &&changes,
+        const std::vector<page_txn_t *> &txns,
+        fifo_enforcer_write_token_t index_write_token);
+    static void do_flush_txn_set(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> *changes_ptr,
+        const std::vector<page_txn_t *> &txns);
 
     static void remove_txn_set_from_graph(page_cache_t *page_cache,
                                           const std::vector<page_txn_t *> &txns);

--- a/src/buffer_cache/page_cache.hpp
+++ b/src/buffer_cache/page_cache.hpp
@@ -25,6 +25,7 @@
 #include "containers/segmented_vector.hpp"
 #include "repli_timestamp.hpp"
 #include "serializer/types.hpp"
+#include "time.hpp"
 
 // HSI: unordered_map allocates too much, use a different hash table type.
 
@@ -38,6 +39,8 @@ namespace alt {
 class current_page_acq_t;
 class page_cache_t;
 class page_txn_t;
+struct current_page_dirtier_t;
+struct flush_prep_t;
 
 enum class page_create_t { no, yes };
 
@@ -47,7 +50,14 @@ enum class alt_create_t { create };
 
 enum class block_type_t { normal, aux };
 
-class cache_conn_t {
+class page_txn_complete_cb_t
+        : public intrusive_list_node_t<page_txn_complete_cb_t> {
+public:
+    cond_t cond;
+};
+
+
+class cache_conn_t : public half_intrusive_list_node_t<cache_conn_t> {
 public:
     explicit cache_conn_t(cache_t *_cache)
         : cache_(_cache),
@@ -63,9 +73,7 @@ private:
     cache_t *cache_;
 
     // The most recent unflushed txn, or NULL.  This gets set back to NULL when
-    // newest_txn_ pulses its flush_complete_cond_.  It's a bidirectional pointer
-    // pair with the newest txn's cache_conn_ pointer -- either both point at each
-    // other or neither do.
+    // newest_txn_ finishes.  We're an element of its cache_conns_ list.
     alt::page_txn_t *newest_txn_;
 
     DISABLE_COPYING(cache_conn_t);
@@ -86,7 +94,7 @@ public:
                    const counted_t<block_token_t> &token,
                    page_cache_t *page_cache);
     // Constructs a page to be loaded from the serializer.
-    explicit current_page_t(block_id_t block_id);
+    current_page_t(block_id_t block_id, page_cache_t *page_cache);
 
     // You MUST call reset() before destructing a current_page_t!
     ~current_page_t();
@@ -129,6 +137,11 @@ private:
     friend class page_cache_t;
 
     friend backindex_bag_index_t *access_backindex(current_page_t *current_page);
+    friend backindex_bag_index_t *access_backindex(current_page_dirtier_t dirtier);
+    friend void update_backindex_back_pointer(current_page_t *cp, page_txn_t *txn);
+    friend void update_backindex_back_pointer(
+        current_page_dirtier_t cp, page_txn_t *txn);
+
 
     bool is_deleted() const { return is_deleted_; }
 
@@ -154,6 +167,16 @@ private:
     // The version of the page, that the last write acquirer had.
     block_version_t last_write_acquirer_version_;
 
+    page_txn_t *last_dirtier_;
+    backindex_bag_index_t last_dirtier_index_;
+
+    // The version and recency of the page, that the last dirtier had.  We merely set
+    // and read these values, the only thing it affects is compute_changes, later.
+    // Maybe we should replace last_dirtier_ with last_toucher_or_dirtier_.  Then we
+    // wouldn't need this recency field.
+    block_version_t last_dirtier_version_;
+    repli_timestamp_t last_dirtier_recency_;
+
     // Instead of storing the recency here, we store it page_cache_t::recencies_.
 
     // All list elements have current_page_ != NULL, snapshotted_page_ == NULL.
@@ -170,6 +193,15 @@ private:
 inline backindex_bag_index_t *access_backindex(current_page_t *current_page) {
     return &current_page->last_write_acquirer_index_;
 }
+
+// Distinguishes type for access_backindex overloading.
+struct current_page_dirtier_t {
+    current_page_t *current_page;
+};
+inline backindex_bag_index_t *access_backindex(current_page_dirtier_t dirtier) {
+    return &dirtier.current_page->last_dirtier_index_;
+}
+
 
 class current_page_acq_t : public intrusive_list_node_t<current_page_acq_t>,
                            public home_thread_mixin_debug_only_t {
@@ -204,18 +236,20 @@ public:
     page_t *current_page_for_write(cache_account_t *account);
     void set_recency(repli_timestamp_t recency);
 
-    // Returns current_page_for_read, except it guarantees that the page acq has
-    // already snapshotted the page and is not waiting for the page_t *.
-    page_t *snapshotted_page_ptr();
-
     block_id_t block_id() const { return block_id_; }
     access_t access() const { return access_; }
 
     void mark_deleted();
 
-    block_version_t block_version() const;
+    block_version_t block_version() const {
+        assert_thread();
+        return block_version_;
+    }
 
-    page_cache_t *page_cache() const;
+    page_cache_t *page_cache() const {
+        assert_thread();
+        return page_cache_;
+    }
 
 private:
     void init(page_txn_t *txn,
@@ -244,6 +278,8 @@ private:
 
     void pulse_read_available();
     void pulse_write_available();
+
+    void dirty_the_page();
 
     page_cache_t *page_cache_;
     page_txn_t *the_txn_;
@@ -295,13 +331,28 @@ private:
 
 class throttler_acq_t {
 public:
-    throttler_acq_t() { }
+    explicit throttler_acq_t(write_durability_t durability,
+                             int64_t expected_change_count)
+        : prevent_updates_(false),
+          expected_change_count_(expected_change_count),
+          pre_spawn_flush_(durability == write_durability_t::HARD) { }
     ~throttler_acq_t() { }
     throttler_acq_t(throttler_acq_t &&movee)
-        : block_changes_semaphore_acq_(std::move(movee.block_changes_semaphore_acq_)),
+        : prevent_updates_(movee.prevent_updates_),
+          expected_change_count_(movee.expected_change_count_),
+          pre_spawn_flush_(movee.pre_spawn_flush_),
+          block_changes_semaphore_acq_(std::move(movee.block_changes_semaphore_acq_)),
           index_changes_semaphore_acq_(std::move(movee.index_changes_semaphore_acq_)) {
+        movee.prevent_updates_ = false;
+        movee.pre_spawn_flush_ = false;
+        movee.expected_change_count_ = 0;
         movee.block_changes_semaphore_acq_.reset();
         movee.index_changes_semaphore_acq_.reset();
+    }
+
+    bool has_txn_throttler() const {
+        // Either semaphore would do.
+        return block_changes_semaphore_acq_.has_semaphore();
     }
 
     // See below:  this can update how much *_changes_semaphore_acq_ holds.
@@ -311,7 +362,38 @@ public:
     // as it is.
     void mark_dirty_pages_written();
 
+    void merge(throttler_acq_t &&other);
+
+    // This is set by other algorithms.
+    bool pre_spawn_flush() const { return pre_spawn_flush_; }
+
+    // sets pre_spawn_flush to true, updates the dirty page count.
+    void set_pre_spawn_flush(int64_t dirty_page_count) {
+        if (!pre_spawn_flush_) {
+            pre_spawn_flush_ = true;
+            if (has_txn_throttler()) {
+                update_dirty_page_count(dirty_page_count);
+            }
+        }
+    }
+
+    void set_prevent_updates();
+
 private:
+    // Prevents pages the semaphores from updating their dirty page count when true,
+    // despite update_dirty_page_count getting called.  (Allows
+    // mark_dirty_pages_written.)
+    bool prevent_updates_;
+
+    // The original expected_change_count value.  Once pre_spawn_flush_ is true and we
+    // start to block the semaphores, we jump up to this value.
+    int64_t expected_change_count_;
+
+    // True if we want to flush the txn's values ASAP.  (True for hard-durability txn's,
+    // true for soft-durability txn's that we've decided to flush.)
+    // We don't acquire anything on the semaphore until this is true.
+    bool pre_spawn_flush_;
+
     friend class ::alt_txn_throttler_t;
     // At first, the number of dirty pages is 0 and *_changes_semaphore_acq_.count() >=
     // dirtied_count_.  Once the number of dirty pages gets bigger than the original
@@ -325,6 +407,32 @@ private:
 
 class page_cache_index_write_sink_t;
 
+struct block_change_t {
+    block_change_t() = default;
+    block_change_t(block_version_t _version, repli_timestamp_t _tstamp)
+        : version(_version), modified(false), page(), tstamp(_tstamp) { }
+    block_change_t(block_version_t _version, bool _modified,
+                   page_ptr_t &&_page, repli_timestamp_t _tstamp)
+        : version(_version), modified(_modified), page(std::move(_page)),
+          tstamp(_tstamp) { }
+
+    // This function has a specific obligation to leave other in an arbitrary
+    // safe-to-destruct state.  (other's page must be reset.)  Returns the net
+    // difference in the number of dirty pages.  (Either 0 or -1.)
+    MUST_USE int merge(page_cache_t *page_cache, block_change_t &&other);
+
+    block_version_t version;
+
+    // True if the value of the block was modified (or the block was deleted), false
+    // if the block was only touched.
+    bool modified;
+    // If modified == true, the new value for the block, or empty if the block was
+    // deleted.
+    page_ptr_t page;
+    repli_timestamp_t tstamp;
+};
+
+
 class page_cache_t : public home_thread_mixin_t {
 public:
     page_cache_t(serializer_t *serializer,
@@ -332,11 +440,16 @@ public:
                  alt_txn_throttler_t *throttler);
     ~page_cache_t();
 
-    // Takes a txn to be flushed.  Calls on_flush_complete() (which resets the
-    // throttler_acq parameter) when done.
+    // Begins to flush pending txn's.
+    void begin_flush_pending_txns(bool asap, ticks_t soft_deadline /* 0 is okay */);
+    // Starts an official soft durability interval flush, if one isn't running already.
+    void soft_durability_interval_flush(ticks_t soft_deadline);
+
+    // Takes a txn to be flushed.  Pulses on_complete_or_null when done.
     void flush_and_destroy_txn(
-            scoped_ptr_t<page_txn_t> txn,
-            std::function<void(throttler_acq_t *)> on_flush_complete);
+            scoped_ptr_t<page_txn_t> &&txn,
+            write_durability_t durability,
+            page_txn_complete_cb_t *on_complete_or_null);
     // More efficient version of `flush_and_destroy_txn` for read transactions.
     void end_read_txn(scoped_ptr_t<page_txn_t> txn);
 
@@ -375,6 +488,9 @@ public:
     serializer_t *serializer() { return serializer_; }
 
 private:
+    void help_take_snapshotted_dirtied_page(
+        current_page_t *cp, block_id_t block_id, page_txn_t *dirtier);
+
     friend class page_read_ahead_cb_t;
     void add_read_ahead_buf(block_id_t block_id,
                             scoped_device_block_aligned_ptr_t<ser_buffer_t> ptr,
@@ -385,43 +501,58 @@ private:
 
     current_page_t *internal_page_for_new_chosen(block_id_t block_id);
 
-    // KSI: Maybe just have txn_t hold a single list of block_change_t objects.
-    struct block_change_t {
-        block_change_t(block_version_t _version, bool _modified,
-                       page_t *_page, repli_timestamp_t _tstamp)
-            : version(_version), modified(_modified), page(_page), tstamp(_tstamp) { }
-        block_version_t version;
-
-        // True if the value of the block was modified (or the block was deleted), false
-        // if the block was only touched.
-        bool modified;
-        // If modified == true, the new value for the block, or NULL if the block was
-        // deleted.  (The page_t's lifetime is kept by some page_txn_t's
-        // snapshotted_dirtied_pages_ field.)
-        page_t *page;
-        repli_timestamp_t tstamp;
+    struct collapsed_txns_t {
+        auto_drainer_t::lock_t drainer_lock;
+        throttler_acq_t acq;
+        std::unordered_map<block_id_t, block_change_t> changes;
+        intrusive_list_t<page_txn_complete_cb_t> flush_complete_waiters;
     };
 
     friend class page_txn_t;
+    static std::vector<counted_t<block_token_t>> do_write_blocks(
+        page_cache_t *page_cache,
+        const std::vector<buf_write_info_t> &write_infos,
+        state_timestamp_t our_write_number,
+        ticks_t soft_deadline /* 0 is okay */);
     static void do_flush_changes(
         page_cache_t *page_cache,
-        std::unordered_map<block_id_t, block_change_t> &&changes,
-        const std::vector<page_txn_t *> &txns,
-        fifo_enforcer_write_token_t index_write_token);
+        collapsed_txns_t *coltx,
+        fifo_enforcer_write_token_t index_write_token,
+        bool asap,
+        ticks_t soft_deadline /* 0 is okay */);
     static void do_flush_txn_set(
         page_cache_t *page_cache,
-        std::unordered_map<block_id_t, block_change_t> *changes_ptr,
-        const std::vector<page_txn_t *> &txns);
+        collapsed_txns_t *coltx_ptr,
+        bool asap,
+        ticks_t soft_deadline);
 
-    static void remove_txn_set_from_graph(page_cache_t *page_cache,
-                                          const std::vector<page_txn_t *> &txns);
+    static void remove_txn_set_from_graph(
+        page_cache_t *page_cache,
+        const std::vector<scoped_ptr_t<page_txn_t>> &txns);
 
-    static std::unordered_map<block_id_t, block_change_t>
-    compute_changes(const std::vector<page_txn_t *> &txns);
+    static void pulse_flush_complete(collapsed_txns_t &&txns);
 
-    static std::vector<page_txn_t *> maximal_flushable_txn_set(page_txn_t *base);
+    // We only pass the cache to reset the page ptr.
+    static collapsed_txns_t
+    compute_changes(page_cache_t *page_cache,
+                    std::vector<scoped_ptr_t<page_txn_t>> &&txns);
 
-    void im_waiting_for_flush(page_txn_t *txns);
+    static MUST_USE int64_t merge_changes(
+        page_cache_t *page_cache,
+        std::unordered_map<block_id_t, block_change_t> *onto,
+        std::unordered_map<block_id_t, block_change_t> &&from);
+
+    static std::vector<scoped_ptr_t<page_txn_t>>
+    maximal_flushable_txn_set(page_txn_t *base);
+
+    void begin_waiting_for_flush(scoped_ptr_t<page_txn_t> &&txn,
+                                 write_durability_t durability);
+
+    // "asap = true" says to flush immediately, a hard durability transaction (or
+    // otherwise high priority) is waiting.  flush_set must not be empty.
+    void spawn_flush_flushables(std::vector<scoped_ptr_t<page_txn_t>> &&flush_set,
+                                bool asap,
+                                ticks_t soft_deadline);
 
     friend class current_page_acq_t;
     repli_timestamp_t recency_for_block_id(block_id_t id) {
@@ -437,7 +568,7 @@ private:
     }
 
     void set_recency_for_block_id(block_id_t id, repli_timestamp_t recency) {
-        if(is_aux_block_id(id)) {
+        if (is_aux_block_id(id)) {
             guarantee(recency == repli_timestamp_t::invalid);
             return;
         }
@@ -453,6 +584,15 @@ private:
     static void consider_evicting_all_current_pages(page_cache_t *page_cache,
                                                     auto_drainer_t::lock_t lock);
 
+    // Returns next_block_version_ and increments it.
+    block_version_t gen_block_version();
+
+    void merge_into_waiting_for_spawn_flush(scoped_ptr_t<page_txn_t> &&base);
+
+    static flush_prep_t prep_flush_changes(
+        page_cache_t *page_cache,
+        const std::unordered_map<block_id_t, block_change_t> &changes);
+
     const max_block_size_t max_block_size_;
 
     // We use a separate I/O account for reads in each page cache.
@@ -465,12 +605,38 @@ private:
     // move to the serializer thread and get a bunch of blocks written.
     // index_write_sink's pointee's home thread is on the serializer.
     fifo_enforcer_source_t index_write_source_;
+    // (Has nothing to do with repli_timestamp_t.)  The fifo_enforcer_write_token_t of
+    // the most recently spawned "asap" write had this timestamp.  (If this is bigger
+    // than an ongoing write, the ongoing write becomes "asap" too.)
+    state_timestamp_t ser_thread_max_asap_write_token_timestamp_;
+    // Number of flushes started, not yet completed, that are asap=false.
+    bool num_active_asap_false_flushes_;
+
     scoped_ptr_t<page_cache_index_write_sink_t> index_write_sink_;
 
     serializer_t *serializer_;
     segmented_vector_t<repli_timestamp_t> recencies_;
 
     std::unordered_map<block_id_t, current_page_t *> current_pages_;
+
+    // An incrementing 64-bit counter used to generate block versions, with values 1, 2,
+    // 3, ...  This makes sure that block writes never get overwritten by previous block
+    // writes.  alt_snapshot_node_t's will still hold a current_page_acq_t though --
+    // this stops them from destroying and recreating a snapshot node, and getting
+    // multiple copies of the same page.
+    block_version_t next_block_version_;
+
+    // The difference between these two lists is that waiting_for_spawn_flush_ txn's
+    // might be capable of flushing.  want_to_spawn_flush_ txn's can't disconnect from
+    // the graph and flush just yet.
+
+    // Txns that have began_waiting_for_flush_ true, spawned_flush_ false,
+    // pre_spawn_flush_ false.  Right now this has 0 or 1 elements because we merge
+    // _all_ the page_txn's together.
+    intrusive_list_t<page_txn_t> waiting_for_spawn_flush_;
+    // Txns that have began_waiting_for_flush_ true, spawned_flush_ false,
+    // pre_spawn_flush_ true.
+    intrusive_list_t<page_txn_t> want_to_spawn_flush_;
 
     free_list_t free_list_;
 
@@ -487,50 +653,6 @@ private:
     scoped_ptr_t<auto_drainer_t> drainer_;
 
     DISABLE_COPYING(page_cache_t);
-};
-
-class dirtied_page_t {
-public:
-    dirtied_page_t()
-        : block_id(NULL_BLOCK_ID) { }
-    dirtied_page_t(block_version_t _block_version,
-                   block_id_t _block_id, timestamped_page_ptr_t &&_ptr)
-        : block_version(_block_version),
-          block_id(_block_id),
-          ptr(std::move(_ptr)) { }
-    dirtied_page_t(dirtied_page_t &&movee)
-        : block_version(movee.block_version),
-          block_id(movee.block_id),
-          ptr(std::move(movee.ptr)) { }
-    dirtied_page_t &operator=(dirtied_page_t &&movee) {
-        block_version = movee.block_version;
-        block_id = movee.block_id;
-        ptr = std::move(movee.ptr);
-        return *this;
-    }
-    // Our block version of the dirty page.
-    block_version_t block_version;
-    // The block id of the dirty page.
-    block_id_t block_id;
-    // The snapshotted dirty page value.  (If empty, the page was deleted.)
-    timestamped_page_ptr_t ptr;
-};
-
-class touched_page_t {
-public:
-    touched_page_t()
-        : block_id(NULL_BLOCK_ID),
-          tstamp(repli_timestamp_t::invalid) { }
-    touched_page_t(block_version_t _block_version,
-                   block_id_t _block_id,
-                   repli_timestamp_t _tstamp)
-        : block_version(_block_version),
-          block_id(_block_id),
-          tstamp(_tstamp) { }
-
-    block_version_t block_version;
-    block_id_t block_id;
-    repli_timestamp_t tstamp;
 };
 
 // page_txn_t's exist for the purpose of writing to disk.  The rules are as follows:
@@ -556,8 +678,8 @@ public:
 // Right now, situation '(a)' doesn't happen because transactions do greedily keep
 // their copies of the block.
 //
-// LSI: Make situation '(a)' happenable.
-class page_txn_t {
+// HSI: Check this comment.
+class page_txn_t : public intrusive_list_node_t<page_txn_t> {
 public:
     // Our transaction has to get committed to disk _after_ or at the same time as
     // preceding transactions on cache_conn, if that parameter is not NULL.  (The
@@ -575,9 +697,6 @@ public:
 private:
     // To set cache_conn_ to NULL.
     friend class ::cache_conn_t;
-
-    // To access throttler_acq_.
-    friend class flush_and_destroy_txn_waiter_t;
 
     // page cache has access to all of this type's innards, including fields.
     friend class page_cache_t;
@@ -599,11 +718,33 @@ private:
     void add_acquirer(current_page_acq_t *acq);
     void remove_acquirer(current_page_acq_t *acq);
 
-    void announce_waiting_for_flush();
+    // Sets base->pre_spawn_flush_ to true, and propagates to preceders.
+    static void propagate_pre_spawn_flush(page_txn_t *base);
+
+    size_t dirtied_page_count() const {
+        return pages_dirtied_last_.size() + dirty_changes_pages_;
+    }
+
+    // Sets pre_spawn_flush to be true, if not already set.  handles presence in
+    // waiting_for_spawn_flush_/want_to_spawn_flush_.  Returns false if pre_spawn_flush
+    // was already set, in which case there was no side effect.
+    bool set_pre_spawn_flush();
+
+    // If ptr is empty, that means the block was deleted.
+    void add_snapshotted_dirtied_page(
+        block_id_t block_id, block_version_t version, repli_timestamp_t tstamp,
+        page_ptr_t &&ptr);
+    void add_touched_page(
+        block_id_t block_id, block_version_t version, repli_timestamp_t tstamp);
+
+    // Destroys other, merges it into this page txn.
+    void merge(scoped_ptr_t<page_txn_t> &&other);
+
+    auto_drainer_t::lock_t drainer_lock_;
 
     page_cache_t *page_cache_;
-    // This can be NULL, if the txn is not part of some cache conn.
-    cache_conn_t *cache_conn_;
+    // Contains cache_conn_t's for which we are the newest txn.
+    half_intrusive_list_t<cache_conn_t> cache_conns_;
 
     // An acquisition object for the memory tracker.
     throttler_acq_t throttler_acq_;
@@ -636,28 +777,33 @@ private:
     // about memory usage.
     backindex_bag_t<current_page_t *, 16> pages_write_acquired_last_;
 
+    // Pages for which this page_txn_t is the last_dirtier_ of that page.
+    backindex_bag_t<current_page_dirtier_t, 16> pages_dirtied_last_;
+
     // How many current_page_acq_t's for this transaction that are currently alive.
     size_t live_acqs_;
 
-    // Saved pages (by block id).
-    // KSI: Right now we put multiple dirtied_page_t's if we reacquire the same block
-    // and modify it again.
-    segmented_vector_t<dirtied_page_t, 8> snapshotted_dirtied_pages_;
+    // You have to update throttler_acq_ when you add/remove from this.
+    std::unordered_map<block_id_t, block_change_t> changes_;
+    // How many pages are held by changes_.  (Always non-negative.)
+    int64_t dirty_changes_pages_;
 
-    // Touched pages (by block id).
-    // KSI: Right now we put multiple touched_page_t's if we reacquire the same block
-    // and modify it again.
-    segmented_vector_t<touched_page_t, 8> touched_pages_;
-
-    // KSI: We could probably turn began_waiting_for_flush_ and spawned_flush_ into a
-    // generalized state enum.
-    //
-    // KSI: Should we have the spawned_flush_ variable or should we remove the txn
-    // from the graph?
+    // Valid states of (began_waiting_for_flush_, pre_spawn_flush_, spawned_flush_) are:
+    //   (    *,     *, false)
+    //   ( true,  true,  true)
 
     // Tells whether this page_txn_t has announced itself (to the cache) to be
     // waiting for a flush.
     bool began_waiting_for_flush_;
+
+    // We "want" to spawn a flush, so you shouldn't gratuitously add any preceders by
+    // stealing dirtied pages.  If this is true, then it must also be true for any
+    // preceders.
+    // bool pre_spawn_flush_;
+    // Actually, this field is stored in throttler_acq_.pre_spawn_flush_.
+
+    // spawned_flush_ gets set true when we have removed the txn from the graph (just
+    // before we actually start flushing).
     bool spawned_flush_;
 
     enum mark_state_t : uint8_t {
@@ -670,9 +816,7 @@ private:
     // algorithms.
     mark_state_t mark_;
 
-    // This gets pulsed when the flush is complete or when the txn has no reason to
-    // exist any more.
-    cond_t flush_complete_cond_;
+    intrusive_list_t<page_txn_complete_cb_t> flush_complete_waiters_;
 
     DISABLE_COPYING(page_txn_t);
 };

--- a/src/buffer_cache/types.hpp
+++ b/src/buffer_cache/types.hpp
@@ -14,6 +14,13 @@ ARCHIVE_PRIM_MAKE_RANGED_SERIALIZABLE(write_durability_t, int8_t,
                                       write_durability_t::SOFT,
                                       write_durability_t::HARD);
 
+#define DEFAULT_FLUSH_INTERVAL 1000
+// Converting this value from millis to nanos is less than half of 2^63.
+#define NEVER_FLUSH_INTERVAL (0x100000000ll * 1000ll)
+
+struct flush_interval_t {
+    int64_t millis;
+};
 
 typedef uint32_t block_magic_comparison_t;
 

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -217,7 +217,7 @@ void metadata_file_t::read_txn_t::read_bin(
 
 void metadata_file_t::read_txn_t::read_many_bin(
         const store_key_t &key_prefix,
-        const std::function<void(const std::string &key_suffix, read_stream_t *)> &cb,
+        const std::function<void(std::string &&key_suffix, read_stream_t *)> &cb,
         signal_t *interruptor) {
     buf_lock_t sb_lock(buf_parent_t(&txn), SUPERBLOCK_ID, access_t::read);
     wait_interruptible(sb_lock.read_acq_signal(), interruptor);
@@ -234,12 +234,12 @@ void metadata_file_t::read_txn_t::read_many_bin(
             txn->blob_to_stream(
                 kv.expose_buf(),
                 kv.value(),
-                [&](read_stream_t *s) { (*cb)(suffix, s); });
+                [&](read_stream_t *s) { (*cb)(std::move(suffix), s); });
             return continue_bool_t::CONTINUE;
         }
         read_txn_t *txn;
         store_key_t key_prefix;
-        const std::function<void(const std::string &key_suffix, read_stream_t *)> *cb;
+        const std::function<void(std::string &&key_suffix, read_stream_t *)> *cb;
     } dftcb;
     dftcb.txn = this;
     dftcb.key_prefix = key_prefix;

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -306,7 +306,8 @@ metadata_file_t::metadata_file_t(
     filepath_file_opener_t file_opener(get_filename(base_path), io_backender);
     init_serializer(&file_opener, perfmon_parent);
     balancer.init(new dummy_cache_balancer_t(METADATA_CACHE_SIZE));
-    cache.init(new cache_t(serializer.get(), balancer.get(), perfmon_parent));
+    cache.init(new cache_t(serializer.get(), balancer.get(), perfmon_parent,
+                           which_cpu_shard_t{0, 1}));
     cache_conn.init(new cache_conn_t(cache.get()));
 
     /* Migrate data if necessary */
@@ -398,7 +399,7 @@ metadata_file_t::metadata_file_t(
         log_serializer_t::static_config_t());
     init_serializer(&file_opener, perfmon_parent);
     balancer.init(new dummy_cache_balancer_t(METADATA_CACHE_SIZE));
-    cache.init(new cache_t(serializer.get(), balancer.get(), perfmon_parent));
+    cache.init(new cache_t(serializer.get(), balancer.get(), perfmon_parent, which_cpu_shard_t{0, 1}));
     cache_conn.init(new cache_conn_t(cache.get()));
 
     {

--- a/src/clustering/administration/persist/file.hpp
+++ b/src/clustering/administration/persist/file.hpp
@@ -71,17 +71,16 @@ public:
         template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
         void read_many(
                 const key_t<T> &key_prefix,
-                const std::function<void(
-                    const std::string &key_suffix, const T &value)> &cb,
+                const std::function<void(std::string &&key_suffix, T &&value)> &cb,
                 signal_t *interruptor) {
             read_many_bin(
                 key_prefix.key,
-                [&](const std::string &key_suffix, read_stream_t *bin_value) {
+                [&](std::string &&key_suffix, read_stream_t *bin_value) {
                     T value;
                     archive_result_t res = deserialize<W>(bin_value, &value);
                     guarantee_deserialization(res,
                         "metadata_file_t::read_txn_t::read_many");
-                    cb(key_suffix, value);
+                    cb(std::move(key_suffix), std::move(value));
                 },
                 interruptor);
         }
@@ -110,7 +109,7 @@ public:
         void read_many_bin(
             const store_key_t &key_prefix,
             const std::function<void(
-                const std::string &key_suffix, read_stream_t *)> &cb,
+                std::string &&key_suffix, read_stream_t *)> &cb,
             signal_t *interruptor);
 
         metadata_file_t *file;

--- a/src/clustering/administration/persist/migrate/migrate_v1_16.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v1_16.cc
@@ -430,7 +430,8 @@ void check_for_obsolete_sindexes(io_backender_t *io_backender,
                                       base_path,
                                       info.first,
                                       /* Important: Don't update indexes yet. */
-                                      update_sindexes_t::LEAVE_ALONE);
+                                      update_sindexes_t::LEAVE_ALONE,
+                                      which_cpu_shard_t{index, CPU_SHARDING_FACTOR});
 
                         store.sindex_list(interruptor);
                     });
@@ -478,7 +479,8 @@ void migrate_tables(io_backender_t *io_backender,
                                       io_backender,
                                       base_path,
                                       info.first,
-                                      update_sindexes_t::UPDATE);
+                                      update_sindexes_t::UPDATE,
+                                      which_cpu_shard_t{index, CPU_SHARDING_FACTOR});
 
                         if (index == 0) {
                             sindex_list = store.sindex_list(interruptor);
@@ -628,7 +630,7 @@ void migrate_auth_metadata_to_v2_1(io_backender_t *io_backender,
     }
 
     dummy_cache_balancer_t balancer(MEGABYTE);
-    cache_t cache(&serializer, &balancer, &dummy_stats);
+    cache_t cache(&serializer, &balancer, &dummy_stats, which_cpu_shard_t{0, 1});
     cache_conn_t cache_conn(&cache);
 
     txn_t read_txn(&cache_conn, read_access_t::read);

--- a/src/clustering/administration/persist/raft_storage_interface.cc
+++ b/src/clustering/administration/persist/raft_storage_interface.cc
@@ -55,8 +55,8 @@ table_raft_storage_interface_t::table_raft_storage_interface_t(
     state.log.prev_term = snapshot.log_prev_term;
     txn->read_many<raft_log_entry_t<table_raft_state_t> >(
         mdprefix_table_raft_log().suffix(uuid_to_str(table_id) + "/"),
-        [&](const std::string &index_str,
-                const raft_log_entry_t<table_raft_state_t> &entry) {
+        [&](std::string &&index_str,
+            raft_log_entry_t<table_raft_state_t> &&entry) {
             guarantee(str_to_log_index(index_str) == state.log.get_latest_index() + 1,
                 "%" PRIu64 " ('%s') == %" PRIu64,
                 str_to_log_index(index_str),
@@ -117,8 +117,8 @@ void table_raft_storage_interface_t::erase(
     std::vector<std::string> log_keys;
     txn->read_many<raft_log_entry_t<table_raft_state_t> >(
         mdprefix_table_raft_log().suffix(uuid_to_str(table_id) + "/"),
-        [&](const std::string &index_str, const raft_log_entry_t<table_raft_state_t> &) {
-            log_keys.push_back(index_str);
+        [&](std::string &&index_str, raft_log_entry_t<table_raft_state_t> &&) {
+            log_keys.push_back(std::move(index_str));
         },
         &non_interruptor);
     for (const std::string &key : log_keys) {

--- a/src/clustering/administration/persist/table_interface.cc
+++ b/src/clustering/administration/persist/table_interface.cc
@@ -94,7 +94,8 @@ public:
                 io_backender,
                 base_path,
                 table_id,
-                update_sindexes_t::UPDATE));
+                update_sindexes_t::UPDATE,
+                which_cpu_shard_t{ix, CPU_SHARDING_FACTOR}));
 
             /* Initialize the metainfo if necessary */
             if (create) {

--- a/src/clustering/generic/raft_core.hpp
+++ b/src/clustering/generic/raft_core.hpp
@@ -308,8 +308,8 @@ public:
     }
 
     /* Appends the given entry ot the log. */
-    void append(const raft_log_entry_t<state_t> &entry) {
-        entries.push_back(entry);
+    void append(raft_log_entry_t<state_t> entry) {
+        entries.push_back(std::move(entry));
     }
 
     /* The equality and inequality operators are for testing. */

--- a/src/clustering/table_manager/flush_interval_manager.cc
+++ b/src/clustering/table_manager/flush_interval_manager.cc
@@ -1,0 +1,37 @@
+// Copyright 2010-2015 RethinkDB, all rights reserved
+#include "clustering/table_manager/flush_interval_manager.hpp"
+
+#include "clustering/administration/issues/outdated_index.hpp"
+
+#include "concurrency/cross_thread_signal.hpp"
+#include "concurrency/pmap.hpp"
+#include "rdb_protocol/store.hpp"
+
+flush_interval_manager_t::flush_interval_manager_t(
+        multistore_ptr_t *multistore_,
+        const clone_ptr_t<watchable_t<table_config_t> > &table_config_) :
+    multistore(multistore_), table_config(table_config_),
+    update_pumper([this](signal_t *interruptor) { update_blocking(interruptor); }),
+    table_config_subs([this]() { update_pumper.notify(); })
+{
+    watchable_t<table_config_t>::freeze_t freeze(table_config);
+    table_config_subs.reset(table_config, &freeze);
+    update_pumper.notify();
+}
+
+void flush_interval_manager_t::update_blocking(signal_t *interruptor) {
+    flush_interval_t flush_interval;
+    table_config->apply_read([&](const table_config_t *config) {
+        // HSI: Oh definitely read the value out of the config, thank you.
+        flush_interval = get_flush_interval(*config);
+    });
+
+    for (size_t i = 0; i < CPU_SHARDING_FACTOR; ++i) {
+        store_t *store = multistore->get_underlying_store(i);
+        cross_thread_signal_t ct_interruptor(interruptor, store->home_thread());
+        on_thread_t thread_switcher(store->home_thread());
+
+        store->configure_flush_interval(flush_interval);
+    }
+}
+

--- a/src/clustering/table_manager/flush_interval_manager.hpp
+++ b/src/clustering/table_manager/flush_interval_manager.hpp
@@ -1,0 +1,35 @@
+// Copyright 2010-2015 RethinkDB, all rights reserved.
+#ifndef CLUSTERING_TABLE_MANAGER_FLUSH_INTERVAL_MANAGER_HPP_
+#define CLUSTERING_TABLE_MANAGER_FLUSH_INTERVAL_MANAGER_HPP_
+
+#include "clustering/table_contract/cpu_sharding.hpp"
+#include "clustering/administration/tables/table_metadata.hpp"
+#include "concurrency/pump_coro.hpp"
+#include "concurrency/watchable.hpp"
+
+/* The `flush_interval_manager_t` is responsible for reading the flush interval
+description from the `table_config_t` updating the flush interval on the `store_t`. */
+
+class flush_interval_manager_t {
+public:
+    flush_interval_manager_t(
+        multistore_ptr_t *multistore,
+        const clone_ptr_t<watchable_t<table_config_t> > &table_config);
+
+private:
+    void update_blocking(signal_t *interruptor);
+
+    multistore_ptr_t *const multistore;
+    clone_ptr_t<watchable_t<table_config_t> > const table_config;
+
+    /* Destructor order matters: The `table_config_subs` must be destroyed before the
+    `update_pumper` because it calls `update_pumper.notify()`. But `update_pumper` must
+    be destroyed before the other variables because it runs `update_blocking()`, which
+    accesses the other variables. */
+    pump_coro_t update_pumper;
+
+    watchable_t<table_config_t>::subscription_t table_config_subs;
+};
+
+#endif /* CLUSTERING_TABLE_MANAGER_FLUSH_INTERVAL_MANAGER_HPP_ */
+

--- a/src/clustering/table_manager/table_manager.cc
+++ b/src/clustering/table_manager/table_manager.cc
@@ -61,6 +61,13 @@ table_manager_t::table_manager_t(
                     -> table_config_t {
                 return sc.state.config.config;
             })),
+    flush_interval_manager(
+        multistore_ptr,
+        raft.get_raft()->get_committed_state()->subview(
+            [](const raft_member_t<table_raft_state_t>::state_and_config_t &sc)
+                    -> table_config_t {
+                return sc.state.config.config;
+            })),
     table_directory_subs(
         _table_manager_directory,
         std::bind(&table_manager_t::on_table_directory_change, this, ph::_1, ph::_2),

--- a/src/clustering/table_manager/table_manager.hpp
+++ b/src/clustering/table_manager/table_manager.hpp
@@ -5,6 +5,7 @@
 #include "clustering/table_contract/coordinator/coordinator.hpp"
 #include "clustering/table_contract/executor/executor.hpp"
 #include "clustering/table_manager/backfill_progress_tracker.hpp"
+#include "clustering/table_manager/flush_interval_manager.hpp"
 #include "clustering/table_manager/server_name_cache_updater.hpp"
 #include "clustering/table_manager/sindex_manager.hpp"
 #include "clustering/table_manager/table_metadata.hpp"
@@ -179,6 +180,10 @@ private:
     /* The `sindex_manager` watches the `table_config_t` and changes the sindexes on
     `multistore_ptr` according to what it sees. */
     sindex_manager_t sindex_manager;
+
+    /* The `flush_interval_manager` watches the `table_config_t` and changes the flush
+    interval according to what it sees. */
+    flush_interval_manager_t flush_interval_manager;
 
     auto_drainer_t drainer;
 

--- a/src/concurrency/cond_var.hpp
+++ b/src/concurrency/cond_var.hpp
@@ -16,6 +16,11 @@ public:
     cond_t(cond_t &&movee) : signal_t(std::move(movee)) { }
     void pulse_if_not_already_pulsed();
 
+    void swap(cond_t &other) {
+        signal_t &sig_other = other;
+        signal_t::swap(sig_other);
+    }
+
     using signal_t::pulse;
     using signal_t::reset;
 

--- a/src/concurrency/mutex_assertion.hpp
+++ b/src/concurrency/mutex_assertion.hpp
@@ -56,8 +56,14 @@ struct mutex_assertion_t : public home_thread_mixin_t {
     // Unimplemented because nobody uses this yet.
     void operator=(mutex_assertion_t &&movee) = delete;
 
+    bool is_locked() const { return locked; }
+
     ~mutex_assertion_t() { reset(); }
     void reset() { rassert(!locked); }
+    void swap(mutex_assertion_t &other) {
+        rassert(!locked);
+        rassert(!other.locked);
+    }
 
     void rethread(threadnum_t new_thread) {
         rassert(!locked);
@@ -193,6 +199,8 @@ struct mutex_assertion_t {
     mutex_assertion_t(mutex_assertion_t &&) { }
     void reset() { }
     void rethread(threadnum_t) { }
+    // is_locked not defined
+    void swap(mutex_assertion_t &) { }
 private:
     DISABLE_COPYING(mutex_assertion_t);
 };

--- a/src/concurrency/new_semaphore.cc
+++ b/src/concurrency/new_semaphore.cc
@@ -52,6 +52,14 @@ new_semaphore_in_line_t::~new_semaphore_in_line_t() {
     reset();
 }
 
+new_semaphore_in_line_t &new_semaphore_in_line_t::operator=(new_semaphore_in_line_t &&movee) {
+    new_semaphore_in_line_t tmp(std::move(movee));
+    std::swap(semaphore_, tmp.semaphore_);
+    std::swap(count_, tmp.count_);
+    cond_.swap(tmp.cond_);
+    return *this;
+}
+
 void new_semaphore_in_line_t::reset() {
     if (semaphore_ != nullptr) {
         semaphore_->remove_acquirer(this);
@@ -86,10 +94,6 @@ new_semaphore_in_line_t::new_semaphore_in_line_t(new_semaphore_in_line_t &&movee
     movee.semaphore_ = nullptr;
     movee.count_ = 0;
     movee.cond_.reset();
-}
-
-int64_t new_semaphore_in_line_t::count() const {
-    return count_;
 }
 
 void new_semaphore_in_line_t::change_count(int64_t new_count) {

--- a/src/concurrency/new_semaphore.hpp
+++ b/src/concurrency/new_semaphore.hpp
@@ -52,9 +52,17 @@ public:
     new_semaphore_in_line_t();
     new_semaphore_in_line_t(new_semaphore_t *semaphore, int64_t count);
     new_semaphore_in_line_t(new_semaphore_in_line_t &&movee);
+    new_semaphore_in_line_t &operator=(new_semaphore_in_line_t &&movee);
 
     // Returns "how much" of the semaphore this acq has acquired or would acquire.
-    int64_t count() const;
+    int64_t count() const {
+        return count_;
+    }
+
+    // Is this object not in a default-constructed state?
+    bool has_semaphore() const {
+        return semaphore_ != nullptr;
+    }
 
     // Changes "how much" of the semaphore this acq has acquired or would acquire.
     // If it's already acquired the semaphore, and new_count is bigger than the

--- a/src/concurrency/pubsub.hpp
+++ b/src/concurrency/pubsub.hpp
@@ -92,6 +92,12 @@ private:
         rassert(subscriptions.empty());
     }
 
+    void swap(publisher_t &other) {
+        rassert(subscriptions.empty());
+        rassert(other.subscriptions.empty());
+        mutex.swap(other.mutex);
+    }
+
     publisher_t(publisher_t &&movee)
         : subscriptions(std::move(movee.subscriptions)),
           mutex(std::move(movee.mutex)) {
@@ -148,6 +154,10 @@ public:
 
     void reset() {
         publisher.reset();
+    }
+
+    void swap(publisher_controller_t &other) {
+        publisher.swap(other.publisher);
     }
 
 private:

--- a/src/concurrency/signal.cc
+++ b/src/concurrency/signal.cc
@@ -51,6 +51,15 @@ signal_t::signal_t(signal_t &&movee)
     movee.pulsed = false;
 }
 
+void signal_t::swap(signal_t &other) {
+    assert_thread();
+    other.assert_thread();
+
+    std::swap(pulsed, other.pulsed);
+    publisher_controller.swap(other.publisher_controller);
+    lock.swap(other.lock);
+}
+
 // The same thing that happens when a signal_t is destructed happens: We crash if
 // there are any current waiters.
 void signal_t::reset() {

--- a/src/concurrency/signal.hpp
+++ b/src/concurrency/signal.hpp
@@ -107,6 +107,9 @@ protected:
 
     void reset();
 
+    // You can only call this when it's safe to destruct or reset both objects.
+    void swap(signal_t &other);
+
 private:
     static void call(subscription_t *subscription) THROWS_NOTHING {
         subscription->run();

--- a/src/config/args.hpp
+++ b/src/config/args.hpp
@@ -99,9 +99,6 @@
 // TODO: make this dynamic where possible
 #define MAX_THREADS                               128
 
-// Ticks (in milliseconds) the internal timed tasks are performed at
-#define TIMER_TICKS_IN_MS                         5
-
 // How many times the page replacement algorithm tries to find an eligible page before giving up.
 // Note that (MAX_UNSAVED_DATA_LIMIT_FRACTION ** PAGE_REPL_NUM_TRIES) is the probability that the
 // page replacement algorithm will succeed on a given try, and if that probability is less than 1/2

--- a/src/containers/backindex_bag.hpp
+++ b/src/containers/backindex_bag.hpp
@@ -69,7 +69,7 @@ public:
 
     ~backindex_bag_t() {
         // Another way to implement this would be to simply remove all its elements.
-        guarantee(vector_.size() == 0);
+        guarantee(empty());
     }
 
     // Returns true if the potential element of this container is in fact an element
@@ -128,6 +128,10 @@ public:
 
     size_t size() const {
         return vector_.size();
+    }
+
+    bool empty() const {
+        return vector_.empty();
     }
 
     // Accesses an element by index.  This is called "access random" because

--- a/src/containers/disk_backed_queue.cc
+++ b/src/containers/disk_backed_queue.cc
@@ -28,7 +28,8 @@ internal_disk_backed_queue_t::internal_disk_backed_queue_t(io_backender_t *io_ba
                                               &perfmon_collection));
 
     balancer.init(new dummy_cache_balancer_t(2 * MEGABYTE));
-    cache.init(new cache_t(serializer.get(), balancer.get(), &perfmon_collection));
+    cache.init(new cache_t(serializer.get(), balancer.get(), &perfmon_collection,
+                           which_cpu_shard_t{0, 1}));
     cache_conn.init(new cache_conn_t(cache.get()));
     // Emulate cache_t::create behavior by zeroing the block with id SUPERBLOCK_ID.
     txn_t txn(cache_conn.get(), write_durability_t::HARD, 1);

--- a/src/containers/half_intrusive_list.hpp
+++ b/src/containers/half_intrusive_list.hpp
@@ -108,6 +108,16 @@ public:
 
     void remove(T *elem) {
         guarantee(elem->in_a_list());
+        help_remove(elem);
+    }
+
+    void pop_front() {
+        guarantee(!empty());
+        help_remove(this->next_);
+    }
+
+private:
+    void help_remove(half_intrusive_list_node_t<T> *elem) {
         if (elem->next_ != nullptr) {
             elem->next_->prev_ = elem->prev_;
         }

--- a/src/rdb_protocol/btree_store.cc
+++ b/src/rdb_protocol/btree_store.cc
@@ -86,7 +86,8 @@ store_t::store_t(const region_t &_region,
                  io_backender_t *io_backender,
                  const base_path_t &base_path,
                  namespace_id_t _table_id,
-                 update_sindexes_t _update_sindexes)
+                 update_sindexes_t _update_sindexes,
+                 which_cpu_shard_t which_cpu_shard)
     : store_view_t(_region),
       perfmon_collection(),
       io_backender_(io_backender), base_path_(base_path),
@@ -95,7 +96,7 @@ store_t::store_t(const region_t &_region,
       table_id(_table_id),
       write_superblock_acq_semaphore(WRITE_SUPERBLOCK_ACQ_WAITERS_LIMIT)
 {
-    cache.init(new cache_t(serializer, balancer, &perfmon_collection));
+    cache.init(new cache_t(serializer, balancer, &perfmon_collection, which_cpu_shard));
     general_cache_conn.init(new cache_conn_t(cache.get()));
 
     if (create) {
@@ -484,6 +485,10 @@ void store_t::sindex_drop(
 
     sindex_block.reset_buf_lock();
     txn->commit();
+}
+
+void store_t::configure_flush_interval(flush_interval_t interval) {
+    cache->configure_flush_interval(interval);
 }
 
 new_mutex_in_line_t store_t::get_in_line_for_sindex_queue(buf_lock_t *sindex_block) {

--- a/src/rdb_protocol/store.hpp
+++ b/src/rdb_protocol/store.hpp
@@ -88,7 +88,8 @@ public:
             io_backender_t *io_backender,
             const base_path_t &base_path,
             namespace_id_t table_id,
-            update_sindexes_t update_sindexes);
+            update_sindexes_t update_sindexes,
+            which_cpu_shard_t which_cpu_shard);
     ~store_t();
 
     void note_reshard(const region_t &shard_region);
@@ -198,6 +199,8 @@ public:
             const std::string &id,
             signal_t *interruptor)
             THROWS_ONLY(interrupted_exc_t);
+
+    void configure_flush_interval(flush_interval_t interval);
 
     new_mutex_in_line_t get_in_line_for_sindex_queue(buf_lock_t *sindex_block);
     rwlock_in_line_t get_in_line_for_cfeed_stamp(access_t access);

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -82,13 +82,14 @@ public:
     // ratio of garbage to blocks in the system
     double garbage_ratio() const;
 
-    std::vector<counted_t<block_token_t>>
-    many_writes(const std::vector<buf_write_info_t> &writes,
+    std::vector<counted_t<block_token_t> >
+    many_writes(const buf_write_info_t *writes,
+                size_t writes_count,
                 file_account_t *io_account,
                 iocallback_t *cb);
 
-    std::vector<std::vector<counted_t<block_token_t>>>
-    gimme_some_new_offsets(const std::vector<buf_write_info_t> &writes);
+    std::vector<std::vector<counted_t<block_token_t> > >
+    gimme_some_new_offsets(const buf_write_info_t *writes, size_t writes_count);
 
     bool is_gc_active() const;
 

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -663,15 +663,18 @@ log_serializer_t::generate_block_token(int64_t offset, block_size_t block_size) 
     return token;
 }
 
-std::vector<counted_t<block_token_t>>
-log_serializer_t::block_writes(const std::vector<buf_write_info_t> &write_infos,
-                               file_account_t *io_account, iocallback_t *cb) {
+std::vector<counted_t<block_token_t> >
+log_serializer_t::block_writes(const buf_write_info_t *write_infos,
+                               size_t write_infos_count,
+                               file_account_t *io_account,
+                               iocallback_t *cb) {
     assert_thread();
-    stats->pm_serializer_block_writes += write_infos.size();
+    stats->pm_serializer_block_writes += write_infos_count;
 
-    std::vector<counted_t<block_token_t>> result
-        = data_block_manager->many_writes(write_infos, io_account, cb);
-    guarantee(result.size() == write_infos.size());
+    std::vector<counted_t<block_token_t> > result
+        = data_block_manager->many_writes(write_infos, write_infos_count, io_account,
+                                          cb);
+    guarantee(result.size() == write_infos_count);
     return result;
 }
 

--- a/src/serializer/log/log_serializer.hpp
+++ b/src/serializer/log/log_serializer.hpp
@@ -141,10 +141,11 @@ public:
                      const std::function<void()> &on_writes_reflected,
                      const std::vector<index_write_op_t> &write_ops);
 
-    std::vector<counted_t<block_token_t>> block_writes(
-            const std::vector<buf_write_info_t> &write_infos,
-            file_account_t *io_account,
-            iocallback_t *cb);
+    std::vector<counted_t<block_token_t> > block_writes(
+        const buf_write_info_t *write_infos,
+        size_t write_infos_count,
+        file_account_t *io_account,
+        iocallback_t *cb);
 
     max_block_size_t max_block_size() const;
 

--- a/src/serializer/merger.hpp
+++ b/src/serializer/merger.hpp
@@ -92,15 +92,17 @@ public:
                      const std::vector<index_write_op_t> &write_ops);
 
     // Returns block tokens in the same order as write_infos.
-    std::vector<counted_t<block_token_t>>
-    block_writes(const std::vector<buf_write_info_t> &write_infos,
+    std::vector<counted_t<block_token_t> >
+    block_writes(const buf_write_info_t *write_infos,
+                 size_t write_infos_count,
                  UNUSED file_account_t *io_account,
                  iocallback_t *cb) {
         // Currently, we do not merge block writes, only index writes.
         // However we do use a common file account for all of them, which
         // reduces random disk seeks that would arise from trying to interleave
         // writes from the individual accounts further down in the i/o layer.
-        return inner->block_writes(write_infos, block_writes_io_account.get(), cb);
+        return inner->block_writes(write_infos, write_infos_count,
+                                   block_writes_io_account.get(), cb);
     }
 
     /* The size, in bytes, of each serializer block */

--- a/src/serializer/serializer.hpp
+++ b/src/serializer/serializer.hpp
@@ -111,8 +111,9 @@ public:
                              const std::vector<index_write_op_t> &write_ops) = 0;
 
     // Returns block tokens in the same order as write_infos.
-    virtual std::vector<counted_t<block_token_t>>
-    block_writes(const std::vector<buf_write_info_t> &write_infos,
+    virtual std::vector<counted_t<block_token_t> >
+    block_writes(const buf_write_info_t *write_infos,
+                 size_t num_write_infos,
                  file_account_t *io_account,
                  iocallback_t *cb) = 0;
 

--- a/src/serializer/translator.hpp
+++ b/src/serializer/translator.hpp
@@ -126,7 +126,7 @@ public:
                      const std::vector<index_write_op_t> &write_ops);
 
     std::vector<counted_t<block_token_t> >
-    block_writes(const std::vector<buf_write_info_t> &write_infos,
+    block_writes(const buf_write_info_t *write_infos, size_t write_infos_count,
                  file_account_t *io_account, iocallback_t *cb);
 
     max_block_size_t max_block_size() const;

--- a/src/unittest/blob_test.cc
+++ b/src/unittest/blob_test.cc
@@ -295,7 +295,8 @@ TPTEST(BlobTest, AllTests) {
             &get_global_perfmon_collection());
 
     dummy_cache_balancer_t balancer(GIGABYTE);
-    cache_t cache(&log_serializer, &balancer, &get_global_perfmon_collection());
+    cache_t cache(&log_serializer, &balancer, &get_global_perfmon_collection(),
+                  which_cpu_shard_t{0, 1});
 
     run_tests(&cache);
 }

--- a/src/unittest/btree_metainfo.cc
+++ b/src/unittest/btree_metainfo.cc
@@ -57,7 +57,8 @@ TPTEST(BtreeMetainfo, MetainfoTest) {
         &get_global_perfmon_collection());
 
     dummy_cache_balancer_t balancer(GIGABYTE);
-    cache_t cache(&serializer, &balancer, &get_global_perfmon_collection());
+    cache_t cache(&serializer, &balancer, &get_global_perfmon_collection(),
+                  which_cpu_shard_t{0, 1});
     cache_conn_t cache_conn(&cache);
 
     {

--- a/src/unittest/btree_sindex.cc
+++ b/src/unittest/btree_sindex.cc
@@ -33,7 +33,8 @@ TPTEST(BTreeSindex, LowLevelOps) {
         &file_opener,
         &get_global_perfmon_collection());
 
-    cache_t cache(&serializer, &balancer, &get_global_perfmon_collection());
+    cache_t cache(&serializer, &balancer, &get_global_perfmon_collection(),
+                  which_cpu_shard_t{0, 1});
     cache_conn_t cache_conn(&cache);
 
     {
@@ -169,7 +170,8 @@ TPTEST(BTreeSindex, BtreeStoreAPI) {
             &io_backender,
             base_path_t("."),
             generate_uuid(),
-            update_sindexes_t::UPDATE);
+            update_sindexes_t::UPDATE,
+            which_cpu_shard_t{0, 1});
 
     cond_t dummy_interruptor;
 

--- a/src/unittest/btree_whole.cc
+++ b/src/unittest/btree_whole.cc
@@ -54,7 +54,8 @@ public:
                 std::move(inner_serializer),
                 MERGER_SERIALIZER_MAX_ACTIVE_WRITES);
 
-        cache = make_scoped<cache_t>(serializer.get(), &balancer, &get_global_perfmon_collection());
+        cache = make_scoped<cache_t>(serializer.get(), &balancer, &get_global_perfmon_collection(),
+                                     which_cpu_shard_t{0, 1});
         cache_conn = make_scoped<cache_conn_t>(cache.get());
         sizer = make_scoped<short_value_sizer_t>(cache.get()->max_block_size());
 

--- a/src/unittest/clustering_utils.hpp
+++ b/src/unittest/clustering_utils.hpp
@@ -65,7 +65,8 @@ public:
             store(region_t::universe(), serializer.get(), balancer.get(),
                 temp_file.name().permanent_path(), true,
                 &get_global_perfmon_collection(), ctx, io_backender, base_path_t("."),
-                generate_uuid(), update_sindexes_t::UPDATE) {
+                generate_uuid(), update_sindexes_t::UPDATE,
+                which_cpu_shard_t({0, 1})) {
         /* Initialize store metadata */
         cond_t non_interruptor;
         write_token_t token;

--- a/src/unittest/page_test.cc
+++ b/src/unittest/page_test.cc
@@ -42,10 +42,6 @@ struct mock_ser_t {
     }
 };
 
-void reset_throttler_acq(alt::throttler_acq_t *acq) {
-    alt::throttler_acq_t movee(std::move(*acq));
-}
-
 class test_txn_t;
 
 class test_cache_t : public page_cache_t {
@@ -57,13 +53,13 @@ public:
           throttler_(throttler) { }
 
     void flush(scoped_ptr_t<test_txn_t> txn) {
-        flush_and_destroy_txn(std::move(txn), &reset_throttler_acq);
+        flush_and_destroy_txn(std::move(txn), write_durability_t::SOFT, nullptr);
     }
 
     alt::throttler_acq_t make_throttler_acq() {
         // KSI: We could make these tests better by varying the expected change
         // count.
-        return throttler_->begin_txn_or_throttle(0);
+        return throttler_->begin_txn_or_throttle(write_durability_t::SOFT, 0);
     }
 
 private:

--- a/src/unittest/rdb_btree.cc
+++ b/src/unittest/rdb_btree.cc
@@ -269,7 +269,8 @@ TPTEST(RDBBtree, SindexPostConstruct) {
             &io_backender,
             base_path_t("."),
             generate_uuid(),
-            update_sindexes_t::UPDATE);
+            update_sindexes_t::UPDATE,
+            which_cpu_shard_t{0, 1});
 
     cond_t dummy_interruptor;
 
@@ -312,7 +313,8 @@ TPTEST(RDBBtree, SindexEraseRange) {
             &io_backender,
             base_path_t("."),
             generate_uuid(),
-            update_sindexes_t::UPDATE);
+            update_sindexes_t::UPDATE,
+            which_cpu_shard_t{0, 1});
 
     cond_t dummy_interruptor;
 
@@ -399,7 +401,8 @@ TPTEST(RDBBtree, SindexInterruptionViaDrop) {
             &io_backender,
             base_path_t("."),
             generate_uuid(),
-            update_sindexes_t::UPDATE);
+            update_sindexes_t::UPDATE,
+            which_cpu_shard_t{0, 1});
 
     cond_t dummy_interruptor;
 
@@ -442,7 +445,8 @@ TPTEST(RDBBtree, SindexInterruptionViaStoreDelete) {
             &io_backender,
             base_path_t("."),
             generate_uuid(),
-            update_sindexes_t::UPDATE));
+            update_sindexes_t::UPDATE,
+            which_cpu_shard_t{0, 1}));
 
     insert_rows(0, (TOTAL_KEYS_TO_INSERT * 9) / 10, store.get());
 

--- a/src/unittest/rdb_protocol.cc
+++ b/src/unittest/rdb_protocol.cc
@@ -86,7 +86,8 @@ void run_with_namespace_interface(
                     make_scoped<store_t>(region_t::universe(), serializers[i].get(),
                         &balancer, temp_files[i]->name().permanent_path(), do_create,
                         &get_global_perfmon_collection(), &ctx, &io_backender,
-                        base_path_t("."), generate_uuid(), update_sindexes_t::UPDATE));
+                        base_path_t("."), generate_uuid(), update_sindexes_t::UPDATE,
+                        which_cpu_shard_t{0, 1}));
         }
 
         std::vector<scoped_ptr_t<store_view_t> > stores;

--- a/src/unittest/serializer_test.cc
+++ b/src/unittest/serializer_test.cc
@@ -47,8 +47,8 @@ void run_AddDeleteRepeatedly(bool perform_index_write) {
             }
         } cb;
 
-        std::vector<counted_t<block_token_t>> tokens
-            = ser.block_writes(infos, account.get(), &cb);
+        std::vector<counted_t<block_token_t> > tokens
+            = ser.block_writes(infos.data(), infos.size(), account.get(), &cb);
 
         // Wait for it to be written (because we're nice).
         cb.wait();

--- a/src/unittest/timer_test.cc
+++ b/src/unittest/timer_test.cc
@@ -58,5 +58,39 @@ TPTEST(TimerTest, TestApproximateWaitTimes) {
         << "Average timer error too high";
 }
 
+TPTEST(TimerTest, TestRepeatingTimer) {
+    int64_t first_ticks = get_ticks().nanos;
+    int count = 0;
+    repeating_timer_t timer(30, [&]() {
+        ++count;
+        int64_t ticks = get_ticks().nanos;
+        int64_t diff = ticks - first_ticks;
+        EXPECT_LT(std::abs(diff - 30 * MILLION * count), max_error_ms * MILLION);
+    });
+    nap(100);
+}
+
+TPTEST(TimerTest, TestChangeInterval) {
+    ticks_t first_ticks = get_ticks();
+    int count = 0;
+    int64_t expected[] = { 5, 10, 20, 40, 65 };
+    int64_t naps[] = {0,  0,  0,  25, 0};
+    int64_t ms[] = { 10, 20, 30, 10, 50};
+    repeating_timer_t timer(10, [&]() {
+        coro_t::spawn_now_dangerously([&]() {
+            ASSERT_LT(count, 5);
+            ticks_t ticks = get_ticks();
+            int64_t diff = ticks.nanos - first_ticks.nanos;
+            EXPECT_LT(std::abs(diff - expected[count] * MILLION),
+                      max_error_ms * MILLION);
+            nap(naps[count]);
+            timer.change_interval(ms[count]);
+            ++count;
+        });
+    });
+    timer.change_interval(5);
+    nap(70);
+}
+
 
 }  // namespace unittest


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This changes the cache's flush strategy for soft durability writes to be to accumulate changes, and then flush the changes every `t` seconds.  It has the effect of greatly reducing the number of write operations.

The feature is described in the notes for https://github.com/srh/rethinkdb/releases/tag/v2.3.5-srh-extra except that the configuration option is moved to a top-level `flush_interval` table config.  Also, the default interval is 1.0 seconds.

This addresses some suggestions in #1771.  It's easy to imagine people finding something to complain about here, so I'm going to leave this up for a while.