### PR TITLE
Fix compilation on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ init () {
     max_browserify_version=13.1.0
     min_python_version=2.6.0
     
-    osx_min_version=10.7
+    osx_min_version=10.9
 
     min_msbuild_version=14.0
     min_nmake_version=14.0

--- a/mk/support/pkg/curl.sh
+++ b/mk/support/pkg/curl.sh
@@ -7,15 +7,10 @@ src_url_sha1=f5193316e4b5ff23505cb09bc946763d35d02cd6
 pkg_configure () {
     local prefix
     prefix="$(niceabspath "$install_dir")"
-    local ssl_command
-    ssl_command="--with-ssl"
-    if [[ "$OS" = "Darwin" ]]; then
-        ssl_command="--with-darwinssl --without-ssl --without-nghttp2"
-    fi
     if [[ "$CROSS_COMPILING" = 1 ]]; then
         configure_flags="--host=$($CXX -dumpmachine)"
     fi
-    in_dir "$build_dir" ./configure --prefix="$prefix" --without-gnutls $ssl_command --without-librtmp --disable-ldap --disable-shared ${configure_flags:-}
+    in_dir "$build_dir" ./configure --prefix="$prefix" --without-gnutls --with-ssl --without-nghttp2 --without-librtmp --disable-ldap --disable-shared ${configure_flags:-}
 }
 
 pkg_install-include () {

--- a/mk/support/pkg/curl.sh
+++ b/mk/support/pkg/curl.sh
@@ -1,8 +1,8 @@
 
-version=7.40.0
+version=7.54.1
 
 src_url=http://curl.haxx.se/download/curl-$version.tar.bz2
-src_url_sha1=1446603f4df89b6d1cafc4d6a8617c892651b3ff
+src_url_sha1=f5193316e4b5ff23505cb09bc946763d35d02cd6
 
 pkg_configure () {
     local prefix
@@ -10,7 +10,7 @@ pkg_configure () {
     local ssl_command
     ssl_command="--with-ssl"
     if [[ "$OS" = "Darwin" ]]; then
-        ssl_command="--with-darwinssl --without-ssl"
+        ssl_command="--with-darwinssl --without-ssl --without-nghttp2"
     fi
     if [[ "$CROSS_COMPILING" = 1 ]]; then
         configure_flags="--host=$($CXX -dumpmachine)"

--- a/mk/support/pkg/node.sh
+++ b/mk/support/pkg/node.sh
@@ -1,4 +1,4 @@
-version=6.10.0
+version=6.11.0
 
 src_url=http://nodejs.org/dist/v$version/node-v$version.tar.gz
-src_url_sha1=3bb2629ed623f38b8c3011cf422333862d3653a3
+src_url_sha1=df31d0e4e2104b3a62342533af5fb879f321416b

--- a/mk/support/pkg/openssl.sh
+++ b/mk/support/pkg/openssl.sh
@@ -1,9 +1,9 @@
 
-version=1.0.1u
+version=1.0.2l
 
 src_url="https://www.openssl.org/source/openssl-$version.tar.gz"
 src_url_backup="ftp://ftp.openssl.org/source/openssl-$version.tar.gz"
-src_url_sha1="93e542696598517862115fbe76a93ab66369661d"
+src_url_sha1="b58d5d0e9cea20e571d903aafa853e2ccd914138"
 
 pkg_configure () {
     case $($CXX -dumpmachine) in


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

macOS compilation on the `next` branch is currently broken regardless of how you configure it. These small tweaks fix it and also update a few dependencies for good will:

- Updates the min os deployment target to 10.9, this is necessary to be compatible with node 6.x due to issues with how c++ and c++11 work.
- Update curl to avoid compilation issues with SecureTransport and also ensure it doesn't attempt to compile http2 support even if libnghttp2 is on the system path
- Update openssl just for security reasons it should always be kept as up to date as possible
- Include icu4c headers because macOS doesn't ship with them

With these updates you can once again do `./configure --fetch all` and then `make -j8` and it compiles with no issues on macOS Sierra.
