### PR TITLE
Fix uses of run_options/runOptions in _export.py.

### DIFF
--- a/drivers/python/rethinkdb/__main__.py
+++ b/drivers/python/rethinkdb/__main__.py
@@ -8,7 +8,6 @@ from . import errors, net, utils_common
 def startInterpreter(argv=None, prog=None):
     import code, optparse
     
-    connectOptions = {}
     replVariables = {'r':net.Connection._r, 'rethinkdb':net.Connection._r}
     banner = 'The RethinkDB driver has been imported as `r`.'
     

--- a/drivers/python/rethinkdb/_export.py
+++ b/drivers/python/rethinkdb/_export.py
@@ -178,7 +178,7 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
         table_info['indexes'] = options.retryQuery(
             'table index data %s.%s' % (db, table),
             query.db(db).table(table).index_status(),
-            runOptions={'binary_format':'raw'}
+            run_options={'binary_format':'raw'}
         )
         
         sindex_counter.value += len(table_info["indexes"])
@@ -186,7 +186,7 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
         table_info['write_hook'] = options.retryQuery(
             'table write hook data %s.%s' % (db, table),
             query.db(db).table(table).get_write_hook(),
-            runOptions={'binary_format':'raw'})
+            run_options={'binary_format':'raw'})
 
         if table_info['write_hook'] != None:
             hook_counter.value += 1
@@ -217,16 +217,16 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
         
         lastPrimaryKey = None
         read_rows      = 0
-        runOptions     = {
+        run_options     = {
             "time_format":"raw",
             "binary_format":"raw"
         }
         if options.outdated:
-            runOptions["read_mode"] = "outdated"
+            run_options["read_mode"] = "outdated"
         cursor = options.retryQuery(
             'inital cursor for %s.%s' % (db, table),
             query.db(db).table(table).order_by(index=table_info["primary_key"]),
-            runOptions=runOptions
+            run_options=run_options
         )
         while not exit_event.is_set():
             try:
@@ -258,7 +258,7 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
                 cursor = options.retryQuery(
                     'backup cursor for %s.%s' % (db, table),
                     query.db(db).table(table).between(lastPrimaryKey, None, left_bound="open").order_by(index=table_info["primary_key"]),
-                    runOptions=runOptions
+                    run_options=run_options
                 )
     
     except (errors.ReqlError, errors.ReqlDriverError) as ex:

--- a/drivers/python/rethinkdb/utils_common.py
+++ b/drivers/python/rethinkdb/utils_common.py
@@ -63,7 +63,7 @@ class RetryQuery(object):
             raise ValueError('times must be a positive integer, got: %s' % times)
         if run_options is None:
             run_options = {}
-        assert isinstance(run_options, dict), 'runOptions must be a dict, got: %s' % run_options
+        assert isinstance(run_options, dict), 'run_options must be a dict, got: %s' % run_options
         
         last_error = None
         test_connection = False


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Thanks to my merging of 3b29933aa033e6b871ae43418c62005b113f39c1 by @rayrase the export script was now broken, using `runOptions`.  This fixes the export script.

I also will cherry-pick 3b29933aa and then this fix onto v2.4.x.