### PR TITLE
Shrink size of gc_entry_t

### DIFF
--- a/src/btree/get_distribution.cc
+++ b/src/btree/get_distribution.cc
@@ -17,7 +17,7 @@ public:
     void read_stat_block(buf_lock_t *stat_block) {
         guarantee (stat_block != nullptr);
         buf_read_t read(stat_block);
-        uint32_t sb_size;
+        uint16_t sb_size;
         const btree_statblock_t *sb_data =
             static_cast<const btree_statblock_t *>(read.get_data_read(&sb_size));
         guarantee(sb_size == BTREE_STATBLOCK_SIZE);

--- a/src/btree/reql_specific.cc
+++ b/src/btree/reql_specific.cc
@@ -61,12 +61,17 @@ void real_superblock_t::release() {
     sb_buf_.reset_buf_lock();
 }
 
+const reql_btree_superblock_t *get_reql_btree_superblock(buf_read_t *read) {
+    uint16_t sb_size;
+    const reql_btree_superblock_t *sb_data
+        = static_cast<const reql_btree_superblock_t *>(read->get_data_read(&sb_size));
+    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    return sb_data;
+}
+
 block_id_t real_superblock_t::get_root_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data
-        = static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->root_block;
 }
 
@@ -79,19 +84,13 @@ void real_superblock_t::set_root_block_id(const block_id_t new_root_block) {
 
 block_id_t real_superblock_t::get_stat_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data =
-        static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->stat_block;
 }
 
 block_id_t real_superblock_t::get_sindex_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data =
-        static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->sindex_block;
 }
 
@@ -104,10 +103,7 @@ void sindex_superblock_t::release() {
 
 block_id_t sindex_superblock_t::get_root_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data
-        = static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->root_block;
 }
 
@@ -120,19 +116,13 @@ void sindex_superblock_t::set_root_block_id(const block_id_t new_root_block) {
 
 block_id_t sindex_superblock_t::get_stat_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data =
-        static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->stat_block;
 }
 
 block_id_t sindex_superblock_t::get_sindex_block_id() {
     buf_read_t read(&sb_buf_);
-    uint32_t sb_size;
-    const reql_btree_superblock_t *sb_data =
-        static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-    guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+    const reql_btree_superblock_t *sb_data = get_reql_btree_superblock(&read);
     return sb_data->sindex_block;
 }
 
@@ -243,10 +233,7 @@ void get_superblock_metainfo(
     std::vector<char> metainfo;
     {
         buf_read_t read(superblock->get());
-        uint32_t sb_size;
-        const reql_btree_superblock_t *data
-            = static_cast<const reql_btree_superblock_t *>(read.get_data_read(&sb_size));
-        guarantee(sb_size == REQL_BTREE_SUPERBLOCK_SIZE);
+        const reql_btree_superblock_t *data = get_reql_btree_superblock(&read);
 
         if (data->magic == reql_btree_version_magic_t<cluster_version_t::v2_1>::value) {
             *version_out = cluster_version_t::v2_1;

--- a/src/buffer_cache/alt.cc
+++ b/src/buffer_cache/alt.cc
@@ -808,7 +808,7 @@ buf_read_t::~buf_read_t() {
     lock_->access_ref_count_--;
 }
 
-const void *buf_read_t::get_data_read(uint32_t *block_size_out) {
+const void *buf_read_t::get_data_read(uint16_t *block_size_out) {
     page_t *page = lock_->get_held_page_for_read();
     if (!page_acq_.has()) {
         page_acq_.init(page, &lock_->cache()->page_cache_,
@@ -830,7 +830,7 @@ buf_write_t::~buf_write_t() {
     lock_->access_ref_count_--;
 }
 
-void *buf_write_t::get_data_write(uint32_t block_size) {
+void *buf_write_t::get_data_write(uint16_t block_size) {
     page_t *page = lock_->get_held_page_for_write();
     if (!page_acq_.has()) {
         page_acq_.init(page, &lock_->cache()->page_cache_,

--- a/src/buffer_cache/alt.hpp
+++ b/src/buffer_cache/alt.hpp
@@ -327,9 +327,9 @@ public:
     explicit buf_read_t(buf_lock_t *lock);
     ~buf_read_t();
 
-    const void *get_data_read(uint32_t *block_size_out);
+    const void *get_data_read(uint16_t *block_size_out);
     const void *get_data_read() {
-        uint32_t block_size;
+        uint16_t block_size;
         const void *data = get_data_read(&block_size);
         guarantee(block_size == lock_->cache()->max_block_size().value());
         return data;
@@ -347,7 +347,7 @@ public:
     explicit buf_write_t(buf_lock_t *lock);
     ~buf_write_t();
 
-    void *get_data_write(uint32_t block_size);
+    void *get_data_write(uint16_t block_size);
     // Equivalent to passing the max_block_size.
     void *get_data_write();
 

--- a/src/buffer_cache/blob.cc
+++ b/src/buffer_cache/blob.cc
@@ -462,7 +462,7 @@ void expose_tree_from_block_ids(buf_parent_t parent, access_t mode,
                 // intricate logic), because immediately after creation, the blob has
                 // size max_value_size, but after we've written to the block, its
                 // size could be shrunken.
-                uint32_t block_size;
+                uint16_t block_size;
                 leaf_buf = const_cast<void *>(buf_read->get_data_read(&block_size));
                 acq_group_out->add_buf(buf, buf_read);
             } else {
@@ -762,7 +762,7 @@ bool blob_t::remove_level(buf_parent_t parent, int *levels_ref) {
                         access_t::write);
         if (levels == 1) {
             buf_read_t lock_read(&lock);
-            uint32_t unused_block_size;
+            uint16_t unused_block_size;
             const char *b = blob::leaf_node_data(lock_read.get_data_read(&unused_block_size));
             char *small = blob::small_buffer(ref_, maxreflen_);
             memcpy(small, b, bigsize);

--- a/src/buffer_cache/page.cc
+++ b/src/buffer_cache/page.cc
@@ -523,7 +523,7 @@ void page_t::reset_block_token(DEBUG_VAR page_cache_t *page_cache) {
     rassert(!waiters_.empty());
     rassert(buf_.has());
     if (block_token_.has()) {
-        rassert(buf_.block_size().value() == block_token_->block_size().value());
+        rassert(buf_.block_size() == block_token_->block_size());
 #ifndef NDEBUG
         const uint32_t usage_before = hypothetical_memory_usage(page_cache);
 #endif
@@ -550,7 +550,7 @@ void page_t::evict_self(DEBUG_VAR page_cache_t *page_cache) {
     rassert(waiters_.empty());
     rassert(block_token_.has());
     rassert(buf_.has());
-    rassert(block_token_->block_size().value() == buf_.block_size().value());
+    rassert(block_token_->block_size() == buf_.block_size());
 #ifndef NDEBUG
     const uint32_t usage_before = hypothetical_memory_usage(page_cache);
 #endif
@@ -569,7 +569,7 @@ ser_buffer_t *page_t::get_loaded_ser_buffer() {
 void page_t::init_block_token(counted_t<block_token_t> token,
                               DEBUG_VAR page_cache_t *page_cache) {
     rassert(buf_.has());
-    rassert(buf_.block_size().value() == token->block_size().value());
+    rassert(buf_.block_size() == token->block_size());
     rassert(!block_token_.has());
 #ifndef NDEBUG
     const uint32_t usage_before = hypothetical_memory_usage(page_cache);

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -72,7 +72,7 @@ void page_read_ahead_cb_t::offer_read_ahead_buf(
 
     // We're going to reconstruct the buf_ptr_t on the other side of this do_on_thread
     // call, so we'd better make sure the block size is right.
-    guarantee(block_size.value() == token->block_size().value());
+    guarantee(block_size == token->block_size());
 
     // Notably, this code relies on do_on_thread to preserve callback order (which it
     // does do).

--- a/src/serializer/buf_ptr.cc
+++ b/src/serializer/buf_ptr.cc
@@ -44,8 +44,8 @@ void buf_ptr_t::resize_fill_zero(block_size_t new_size) {
     guarantee(new_size.ser_value() != 0);
     guarantee(ser_buffer_.has());
 
-    uint32_t old_reserved = compute_aligned_block_size(block_size_);
-    uint32_t new_reserved = compute_aligned_block_size(new_size);
+    uint16_t old_reserved = compute_aligned_block_size(block_size_);
+    uint16_t new_reserved = compute_aligned_block_size(new_size);
 
     if (old_reserved == new_reserved) {
         if (new_size.ser_value() < block_size_.ser_value()) {
@@ -70,8 +70,8 @@ void buf_ptr_t::resize_fill_zero(block_size_t new_size) {
 void buf_ptr_t::fill_padding_zero() const {
     guarantee(has());
     char *p = reinterpret_cast<char *>(ser_buffer());
-    uint32_t ser_block_size = block_size().ser_value();
-    uint32_t aligned = aligned_block_size();
+    uint16_t ser_block_size = block_size().ser_value();
+    uint16_t aligned = aligned_block_size();
     memset(p + ser_block_size, 0, aligned - ser_block_size);
 }
 
@@ -79,9 +79,9 @@ void buf_ptr_t::fill_padding_zero() const {
 void buf_ptr_t::assert_padding_zero() const {
     guarantee(has());
     char *p = reinterpret_cast<char *>(ser_buffer());
-    uint32_t ser_block_size = block_size().ser_value();
-    uint32_t aligned = aligned_block_size();
-    for (uint32_t i = ser_block_size; i < aligned; ++i) {
+    uint16_t ser_block_size = block_size().ser_value();
+    uint16_t aligned = aligned_block_size();
+    for (uint16_t i = ser_block_size; i < aligned; ++i) {
         rassert(p[i] == 0);
     }
 }

--- a/src/serializer/buf_ptr.hpp
+++ b/src/serializer/buf_ptr.hpp
@@ -68,14 +68,14 @@ public:
     // Returns the actual allocated size of the buffer, wich is
     // DEVICE_BLOCK_SIZE-aligned.  (Returns the value of block_size().ser_value()
     // rounded up to the next multiple of DEVICE_BLOCK_SIZE.)
-    uint32_t aligned_block_size() const {
+    uint16_t aligned_block_size() const {
         guarantee(ser_buffer_.has());
         return buf_ptr_t::compute_aligned_block_size(block_size_);
     }
 
     // Returns what aligned_block_size() would return for a buf_ptr_t that has the
     // given block size.
-    static uint32_t compute_aligned_block_size(block_size_t block_size) {
+    static uint16_t compute_aligned_block_size(block_size_t block_size) {
         return ceil_aligned(block_size.ser_value(), DEVICE_BLOCK_SIZE);
     }
 

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -308,6 +308,10 @@ public:
         return ret;
     }
 
+    void shrink_to_fit() {
+        block_infos.shrink_to_fit();
+    }
+
 private:
     // Private because we cannot guarantee that our stats remain consistent if somebody
     // gets a non-const iterator.
@@ -483,6 +487,7 @@ void data_block_manager_t::start_existing(
 
         guarantee(entry->state == gc_entry_t::state_reconstructing);
         entry->state = gc_entry_t::state_old;
+        entry->shrink_to_fit();
 
         entry->our_pq_entry = gc_pq.push(entry);
 
@@ -1453,6 +1458,7 @@ data_block_manager_t::gimme_some_new_offsets(const std::vector<buf_write_info_t>
                 destroy_entry(old_active_extent);
             } else {
                 active_extent->state = gc_entry_t::state_young;
+                active_extent->shrink_to_fit();
                 young_extent_queue.push_back(active_extent);
                 mark_unyoung_entries();
                 active_extent = new gc_entry_t(this);

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -61,8 +61,8 @@ private:
         // 512 * 2^14 = 2^23 = 8MB. Assumes extent size < 8 MB.  Right now extent size
         // is 2.  ("dblocks" = "device blocks").
         uint16_t relative_offset_in_dblocks : 14;
-        bool token_referenced : 1;
-        bool index_referenced : 1;
+        uint16_t token_referenced : 1;
+        uint16_t index_referenced : 1;
         block_size_t block_size;
     };
 

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -176,7 +176,7 @@ public:
         }
     }
 
-    static uint32_t aligned_value(block_size_t bs) {
+    static uint16_t aligned_value(block_size_t bs) {
         return ceil_aligned(bs.ser_value(), DEVICE_BLOCK_SIZE);
     }
 
@@ -294,7 +294,7 @@ public:
         const int64_t offset = extent_ref.offset();
         std::string ret;
         for (auto it = block_infos.begin(); it != block_infos.end(); ++it) {
-            ret += strprintf("%s[%" PRIi64 "..+%" PRIu32 ") %c%c",
+            ret += strprintf("%s[%" PRIi64 "..+%" PRIu16 ") %c%c",
                              it == block_infos.begin() ? "" : separator,
                              offset + it->relative_offset, it->block_size.ser_value(),
                              it->token_referenced ? 'T' : ' ',
@@ -493,7 +493,7 @@ void data_block_manager_t::start_existing(
 // block_boundaries() value.  Outputs an interval that is _NOT_ fit to device block
 // size boundaries.  This is used by read_ahead_offset_and_size.
 void unaligned_read_ahead_interval(const int64_t block_offset,
-                                   const uint32_t ser_block_size,
+                                   const uint16_t ser_block_size,
                                    const int64_t extent_size,
                                    const int64_t read_ahead_size,
                                    const std::vector<uint32_t> &boundaries,
@@ -540,7 +540,7 @@ void unaligned_read_ahead_interval(const int64_t block_offset,
 // ser_block_size_in) interval.  boundaries is the extent's gc_entry_t's
 // block_boundaries() value.
 void read_ahead_interval(const int64_t block_offset,
-                         const uint32_t ser_block_size,
+                         const uint16_t ser_block_size,
                          const int64_t extent_size,
                          const int64_t read_ahead_size,
                          const int64_t device_block_size,
@@ -558,7 +558,7 @@ void read_ahead_interval(const int64_t block_offset,
 }
 
 void read_ahead_offset_and_size(int64_t off_in,
-                                int64_t ser_block_size_in,
+                                uint16_t ser_block_size_in,
                                 int64_t extent_size,
                                 const std::vector<uint32_t> &boundaries,
                                 int64_t *offset_out, int64_t *size_out) {
@@ -588,7 +588,7 @@ public:
 
     static void perform_read_ahead(data_block_manager_t *const parent,
                                    const int64_t off_in,
-                                   const uint32_t ser_block_size_in,
+                                   const uint16_t ser_block_size_in,
                                    void *const buf_out,
                                    file_account_t *const io_account,
                                    log_serializer_stats_t *const stats) {

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -266,11 +266,11 @@ private:
     DISABLE_COPYING(data_block_manager_t);
 };
 
-// Exposed for unit tests.  Returns a super-interval of [block_offset,
+// Exposed for unit tests.  Returns a super-interval of [block_offset, block_offset +
 // ser_block_size) that is almost appropriate for a read-ahead disk read -- it still
 // needs to be stretched to be aligned with disk block boundaries.
 void unaligned_read_ahead_interval(const int64_t block_offset,
-                                   const uint32_t ser_block_size,
+                                   const uint16_t ser_block_size,
                                    const int64_t extent_size,
                                    const int64_t read_ahead_size,
                                    const std::vector<uint32_t> &boundaries,

--- a/src/serializer/log/lba/disk_format.hpp
+++ b/src/serializer/log/lba/disk_format.hpp
@@ -76,7 +76,7 @@ ATTR_PACKED(struct lba_entry_t {
     flagged_off64_t offset;
 
     static lba_entry_t make(block_id_t block_id, repli_timestamp_t recency,
-                            flagged_off64_t offset, uint32_t ser_block_size) {
+                            flagged_off64_t offset, uint16_t ser_block_size) {
         guarantee(ser_block_size != 0 || !offset.has_value());
         lba_entry_t entry;
         entry.zero_reserved = 0;

--- a/src/serializer/log/lba/disk_structure.cc
+++ b/src/serializer/log/lba/disk_structure.cc
@@ -69,7 +69,7 @@ void lba_disk_structure_t::on_extent_read() {
 }
 
 void lba_disk_structure_t::add_entry(block_id_t block_id, repli_timestamp_t recency,
-                                     flagged_off64_t offset, uint32_t ser_block_size,
+                                     flagged_off64_t offset, uint16_t ser_block_size,
                                      file_account_t *io_account,
                                      extent_transaction_t *txn) {
     if (last_extent && last_extent->full()) {

--- a/src/serializer/log/lba/disk_structure.hpp
+++ b/src/serializer/log/lba/disk_structure.hpp
@@ -33,7 +33,7 @@ public:
 
     // Put entries in an LBA and then call wait_for_write_completion() to write to disk
     void add_entry(block_id_t block_id, repli_timestamp_t recency,
-                   flagged_off64_t offset, uint32_t ser_block_size,
+                   flagged_off64_t offset, uint16_t ser_block_size,
                    file_account_t *io_account,
                    extent_transaction_t *txn);
     struct completion_callback_t {

--- a/src/serializer/log/lba/lba_list.hpp
+++ b/src/serializer/log/lba/lba_list.hpp
@@ -43,7 +43,7 @@ public:
 
     // These return individual fields of get_block_info.
     flagged_off64_t get_block_offset(block_id_t block);
-    uint32_t get_ser_block_size(block_id_t block);
+    uint16_t get_ser_block_size(block_id_t block);
     block_size_t get_block_size(block_id_t block);
     repli_timestamp_t get_block_recency(block_id_t block);
     segmented_vector_t<repli_timestamp_t> get_block_recencies(block_id_t first,
@@ -61,7 +61,7 @@ public:
 #endif
 
     void set_block_info(block_id_t block, repli_timestamp_t recency,
-                        flagged_off64_t offset, uint32_t ser_block_size,
+                        flagged_off64_t offset, uint16_t ser_block_size,
                         file_account_t *io_account,
                         extent_transaction_t *txn);
 

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -492,7 +492,7 @@ void log_serializer_t::index_write(new_mutex_in_line_t *mutex_acq,
              ++write_op_it) {
             const index_write_op_t &op = *write_op_it;
             flagged_off64_t offset = lba_index->get_block_offset(op.block_id);
-            uint32_t ser_block_size = lba_index->get_ser_block_size(op.block_id);
+            uint16_t ser_block_size = lba_index->get_ser_block_size(op.block_id);
 
             if (op.token) {
                 // Update the offset pointed to, and mark garbage/liveness as necessary.
@@ -1002,7 +1002,7 @@ void block_token_t::do_destroy() {
 void debug_print(printf_buffer_t *buf,
                  const counted_t<block_token_t> &token) {
     if (token.has()) {
-        buf->appendf("standard_block_token{%" PRIi64 ", +%" PRIu32 "}",
+        buf->appendf("standard_block_token{%" PRIi64 ", +%" PRIu16 "}",
                      token->offset(), token->block_size().ser_value());
     } else {
         buf->appendf("nil");

--- a/src/serializer/serializer.cc
+++ b/src/serializer/serializer.cc
@@ -22,6 +22,6 @@ ser_buffer_t *convert_buffer_cache_buf_to_ser_buffer(const void *buf) {
 }
 
 void debug_print(printf_buffer_t *buf, const buf_write_info_t &info) {
-    buf->appendf("bwi{buf=%p, size=%" PRIu32 ", id=%" PRIu64 "}",
+    buf->appendf("bwi{buf=%p, size=%" PRIu16 ", id=%" PRIu64 "}",
                  info.buf, info.block_size.ser_value(), info.block_id);
 }

--- a/src/serializer/types.hpp
+++ b/src/serializer/types.hpp
@@ -61,25 +61,25 @@ public:
     // things could call value() instead of ser_value() or vice versa.
 
     // The "block size" (in bytes) used by things above the serializer.
-    uint32_t value() const {
+    uint16_t value() const {
         rassert(ser_bs_ != 0);
         return ser_bs_ - sizeof(ls_buf_data_t);
     }
 
     // The "block size" (in bytes) used by things in the serializer.
-    uint32_t ser_value() const {
+    uint16_t ser_value() const {
         rassert(ser_bs_ != 0);
         return ser_bs_;
     }
 
-    static block_size_t make_from_cache(uint32_t cache_block_size) {
+    static block_size_t make_from_cache(uint16_t cache_block_size) {
         return block_size_t(cache_block_size + sizeof(ls_buf_data_t));
     }
 
     // Avoid using this function.  We want there to be a small
     // number of uses so that we can be sure it's impossible to pass
     // the wrong value as a block_size_t.
-    static block_size_t unsafe_make(uint32_t ser_bs) {
+    static block_size_t unsafe_make(uint16_t ser_bs) {
         return block_size_t(ser_bs);
     }
 
@@ -89,18 +89,18 @@ public:
     }
 
 protected:
-    explicit block_size_t(uint32_t ser_bs) : ser_bs_(ser_bs) { }
+    explicit block_size_t(uint16_t ser_bs) : ser_bs_(ser_bs) { }
 
 private:
-    uint32_t ser_bs_;
+    uint16_t ser_bs_;
 };
 
 // For use in compile-time constants
-template<uint32_t ser_size> struct from_ser_block_size_t {
-    static const uint32_t cache_size = ser_size - sizeof(ls_buf_data_t);
+template<uint16_t ser_size> struct from_ser_block_size_t {
+    static const uint16_t cache_size = ser_size - sizeof(ls_buf_data_t);
 };
-template<uint32_t cache_size> struct from_cache_block_size_t {
-    static const uint32_t ser_size = cache_size + sizeof(ls_buf_data_t);
+template<uint16_t cache_size> struct from_cache_block_size_t {
+    static const uint16_t ser_size = cache_size + sizeof(ls_buf_data_t);
 };
 
 inline bool operator==(block_size_t x, block_size_t y) {
@@ -116,7 +116,7 @@ public:
     using block_size_t::value;
     using block_size_t::ser_value;
 
-    static max_block_size_t unsafe_make(uint32_t ser_bs) {
+    static max_block_size_t unsafe_make(uint16_t ser_bs) {
         CT_ASSERT(sizeof(block_size_t) == sizeof(max_block_size_t));
         return max_block_size_t(ser_bs);
     }

--- a/src/unittest/page_test.cc
+++ b/src/unittest/page_test.cc
@@ -1083,13 +1083,13 @@ private:
     void make_empty(const scoped_ptr_t<current_test_acq_t> &acq) {
         test_acq_t page_acq;
         page_acq.init(acq->current_page_for_write(), c);
-        const uint32_t n = page_acq.get_buf_size().value();
+        const uint16_t n = page_acq.get_buf_size().value();
         ASSERT_EQ(4088u, n);
         memset(page_acq.get_buf_write(), 0, n);
     }
 
     void check_page_acq(page_acq_t *page_acq, const std::string &expected) {
-        const uint32_t n = page_acq->get_buf_size().value();
+        const uint16_t n = page_acq->get_buf_size().value();
         ASSERT_EQ(4088u, n);
         const char *const p = static_cast<const char *>(page_acq->get_buf_read());
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This reduces the memory overhead of gc_entry_t.  This reduces the constant factor of memory overhead per unit of data on disk.