### PR TITLE
Serializer checksums

### DIFF
--- a/src/arch/arch.cc
+++ b/src/arch/arch.cc
@@ -18,8 +18,8 @@ void co_read(file_t *file, int64_t offset, size_t length, void *buf, file_accoun
 }
 
 void co_write(file_t *file, int64_t offset, size_t length, void *buf,
-              file_account_t *account, file_t::wrap_in_datasyncs_t wrap_in_datasyncs) {
+              file_account_t *account, datasync_op datasync) {
     io_coroutine_adapter_t adapter;
-    file->write_async(offset, length, buf, account, &adapter, wrap_in_datasyncs);
+    file->write_async(offset, length, buf, account, &adapter, datasync);
     coro_t::wait();
 }

--- a/src/arch/arch.hpp
+++ b/src/arch/arch.hpp
@@ -9,8 +9,9 @@ changed back. We'll sort this mess out when it's time to support another OS. */
 
 #include "arch/types.hpp"
 
-void co_read(file_t *file, int64_t offset, size_t length, void *buf, file_account_t *account);
-void co_write(file_t *file, int64_t offset, size_t length, void *buf, file_account_t *account,
-              file_t::wrap_in_datasyncs_t wrap_in_datasyncs);
+void co_read(file_t *file, int64_t offset, size_t length, void *buf,
+             file_account_t *account);
+void co_write(file_t *file, int64_t offset, size_t length, void *buf,
+              file_account_t *account, datasync_op wrap_in_datasyncs);
 
 #endif /* ARCH_ARCH_HPP_ */

--- a/src/arch/io/disk.hpp
+++ b/src/arch/io/disk.hpp
@@ -73,9 +73,11 @@ public:
     void set_file_size(int64_t size);
     void set_file_size_at_least(int64_t size, int64_t extent_size);
 
-    void read_async(int64_t offset, size_t length, void *buf, file_account_t *account, linux_iocallback_t *cb);
-    void write_async(int64_t offset, size_t length, const void *buf, file_account_t *account, linux_iocallback_t *cb,
-                     wrap_in_datasyncs_t wrap_in_datasyncs);
+    void read_async(int64_t offset, size_t length, void *buf, file_account_t *account,
+                    linux_iocallback_t *cb);
+    void write_async(int64_t offset, size_t length, const void *buf,
+                     file_account_t *account, linux_iocallback_t *cb,
+                     datasync_op ds_op);
 
     // Does not guarantee the atomicity that writev guarantees.
     void writev_async(int64_t offset, size_t length, scoped_array_t<iovec> &&bufs,

--- a/src/arch/io/disk/pool.cc
+++ b/src/arch/io/disk/pool.cc
@@ -149,7 +149,7 @@ int64_t pool_diskmgr_t::action_t::perform_read_write(iovec *vecs,
 }
 
 void pool_diskmgr_t::action_t::run() {
-    if (wrap_in_datasyncs) {
+    if (ds_op == datasync_op::wrap_in_datasyncs) {
         int errcode = perform_datasync(fd);
         if (errcode != 0) {
             io_result = -errcode;
@@ -194,7 +194,8 @@ void pool_diskmgr_t::action_t::run() {
         unreachable("Unknown I/O action");
     }
 
-    if (wrap_in_datasyncs) {
+    if (ds_op == datasync_op::wrap_in_datasyncs
+        || ds_op == datasync_op::datasync_after) {
         int errcode = perform_datasync(fd);
         if (errcode != 0) {
             io_result = -errcode;

--- a/src/arch/types.hpp
+++ b/src/arch/types.hpp
@@ -105,12 +105,12 @@ enum class file_direct_io_mode_t {
     buffered_desired
 };
 
+enum class datasync_op { no_datasyncs, wrap_in_datasyncs, datasync_after };
+
 // A linux file.  It expects reads and writes and buffers to have an
 // alignment of DEVICE_BLOCK_SIZE.
 class file_t {
 public:
-    enum wrap_in_datasyncs_t { NO_DATASYNCS, WRAP_IN_DATASYNCS };
-
     file_t() { }
 
     virtual ~file_t() { }
@@ -122,7 +122,7 @@ public:
                             file_account_t *account, linux_iocallback_t *cb) = 0;
     virtual void write_async(int64_t offset, size_t length, const void *buf,
                              file_account_t *account, linux_iocallback_t *cb,
-                             wrap_in_datasyncs_t wrap_in_datasyncs) = 0;
+                             datasync_op ds_op) = 0;
     // writev_async doesn't provide the atomicity guarantees of writev.
     virtual void writev_async(int64_t offset, size_t length, scoped_array_t<iovec> &&bufs,
                               file_account_t *account, linux_iocallback_t *cb) = 0;

--- a/src/serializer/checksum.cc
+++ b/src/serializer/checksum.cc
@@ -1,0 +1,90 @@
+#include "serializer/checksum.hpp"
+
+// The return value of this function or its behavior can't be changed -- the on-disk
+// format obviously requires a specific checksum algorithm.
+serializer_checksum compute_checksum(const void *word32s, size_t wordcount) {
+    const uint32_t *p = static_cast<const uint32_t *>(word32s);
+
+    // This is the Fletcher-64 algorithm, applied to the input whose words are xored with
+    // 1.
+
+    // Given a sequence of 32-bit words x0, x1, ..., xN-1, define sK by
+    // sK = x0 + x1 + ... + xK.  Our checksum computes two values:
+    // A = (sN-1 MOD (2**32 - 1)).
+    // B = ((s0 + s1 + ... + sN-1) MOD (2**32 - 1)).
+    //
+    // We output the pair ((A == 0 ? (2**32-1) : A), (B == 0 ? (2**32-1) : B)).
+
+    // Why Fletcher-64 on xored inputs?
+    //
+    // One advantage is that checksum(s + t) can be computed from checksum(s) => (A1, B1)
+    // and checksum(t) => (A2, B2).  Output (A3, B3) where A3 = A1 + A2, B3 = B1 + A1 *
+    // length(t) + B2.
+    //
+    // We first xor the words by 1, so that the word 0x00000000 is distinguishable from
+    // 0xFFFFFFFF.
+
+    uint64_t a = 0xFFFFFFFF;
+    uint64_t b = 0xFFFFFFFF;
+
+    // We go through a minor shenanigan here to handle very large buffers.
+    for (;;) {
+        // 0xFFFFul is low enough that a and b can't overflow.
+        const size_t n = wordcount & 0xFFFFul;
+
+        // At this point, a and b are <= 0x1_FFFF_FFFE and non-zero.
+
+        const uint32_t xorer = 1;
+
+        for (size_t i = 0; i < n; i++) {
+            a += (uint64_t)(p[i] ^ xorer);
+            b += a;
+        }
+
+        a = (a & 0xFFFFFFFFul) + (a >> 32);
+        b = (b & 0xFFFFFFFFul) + (b >> 32);
+
+        // At this point, a and b are <= 0x1_FFFF_FFFE and non-zero.
+
+        wordcount -= n;
+        if (wordcount == 0) {
+            break;
+        }
+        p += n;
+    }
+
+    // At this point, a and b are <= 0x1_FFFF_FFFE and non-zero.
+    a = (a & 0xFFFFFFFFul) + (a >> 32);
+    b = (b & 0xFFFFFFFFul) + (b >> 32);
+    // Now a and b are <= 0xFFFF_FFFF and non-zero.
+    return serializer_checksum{(b << 32) | a};
+}
+
+serializer_checksum compute_checksum_concat(serializer_checksum left,
+                                            serializer_checksum right,
+                                            uint64_t right_wordcount) {
+    uint64_t a_left = left.value & 0xFFFFFFFFull;
+    uint64_t b_left = left.value >> 32;
+    uint64_t a_right = right.value & 0xFFFFFFFFull;
+    uint64_t b_right = right.value >> 32;
+
+    // a <= 0x1_FFFF_FFFE.
+    uint64_t a = a_left + a_right;
+    a = (a & 0xFFFFFFFFul) + (a >> 32);
+    // Now a is in the right range.
+
+    // We have to be careful about overflow (what if right_wordcount > 0x1_0000_0000?).
+
+    uint64_t wc = right_wordcount;
+    wc = (wc & 0xFFFFFFFFul) + (wc >> 32);
+    wc = (wc & 0xFFFFFFFFul) + (wc >> 32);
+    // Now wc <= 0xFFFFFFFF.
+    uint64_t b = a_left * right_wordcount;
+    b = (b & 0xFFFFFFFFul) + (b >> 32);
+
+    b = b + b_left + b_right;
+    b = (b & 0xFFFFFFFFul) + (b >> 32);
+    b = (b & 0xFFFFFFFFul) + (b >> 32);
+
+    return serializer_checksum{(b << 32) | a};
+}

--- a/src/serializer/checksum.hpp
+++ b/src/serializer/checksum.hpp
@@ -1,0 +1,54 @@
+#ifndef SERIALIZER_CHECKSUM_HPP_
+#define SERIALIZER_CHECKSUM_HPP_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "arch/compiler.hpp"
+
+// A valid checksum can never be zero, or have a zero-valued 32-bit word.  If value &
+// 0xFFFFFFFFul is zero, that means this holds no checksum.  The upper 32-bit word could
+// then be used to hold extra information (like whether the block has been fdatasynced).
+// This defines the disk format!  Do not change.
+ATTR_PACKED(struct serializer_checksum {
+    uint64_t value;
+    static const size_t word_size = sizeof(uint32_t);
+});
+
+// Computes a checksum of a buffer of length 4*wordcount.
+// word32s: a pointer to the buffer
+// wordcount: the number of 32-bit words in the buffer.
+// return value: the checksum.
+// The checksum is never zero.
+serializer_checksum compute_checksum(const void *word32s, size_t wordcount);
+
+// Combines checksums into the checksum of the concatenated buffer.  Given two buffers,
+// s, and t, serializer_checksum_concat(serializer_checksum(s), serializer_checksum(t),
+// t.wordcount) computes serializer_checksum(concat(s, t)).
+serializer_checksum compute_checksum_concat(serializer_checksum left,
+                                            serializer_checksum right,
+                                            uint64_t right_wordcount);
+
+// The checksum of an empty buffer.
+inline serializer_checksum identity_checksum() {
+    char buf[1];
+    return compute_checksum(&buf, 0);
+}
+
+inline serializer_checksum no_checksum() {
+    return serializer_checksum{0};
+}
+
+inline bool has_checksum(serializer_checksum x) {
+    return (x.value & 0xFFFFFFFFull) != 0;
+}
+
+inline serializer_checksum datasync_checksum() {
+    return serializer_checksum{0x100000000ull};
+}
+
+inline bool is_datasync_checksum(serializer_checksum x) {
+    return x.value == 0x100000000ull;
+}
+
+#endif  // SERIALIZER_CHECKSUM_HPP_

--- a/src/serializer/log/config.hpp
+++ b/src/serializer/log/config.hpp
@@ -14,11 +14,18 @@
 struct log_serializer_dynamic_config_t {
     log_serializer_dynamic_config_t() {
         read_ahead = true;
+        // This is probably too low, thanks to status quo bias (the status quo having
+        // been to never compute checksums).
+        checksum_threshold = 65536;
     }
 
     /* Enable reading more data than requested to let the cache warmup more quickly
        esp. on rotational drives */
     bool read_ahead;
+    /* The threshold above which we don't checksum blocks -- instead we fdatasync before
+       writing the serializer superblock.  Designed to make single-document writes
+       fast. */
+    uint32_t checksum_threshold;
 };
 
 /* This is equivalent to log_serializer_static_config_t below, but is an on-disk

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -736,15 +736,19 @@ buf_ptr_t data_block_manager_t::read(int64_t off_in, block_size_t block_size,
     }
 }
 
-std::vector<counted_t<block_token_t> >
+// Sets maybe_checksum_out if one was computed, or sets it to zero otherwise.
+std::vector<counted_t<block_token_t>>
 data_block_manager_t::many_writes(const buf_write_info_t *writes,
                                   size_t writes_count,
                                   file_account_t *io_account,
                                   iocallback_t *cb) {
     // These tokens are grouped by extent.  You can do a contiguous write in each
     // extent.
-    std::vector<std::vector<counted_t<block_token_t> > > token_groups
-        = gimme_some_new_offsets(writes, writes_count);
+    uint64_t cumulative_aligned_size;
+    std::vector<std::vector<counted_t<block_token_t>>> token_groups
+        = gimme_some_new_offsets(writes, writes_count, &cumulative_aligned_size);
+    const bool wants_checksum
+        = cumulative_aligned_size <= serializer->dynamic_config.checksum_threshold;
 
     for (size_t i = 0; i < writes_count; ++i) {
         writes[i].buf->ser_header.block_id = writes[i].block_id;
@@ -771,24 +775,24 @@ data_block_manager_t::many_writes(const buf_write_info_t *writes,
     intermediate_cb->cb = cb;
 
     size_t write_number = 0;
-    for (size_t i = 0; i < token_groups.size(); ++i) {
-
-        const int64_t front_offset = token_groups[i].front()->offset();
-        const int64_t back_offset = token_groups[i].back()->offset()
-            + gc_entry_t::aligned_value(token_groups[i].back()->block_size());
+    for (const std::vector<counted_t<block_token_t>> &group : token_groups) {
+        const int64_t front_offset = group.front()->offset();
+        const int64_t back_offset = group.back()->offset()
+            + gc_entry_t::aligned_value(group.back()->block_size());
 
         guarantee(divides(DEVICE_BLOCK_SIZE, front_offset));
 
         const int64_t write_size = back_offset - front_offset;
 
-        scoped_array_t<iovec> iovecs(token_groups[i].size());
+        scoped_array_t<iovec> iovecs(group.size());
 
         int64_t last_written_offset = front_offset;
         size_t total_aligned_size = 0;
 
-        for (size_t j = 0; j < token_groups[i].size(); ++j) {
-            const int64_t j_offset = token_groups[i][j]->offset();
-            const block_size_t j_block_size = token_groups[i][j]->block_size();
+        for (size_t j = 0, je = group.size(); j < je; ++j) {
+            block_token_t *token = group[j].get();
+            const int64_t j_offset = token->offset();
+            const block_size_t j_block_size = token->block_size();
             guarantee(j_offset == last_written_offset);
             const size_t j_aligned_size = gc_entry_t::aligned_value(j_block_size);
             total_aligned_size += j_aligned_size;
@@ -797,7 +801,14 @@ data_block_manager_t::many_writes(const buf_write_info_t *writes,
             // we expect writes[write_number] to have the currently-relevant write.
             guarantee(writes[write_number].block_size == j_block_size);
 
-            iovecs[j].iov_base = writes[write_number].buf;
+            void *buf = writes[write_number].buf;
+            if (wants_checksum) {
+                size_t wordcount = j_aligned_size / serializer_checksum::word_size;
+                serializer_checksum chksum = compute_checksum(buf, wordcount);
+                token->checksum_ = chksum;
+            }
+
+            iovecs[j].iov_base = buf;
             iovecs[j].iov_len = j_aligned_size;
             last_written_offset = j_offset + j_aligned_size;
 
@@ -816,11 +827,11 @@ data_block_manager_t::many_writes(const buf_write_info_t *writes,
     // earlier).
     intermediate_cb->on_io_complete();
 
-    std::vector<counted_t<block_token_t> > ret;
+    std::vector<counted_t<block_token_t>> ret;
     ret.reserve(writes_count);
-    for (auto it = token_groups.begin(); it != token_groups.end(); ++it) {
-        for (auto jt = it->begin(); jt != it->end(); ++jt) {
-            ret.push_back(std::move(*jt));
+    for (std::vector<counted_t<block_token_t>> &group : token_groups) {
+        for (counted_t<block_token_t> &token : group) {
+            ret.push_back(std::move(token));
         }
     }
 
@@ -1431,9 +1442,12 @@ void data_block_manager_t::actually_shutdown() {
     }
 }
 
-std::vector<std::vector<counted_t<block_token_t> > >
+// Outputs how many bytes would get written, so we can use that info to decide later
+// whether to checksum the blocks (which'll let us save an fdatasync)
+std::vector<std::vector<counted_t<block_token_t>>>
 data_block_manager_t::gimme_some_new_offsets(const buf_write_info_t *writes,
-                                             size_t writes_count) {
+                                             size_t writes_count,
+                                             uint64_t *cumulative_aligned_size_out) {
     ASSERT_NO_CORO_WAITING;
 
     // Start a new extent if necessary.
@@ -1446,12 +1460,14 @@ data_block_manager_t::gimme_some_new_offsets(const buf_write_info_t *writes,
     guarantee(active_extent->state == gc_entry_t::state_active);
 
     std::vector<std::vector<counted_t<block_token_t>>> ret;
+    uint64_t cumulative_aligned_size = 0;
 
     std::vector<counted_t<block_token_t> > tokens;
     for (size_t i = 0; i < writes_count; ++i) {
         block_size_t block_size = writes[i].block_size;
         uint32_t relative_offset = valgrind_undefined<uint32_t>(UINT32_MAX);
         unsigned int block_index = valgrind_undefined<unsigned int>(UINT_MAX);
+        cumulative_aligned_size += gc_entry_t::aligned_value(block_size);
         if (!active_extent->new_offset(block_size,
                                        &relative_offset, &block_index)) {
             // Move the active_extent gc_entry_t to the young extent queue (if it's
@@ -1493,6 +1509,7 @@ data_block_manager_t::gimme_some_new_offsets(const buf_write_info_t *writes,
         ret.push_back(std::move(tokens));
     }
 
+    *cumulative_aligned_size_out = cumulative_aligned_size;
     return ret;
 }
 

--- a/src/serializer/log/data_block_manager.hpp
+++ b/src/serializer/log/data_block_manager.hpp
@@ -8,10 +8,12 @@
 #include "concurrency/new_semaphore.hpp"
 #include "concurrency/pump_coro.hpp"
 #include "containers/intrusive_list.hpp"
+#include "containers/optional.hpp"
 #include "containers/priority_queue.hpp"
 #include "containers/scoped.hpp"
 #include "containers/two_level_array.hpp"
 #include "perfmon/types.hpp"
+#include "serializer/checksum.hpp"
 #include "serializer/log/config.hpp"
 #include "serializer/log/extent_manager.hpp"
 #include "serializer/types.hpp"
@@ -82,6 +84,8 @@ public:
     // ratio of garbage to blocks in the system
     double garbage_ratio() const;
 
+    // Potentially computes a checksum of the blocks to be written, depending on config.
+    // Caller may ignore that information, or use it to save an fdatasync.
     std::vector<counted_t<block_token_t> >
     many_writes(const buf_write_info_t *writes,
                 size_t writes_count,
@@ -89,7 +93,8 @@ public:
                 iocallback_t *cb);
 
     std::vector<std::vector<counted_t<block_token_t> > >
-    gimme_some_new_offsets(const buf_write_info_t *writes, size_t writes_count);
+    gimme_some_new_offsets(const buf_write_info_t *writes, size_t writes_count,
+                           uint64_t *cumulative_aligned_size_out);
 
     bool is_gc_active() const;
 

--- a/src/serializer/log/lba/disk_extent.hpp
+++ b/src/serializer/log/lba/disk_extent.hpp
@@ -20,7 +20,8 @@ public:
     extent_t *data;
     int count;
 
-    lba_disk_extent_t(extent_manager_t *_em, file_t *file, file_account_t *io_account);
+    lba_disk_extent_t(extent_manager_t *_em, file_t *file, file_account_t *io_account,
+                      optional<std::vector<checksum_filerange>> *checksums);
 
     lba_disk_extent_t(extent_manager_t *_em, file_t *file, int64_t _offset, int _count);
 
@@ -28,10 +29,12 @@ public:
         return data->amount_filled == em->extent_size;
     }
 
-    void add_entry(lba_entry_t entry, file_account_t *io_account);
+    void add_entry(lba_entry_t entry, file_account_t *io_account,
+                   optional<std::vector<checksum_filerange>> *checksums);
 
     void write_outstanding(file_account_t *io_account,
-                           extent_t::completion_callback_t *cb);
+                           extent_t::completion_callback_t *cb,
+                           optional<std::vector<checksum_filerange>> *checksums);
 
     /* To read from an LBA on disk, first call read_step_1(), passing it the address of
     a new read_info_t structure. When it calls the callback you provide, then call

--- a/src/serializer/log/lba/disk_structure.hpp
+++ b/src/serializer/log/lba/disk_structure.hpp
@@ -8,6 +8,7 @@
 #include "serializer/log/extent_manager.hpp"
 #include "serializer/log/lba/disk_format.hpp"
 #include "serializer/log/lba/disk_extent.hpp"
+#include "serializer/log/types.hpp"
 
 class lba_load_fsm_t;
 class lba_writer_t;
@@ -35,12 +36,14 @@ public:
     void add_entry(block_id_t block_id, repli_timestamp_t recency,
                    flagged_off64_t offset, uint16_t ser_block_size,
                    file_account_t *io_account,
-                   extent_transaction_t *txn);
+                   extent_transaction_t *txn,
+                   optional<std::vector<checksum_filerange>> *checksums);
     struct completion_callback_t {
         virtual void on_lba_completion() = 0;
         virtual ~completion_callback_t() {}
     };
     void write_outstanding(file_account_t *io_account,
+                           optional<std::vector<checksum_filerange>> *checksums,
                            completion_callback_t *cb);
 
     // Returns a set of extents that are not currently active.  The returned pointers
@@ -52,7 +55,8 @@ public:
     // the `extents_in_superblock` list.  Once the extents have been destroyed, a new
     // superblock is written to persist the change.
     void destroy_extents(const std::set<lba_disk_extent_t *> &extents,
-                         file_account_t *io_account, extent_transaction_t *txn);
+                         file_account_t *io_account, extent_transaction_t *txn,
+                         optional<std::vector<checksum_filerange>> *checksums);
 
     // If you call read(), then the in_memory_index_t will be populated and then the
     // read_callback_t will be called when it is done.
@@ -79,7 +83,8 @@ public:
 
 private:
     /* Prepares and writes a new superblock. */
-    void write_superblock(file_account_t *io_account, extent_transaction_t *txn);
+    void write_superblock(file_account_t *io_account, extent_transaction_t *txn,
+                          optional<std::vector<checksum_filerange>> *checksums);
 
     /* Used during the startup process */
     void on_extent_read();

--- a/src/serializer/log/lba/extent.hpp
+++ b/src/serializer/log/lba/extent.hpp
@@ -2,8 +2,12 @@
 #ifndef SERIALIZER_LOG_LBA_EXTENT_HPP_
 #define SERIALIZER_LOG_LBA_EXTENT_HPP_
 
-#include "serializer/log/extent_manager.hpp"
+#include <vector>
+
+#include "containers/optional.hpp"
 #include "arch/types.hpp"
+#include "serializer/log/extent_manager.hpp"
+#include "serializer/log/types.hpp"
 
 struct extent_block_t;
 
@@ -30,7 +34,8 @@ public:
     };
     void read(size_t pos, size_t length, void *buffer, read_callback_t *);
 
-    void append(void *buffer, size_t length, file_account_t *io_account);
+    void append(void *buffer, size_t length, file_account_t *io_account,
+                optional<std::vector<checksum_filerange>> *checksums);
 
     struct completion_callback_t {
         virtual void on_extent_completion() = 0;

--- a/src/serializer/log/lba/lba_list.hpp
+++ b/src/serializer/log/lba/lba_list.hpp
@@ -60,16 +60,21 @@ public:
     int extent_refcount(int64_t offset);
 #endif
 
-    void set_block_info(block_id_t block, repli_timestamp_t recency,
-                        flagged_off64_t offset, uint16_t ser_block_size,
+    void set_block_info(block_id_t block,
+                        repli_timestamp_t recency,
+                        flagged_off64_t offset,
+                        uint16_t ser_block_size,
                         file_account_t *io_account,
-                        extent_transaction_t *txn);
+                        extent_transaction_t *txn,
+                        optional<std::vector<checksum_filerange>> *checksums);
 
     struct completion_callback_t {
         virtual void on_lba_completion() = 0;
         virtual ~completion_callback_t() {}
     };
-    void write_outstanding(file_account_t *io_account, completion_callback_t *cb);
+    void write_outstanding(file_account_t *io_account,
+                           optional<std::vector<checksum_filerange>> *checksums,
+                           completion_callback_t *cb);
 
     void consider_gc();
 
@@ -114,8 +119,9 @@ private:
     lba_entry_t inline_lba_entries[LBA_NUM_INLINE_ENTRIES];
     int32_t inline_lba_entries_count;
     bool check_inline_lba_full() const;
-    void move_inline_entries_to_extents(file_account_t *io_account,
-                                        extent_transaction_t *txn);
+    void move_inline_entries_to_extents(
+            file_account_t *io_account, extent_transaction_t *txn,
+            optional<std::vector<checksum_filerange>> *checksums);
     void add_inline_entry(block_id_t block, repli_timestamp_t recency,
                           flagged_off64_t offset, uint16_t ser_block_size);
 

--- a/src/serializer/log/metablock.hpp
+++ b/src/serializer/log/metablock.hpp
@@ -2,6 +2,7 @@
 #define SERIALIZER_LOG_METABLOCK_HPP_
 
 #include "serializer/log/lba/disk_format.hpp"
+#include "serializer/log/types.hpp"
 
 // Size of the metablock (in bytes)
 #define METABLOCK_SIZE (4 * KILOBYTE)
@@ -9,19 +10,22 @@
 // How much space to reserve in the metablock to store inline LBA entries.  Make sure
 // that it fits into METABLOCK_SIZE, including all other meta data.  (Defines the disk
 // format!  Can't change unless you're careful.)
-
-// LBA_INLINE_SIZE is 3.5 KB.  You might note, it's a good thing that this value is a
-// bit shy of 8 * 512, in terms of LBA usage.  It being 7*512bytes means that when we do
-// spill over the inline LBA entries into the actual LBA, we'll use 2 device blocks
-// (2*512bytes) in most LBA shards (because LBA_SHARD_FACTOR is 4).  Each shard gets on
-// average 28 entries.  If one gets more than 32 entries, we have spillover (into a
-// third block).  It's a binomial distribution (right?) with mean 28, stddev 4.5, so I
-// suspect we could stand to lower the value of LBA_INLINE_SIZE a tad.  There's some
-// trade-off here that minimizes LBA space usage.  (Lowering the spill threshold doesn't
-// have to change the disk format, either.)
-
+//
 // 3.5 KB
 #define LBA_INLINE_SIZE (METABLOCK_SIZE - 512)
+
+
+/* LBA_INLINE_SIZE is 3.5 KB.  You might note, it's a good thing that this value is a
+   bit shy of 8 * 512, in terms of LBA usage.  It being 7*512bytes means that when we do
+   spill over the inline LBA entries into the actual LBA, we'll use 2 device blocks
+   (2*512bytes) in most LBA shards (because LBA_SHARD_FACTOR is 4).  Each shard gets on
+   average 28 entries.  If one gets more than 32 entries, we have spillover (into a
+   third block).  It's a binomial distribution (right?) with mean 28, stddev 4.5, so I
+   suspect we could stand to lower the value of LBA_INLINE_SIZE a tad.  There's some
+   trade-off here that minimizes LBA space usage.  (Lowering the spill threshold doesn't
+   have to change the disk format, either.) */
+
+
 
 // sizeof(lba_entry_t) is 32, meaning this is 7*2^9/2^5 = 7*2^4 = 112
 // Value is 112.
@@ -70,9 +74,42 @@ ATTR_PACKED(struct log_serializer_metablock_t {
     // Size: 3736 bytes.
 });
 
+// 16 bytes.
+ATTR_PACKED(struct metablock_filerange_t {
+    // A [offset, offset + size) region in the file the fileranges checksum refers to.
+    // The value offset=0, size=0 is used as a garbage value -- any range with size zero
+    // would work.
+    int64_t offset;
+    int64_t size;
+});
+
+typedef int64_t metablock_version_t;
+
+#define METABLOCK_NUM_CHECKSUMS 8
+
+ATTR_PACKED(struct metablock_fileranges_checksum_t {
+    // How many checksum ranges should there be?  Imagine a small write split between
+    // two data extents, all four LBA shards, one LBA superblock (which is in a separate
+    // LBA superblock extent).  That's 7.  We had 4096-3760 = 336 bytes to work with for
+    // this entire struct, with 16 bytes per filerange-checksum.  So, we're stingy, we
+    // go with 8 checksums.
+
+    // The checksum computes the checksum of the concatenation of the data in the
+    // ranges.  (So, we checksum fileranges[0] ++ fileranges[1] ++ ... ++
+    // fileranges[METABLOCK_NUM_CHECKSUMS - 1].)
+    serializer_checksum checksum;
+
+    // Offset: 8, size: 128.
+    metablock_filerange_t fileranges[METABLOCK_NUM_CHECKSUMS];
+
+    // There's no size field -- we look at filerange values from left to right until we
+    // get one with a zero size.
+
+    // Total size: 136.
+});
+
 
 static const char MB_MARKER_MAGIC[8] = {'m', 'e', 't', 'a', 'b', 'l', 'c', 'k'};
-typedef int64_t metablock_version_t;
 
 // This is stored directly to disk.  Changing it will change the disk format.
 ATTR_PACKED(struct crc_metablock_t {
@@ -89,7 +126,11 @@ ATTR_PACKED(struct crc_metablock_t {
     // The value in the metablock (pointing at LBA superblocks, etc).
     log_serializer_metablock_t metablock;
 
-    // Size: 3760 bytes.
+    // Pre-v2_5 version, this field did not exist.  The space was filled with zeros.
+    // Offset: 3760, size: 192.
+    metablock_fileranges_checksum_t fileranges_checksum_v2_5;
+
+    // Total size: 3952 bytes.
 });
 
 

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -11,9 +11,15 @@
 #include "arch/arch.hpp"
 #include "arch/runtime/coroutines.hpp"
 #include "concurrency/cond_var.hpp"
+#include "math.hpp"
 #include "serializer/log/log_serializer.hpp"
 #include "serializer/log/metablock.hpp"
 #include "version.hpp"
+
+metablock_filerange_t padding_filerange() {
+    metablock_filerange_t ret = { 0, 0 };
+    return ret;
+}
 
 namespace crc_metablock {
 uint32_t compute_metablock_crc(const crc_metablock_t *crc_mb) {
@@ -24,13 +30,89 @@ uint32_t compute_metablock_crc(const crc_metablock_t *crc_mb) {
     return crc.checksum();
 }
 
+struct checksum_filerange_less {
+    bool operator()(const checksum_filerange &x, const checksum_filerange &y) const {
+        return x.offset < y.offset;
+    }
+};
+
+// Returns true if we should double-datasync (ranges are all padding).
+bool prepare_checksums(metablock_fileranges_checksum_t *disk_list,
+                       optional<std::vector<checksum_filerange>> &&checksums) {
+    if (!checksums.has_value()) {
+        goto prepare_padding_ranges;
+    }
+
+    if (checksums.has_value()) {
+        // Sort and compactify the checksums.
+        std::vector<checksum_filerange> ranges = std::move(checksums.get());
+        if (ranges.size() == 0) {
+            // Technically there's nothing wrong with having no checksum-ranges, but it
+            // means we are doing a superfluous metablock write.
+            goto prepare_padding_ranges;
+        }
+        std::sort(ranges.begin(), ranges.end(), checksum_filerange_less());
+
+        size_t merge_ix = 0;
+
+        for (size_t i = 1; i < ranges.size(); ++i) {
+            if (ranges[merge_ix].offset + ranges[merge_ix].size == ranges[i].offset) {
+                serializer_checksum concat
+                    = compute_checksum_concat(ranges[merge_ix].checksum,
+                                              ranges[i].checksum,
+                                              uint64_t(ranges[i].size) / serializer_checksum::word_size);
+                ranges[merge_ix].size += ranges[i].size;
+                ranges[merge_ix].checksum = concat;
+            } else {
+                ++merge_ix;
+                ranges[merge_ix] = ranges[i];
+            }
+        }
+
+        size_t checksum_count = merge_ix + 1;
+        if (checksum_count > METABLOCK_NUM_CHECKSUMS) {
+            goto prepare_padding_ranges;
+        }
+
+        serializer_checksum combined_sum = identity_checksum();
+        for (size_t i = 0; i < checksum_count; ++i) {
+            combined_sum = compute_checksum_concat(combined_sum, ranges[i].checksum,
+                                                   ranges[i].size / serializer_checksum::word_size);
+            metablock_filerange_t range = { ranges[i].offset, ranges[i].size };
+            disk_list->fileranges[i] = range;
+        }
+        metablock_filerange_t zero_range = padding_filerange();
+        for (size_t i = checksum_count; i < METABLOCK_NUM_CHECKSUMS; ++i) {
+            disk_list->fileranges[i] = zero_range;
+        }
+        disk_list->checksum = combined_sum;
+        return false;
+    }
+
+
+ prepare_padding_ranges:
+    metablock_filerange_t zero_range = padding_filerange();
+    for (size_t i = 0; i < METABLOCK_NUM_CHECKSUMS; ++i) {
+        disk_list->fileranges[i] = zero_range;
+    }
+    disk_list->checksum = identity_checksum();
+    return true;
+}
+
 // crc_mb->metablock is already initialized, the rest of the metablock is zero-filled.
-void prepare(crc_metablock_t *crc_mb, uint32_t _disk_format_version,
-             metablock_version_t vers) {
+// Returns true if we should double-datasync.
+bool prepare(crc_metablock_t *crc_mb, uint32_t _disk_format_version,
+             metablock_version_t vers,
+             optional<std::vector<checksum_filerange>> &&checksums) {
     crc_mb->disk_format_version = _disk_format_version;
     memcpy(crc_mb->magic_marker, MB_MARKER_MAGIC, sizeof(MB_MARKER_MAGIC));
     crc_mb->version = vers;
+
+    bool double_datasync = prepare_checksums(&crc_mb->fileranges_checksum_v2_5,
+                                             std::move(checksums));
+
     crc_mb->_crc = compute_metablock_crc(crc_mb);
+    return double_datasync;
 }
 
 bool check_crc(const crc_metablock_t *crc_mb) {
@@ -120,20 +202,22 @@ void metablock_manager_t::create(
         // metablock.
         dbfile->write_async(metablock_offsets::get(extent_size, i),
                             METABLOCK_SIZE, buffer.get(),
-                            DEFAULT_DISK_ACCOUNT, &callback, file_t::NO_DATASYNCS);
+                            DEFAULT_DISK_ACCOUNT, &callback, datasync_op::no_datasyncs);
     }
     callback.wait();
 
     buffer = std::move(initial);
 
+    optional<std::vector<checksum_filerange>> checksums = r_nullopt;
     /* Write the first metablock */
     // We use cluster_version_t::LATEST_DISK.  Maybe we'd want to decouple cluster
     // versions from disk format versions?  We can do that later if we want.
     crc_metablock::prepare(buffer.get(),
                            static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
-                           MB_START_VERSION);
+                           MB_START_VERSION,
+                           std::move(checksums));
     co_write(dbfile, metablock_offsets::get(extent_size, 0), METABLOCK_SIZE, buffer.get(),
-             DEFAULT_DISK_ACCOUNT, file_t::WRAP_IN_DATASYNCS);
+             DEFAULT_DISK_ACCOUNT, datasync_op::wrap_in_datasyncs);
 }
 
 bool disk_format_version_is_recognized(uint32_t disk_format_version) {
@@ -164,6 +248,71 @@ bool disk_format_version_is_recognized(uint32_t disk_format_version) {
             static_cast<uint32_t>(cluster_version_t::v2_5_is_latest_disk);
 }
 
+bool metablock_manager_t::verify_checksum_fileranges(const crc_metablock_t *mb) {
+    if (!disk_format_version_is_recognized(mb->disk_format_version)) {
+        fail_due_to_user_error(
+                "Data version not recognized. Is the data "
+                "directory from a newer version of RethinkDB? "
+                "(version on disk: %" PRIu32 ")",
+                mb->disk_format_version);
+    }
+
+    if (mb->disk_format_version != static_cast<uint32_t>(cluster_version_t::v2_5_is_latest_disk)) {
+        // There are no checksums.
+        return true;
+    }
+
+    // (These file ranges are supposed to be a small amount of data that we can load
+    // into memory all at once.)
+
+    std::vector<scoped_device_block_aligned_ptr_t<char>> bufs;
+
+    struct : public iocallback_t, public cond_t {
+        size_t refcount;
+        void on_io_complete() {
+            refcount--;
+            if (refcount == 0) { pulse(); }
+        }
+    } callback;
+    // Start refcount at 1, call on_io_complete() at end of loop.
+    callback.refcount = 1;
+
+    int64_t total_read = 0;
+    const metablock_fileranges_checksum_t *disk_list = &mb->fileranges_checksum_v2_5;
+    size_t num_fileranges = 0;
+    for (; num_fileranges < METABLOCK_NUM_CHECKSUMS; ++num_fileranges) {
+        const metablock_filerange_t *range = &disk_list->fileranges[num_fileranges];
+        if (range->size == 0) {
+            guarantee(range->offset == 0);
+            break;
+        }
+        guarantee(divides(DEVICE_BLOCK_SIZE, range->offset));
+        guarantee(divides(DEVICE_BLOCK_SIZE, range->size));
+        bufs.push_back(scoped_device_block_aligned_ptr_t<char>(range->size));
+        total_read += range->size;
+        callback.refcount++;
+        dbfile->read_async(range->offset, range->size, bufs.back().get(),
+                           DEFAULT_DISK_ACCOUNT, &callback);
+    }
+
+    callback.on_io_complete();
+    callback.wait();
+    extent_manager->stats->bytes_read(total_read);
+
+    serializer_checksum combined_sum = identity_checksum();
+    for (size_t i = 0; i < num_fileranges; ++i) {
+        serializer_checksum x = compute_checksum(
+                bufs[i].get(),
+                disk_list->fileranges[i].size / serializer_checksum::word_size);
+        combined_sum = compute_checksum_concat(
+                combined_sum, x,
+                disk_list->fileranges[i].size / serializer_checksum::word_size);
+    }
+    if (combined_sum.value != disk_list->checksum.value) {
+        return false;
+    }
+    return true;
+}
 
 void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found_out,
                                             log_serializer_metablock_t *mb_out) {
@@ -199,22 +348,19 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found_out,
     callback.wait();
     extent_manager->stats->bytes_read(METABLOCK_SIZE * metablock_offsets::count(extent_size));
 
-    static_assert(MB_BAD_VERSION < 0, "MB_BAD_VERSION is not -1, not signed int64_t");
-    metablock_version_t max_version = MB_BAD_VERSION;
-    size_t max_index = SIZE_MAX;
+    static_assert(MB_BAD_VERSION < 0, "MB_BAD_VERSION is not -1, not unsigned");
+    std::vector<std::pair<metablock_version_t, size_t>> indices_by_version;
+    indices_by_version.reserve(num_metablocks);
 
     for (size_t i = 0; i < num_metablocks; ++i) {
         crc_metablock_t *mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + i * METABLOCK_SIZE);
         if (crc_metablock::check_crc(mb)) {
-            guarantee(mb->version != max_version);
-            if (mb->version > max_version) {
-                max_version = mb->version;
-                max_index = i;
-            }
+            guarantee(mb->version != MB_BAD_VERSION);
+            indices_by_version.push_back(std::make_pair(mb->version, i));
         }
     }
 
-    if (max_index == SIZE_MAX) {
+    if (indices_by_version.empty()) {
         /* no metablock found anywhere -- the DB is toast */
         next_version_number = MB_START_VERSION;
         *mb_found_out = false;
@@ -222,20 +368,40 @@ void metablock_manager_t::co_start_existing(file_t *file, bool *mb_found_out,
         /* The log serializer will catastrophically fail when it sees that mb_found is
            false. */
     } else {
-        crc_metablock_t *latest_crc_mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + max_index * METABLOCK_SIZE);
-        if (!disk_format_version_is_recognized(latest_crc_mb->disk_format_version)) {
-            fail_due_to_user_error(
-                    "Data version not recognized. Is the data "
-                    "directory from a newer version of RethinkDB? "
-                    "(version on disk: %" PRIu32 ")",
-                    latest_crc_mb->disk_format_version);
+        std::sort(indices_by_version.begin(), indices_by_version.end());
+        size_t n = indices_by_version.size() - 1;
+        size_t index = indices_by_version[n].second;
+
+        crc_metablock_t *latest_crc_mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + index * METABLOCK_SIZE);
+
+        if (verify_checksum_fileranges(latest_crc_mb)) {
+            // We found a metablock.
+            next_version_number = indices_by_version[n].first + 1;
+            next_mb_slot = metablock_offsets::next(extent_size, index);
+            *mb_found_out = true;
+            memcpy(mb_out, &latest_crc_mb->metablock, sizeof(log_serializer_metablock_t));
+        } else {
+            if (indices_by_version.size() == 1) {
+                /* no metablock found anywhere -- the DB is toast */
+                next_version_number = MB_START_VERSION;
+                *mb_found_out = false;
+
+                /* The log serializer will catastrophically fail when it sees that
+                   mb_found is false. */
+            } else {
+                n -= 1;
+                // Yes, we found a metablock.  Since a datasync happened after it was
+                // written, we don't need to verify filerange checksums.
+                index = indices_by_version[n].second;
+                latest_crc_mb = reinterpret_cast<crc_metablock_t *>(lbm.get() + index * METABLOCK_SIZE);
+
+                next_version_number = indices_by_version[n].first + 1;
+                next_mb_slot = metablock_offsets::next(extent_size, index);
+                *mb_found_out = true;
+                memcpy(mb_out, &latest_crc_mb->metablock, sizeof(log_serializer_metablock_t));
+            }
         }
 
-        // We found a metablock.
-        next_version_number = max_version + 1;
-        next_mb_slot = metablock_offsets::next(extent_size, max_index);
-        *mb_found_out = true;
-        memcpy(mb_out, &latest_crc_mb->metablock, sizeof(log_serializer_metablock_t));
     }
 
     state = state_ready;
@@ -257,24 +423,29 @@ bool metablock_manager_t::start_existing(
     return false;
 }
 
-// crc_mb is zero-initialized.
+// crc_mb.get() is zero-initialized, with crc_mb->metablock initialized.
 void metablock_manager_t::co_write_metablock(
         const scoped_device_block_aligned_ptr_t<crc_metablock_t> &crc_mb,
-        file_account_t *io_account) {
+        file_account_t *io_account,
+        optional<std::vector<checksum_filerange>> &&checksums) {
     mutex_t::acq_t hold(&write_lock);
 
     rassert(state == state_ready);
 
-    crc_metablock::prepare(crc_mb.get(),
-                           static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
-                           next_version_number++);
+    bool double_datasync
+        = crc_metablock::prepare(crc_mb.get(),
+                                 static_cast<uint32_t>(cluster_version_t::LATEST_DISK),
+                                 next_version_number++,
+                                 std::move(checksums));
     rassert(crc_metablock::check_crc(crc_mb.get()));
 
     state = state_writing;
     int64_t offset = metablock_offsets::get(extent_manager->extent_size, next_mb_slot);
     next_mb_slot = metablock_offsets::next(extent_manager->extent_size, next_mb_slot);
     co_write(dbfile, offset, METABLOCK_SIZE, crc_mb.get(), io_account,
-             file_t::WRAP_IN_DATASYNCS);
+             double_datasync
+             ? datasync_op::wrap_in_datasyncs
+             : datasync_op::datasync_after);
 
     state = state_ready;
     extent_manager->stats->bytes_written(METABLOCK_SIZE);
@@ -283,17 +454,19 @@ void metablock_manager_t::co_write_metablock(
 void metablock_manager_t::write_metablock_callback(
         const scoped_device_block_aligned_ptr_t<crc_metablock_t> *mb,
         file_account_t *io_account,
+        optional<std::vector<checksum_filerange>> *checksums,
         metablock_write_callback_t *cb) {
-    co_write_metablock(*mb, io_account);
+    co_write_metablock(*mb, io_account, std::move(*checksums));
     cb->on_metablock_write();
 }
 
 void metablock_manager_t::write_metablock(
         const scoped_device_block_aligned_ptr_t<crc_metablock_t> &crc_mb,
         file_account_t *io_account,
+        optional<std::vector<checksum_filerange>> &&checksums,
         metablock_write_callback_t *cb) {
     coro_t::spawn_later_ordered(std::bind(&metablock_manager_t::write_metablock_callback,
-                                          this, &crc_mb, io_account, cb));
+                                          this, &crc_mb, io_account, &checksums, cb));
 }
 
 void metablock_manager_t::shutdown() {

--- a/src/serializer/log/metablock_manager.hpp
+++ b/src/serializer/log/metablock_manager.hpp
@@ -56,9 +56,11 @@ public:
     // crc_mb->metablock must be initialized, the rest zeroed, DEVICE_BLOCK_SIZE-aligned.
     void write_metablock(const scoped_device_block_aligned_ptr_t<crc_metablock_t> &crc_mb,
                          file_account_t *io_account,
+                         optional<std::vector<checksum_filerange>> &&checksums,
                          metablock_write_callback_t *cb);
     void co_write_metablock(const scoped_device_block_aligned_ptr_t<crc_metablock_t> &mb,
-                            file_account_t *io_account);
+                            file_account_t *io_account,
+                            optional<std::vector<checksum_filerange>> &&checksums);
 
     void shutdown();
 
@@ -70,7 +72,10 @@ private:
     void write_metablock_callback(
             const scoped_device_block_aligned_ptr_t<crc_metablock_t> *mb,
             file_account_t *io_account,
+            optional<std::vector<checksum_filerange>> *checksums,
             metablock_write_callback_t *cb);
+
+    bool verify_checksum_fileranges(const crc_metablock_t *mb);
 
     // Only one metablock write can happen at a time.  This isn't necessarily a
     // desirable thing, but that's how this type works.

--- a/src/serializer/log/static_header.cc
+++ b/src/serializer/log/static_header.cc
@@ -54,7 +54,7 @@ void co_static_header_write(file_t *file, void *data, size_t data_size) {
     // We want to follow up the static header write with a datasync, because... it's the
     // most important block in the file!
     co_write(file, 0, DEVICE_BLOCK_SIZE, buffer.get(), DEFAULT_DISK_ACCOUNT,
-             file_t::WRAP_IN_DATASYNCS);
+             datasync_op::wrap_in_datasyncs);
 }
 
 void co_static_header_write_helper(file_t *file, static_header_write_callback_t *cb,

--- a/src/serializer/log/types.hpp
+++ b/src/serializer/log/types.hpp
@@ -1,0 +1,16 @@
+#ifndef SERIALIZER_LOG_TYPES_HPP_
+#define SERIALIZER_LOG_TYPES_HPP_
+
+#include <stdint.h>
+
+#include "serializer/checksum.hpp"
+
+struct checksum_filerange {
+    int64_t offset;
+    int64_t size;
+    // has_checksum(checksum) is always true.
+    serializer_checksum checksum;
+};
+
+
+#endif  // SERIALIZER_LOG_TYPES_HPP_

--- a/src/serializer/translator.cc
+++ b/src/serializer/translator.cc
@@ -27,8 +27,9 @@ int compute_mod_count(int32_t file_number, int32_t n_files, int32_t n_slices) {
     return n_slices / n_files + (n_slices % n_files > file_number);
 }
 
-counted_t<block_token_t> serializer_block_write(serializer_t *ser, const buf_ptr_t &buf,
-                                                         block_id_t block_id, file_account_t *io_account) {
+counted_t<block_token_t>
+serializer_block_write(serializer_t *ser, const buf_ptr_t &buf,
+                       block_id_t block_id, file_account_t *io_account) {
     struct : public cond_t, public iocallback_t {
         void on_io_complete() { pulse(); }
     } cb;
@@ -249,9 +250,8 @@ void translator_serializer_t::index_write(
     inner->index_write(mutex_acq, on_writes_reflected, translated_ops);
 }
 
-std::vector<counted_t<block_token_t> >
-translator_serializer_t::block_writes(const buf_write_info_t *write_infos,
-                                      size_t write_infos_count,
+std::vector<counted_t<block_token_t>>
+translator_serializer_t::block_writes(const buf_write_info_t *write_infos, size_t write_infos_count,
                                       file_account_t *io_account, iocallback_t *cb) {
     std::vector<buf_write_info_t> tmp;
     tmp.reserve(write_infos_count);

--- a/src/serializer/types.hpp
+++ b/src/serializer/types.hpp
@@ -12,6 +12,7 @@
 #include "containers/counted.hpp"
 #include "containers/scoped.hpp"
 #include "errors.hpp"
+#include "serializer/checksum.hpp"
 #include "valgrind.hpp"
 
 // A relatively "lightweight" header file (we wish), in a sense.
@@ -137,6 +138,7 @@ public:
 
 private:
     friend class log_serializer_t;
+    friend class data_block_manager_t;
     friend class dbm_read_ahead_fsm_t;  // For read-ahead tokens.
 
     friend void counted_add_ref(block_token_t *p);
@@ -151,6 +153,15 @@ private:
 
     // The block's size.
     block_size_t block_size_;
+
+    // Either (a.) a checksum of what the block's on-disk contents should be, (b.)(i.)
+    // the value datasync_checksum(), which means the block's write has been datasynced,
+    // or (b.)(ii.) the value no_checksum(), which means the block is not known to have
+    // been datasynced.
+    //
+    // This holds the checksum of the DEVICE_BLOCK_SIZE-aligned block, with padding
+    // included.
+    serializer_checksum checksum_;
 
     // The block's offset on disk.
     int64_t offset_;

--- a/src/unittest/disk_conflict_resolution.cc
+++ b/src/unittest/disk_conflict_resolution.cc
@@ -163,7 +163,8 @@ struct write_test_t {
         offset(o),
         data(d.begin(), d.end()),
         action(driver->make_action()) {
-        action->make_write(IRRELEVANT_DEFAULT_FD, data.data(), d.size(), o, false);
+        action->make_write(IRRELEVANT_DEFAULT_FD, data.data(), d.size(), o,
+                           datasync_op::no_datasyncs);
         driver->submit(action);
     }
 
@@ -195,7 +196,7 @@ struct resize_test_t {
         : driver(_driver),
           action(driver->make_action()) {
         action->make_resize(
-            IRRELEVANT_DEFAULT_FD, _old_size, _new_size, false);
+                IRRELEVANT_DEFAULT_FD, _old_size, _new_size, datasync_op::no_datasyncs);
         driver->submit(action);
     }
 

--- a/src/unittest/disk_format_test.cc
+++ b/src/unittest/disk_format_test.cc
@@ -108,6 +108,12 @@ TEST(DiskFormatTest, ExtentManagerMetablockMixinT) {
     EXPECT_EQ(8u, sizeof(extent_manager_metablock_mixin_t));
 }
 
+TEST(DiskFormatTest, MetablockFilerangeChecksumListT) {
+    EXPECT_EQ(16u, sizeof(metablock_filerange_t));
+    EXPECT_EQ(8u, offsetof(metablock_fileranges_checksum_t, fileranges));
+    EXPECT_EQ(136u, sizeof(metablock_fileranges_checksum_t));
+}
+
 TEST(DiskFormatTest, LogSerializerMetablockT) {
     size_t n = 0;
     EXPECT_EQ(n, offsetof(log_serializer_metablock_t, extent_manager_part));
@@ -139,6 +145,9 @@ TEST(DiskFormatTest, CrcMetablockT) {
     EXPECT_EQ(n, offsetof(crc_metablock_t, metablock));
     n += 3736;
     EXPECT_EQ(3760, n);
+    EXPECT_EQ(n, offsetof(crc_metablock_t, fileranges_checksum_v2_5));
+    n += 136;
+    EXPECT_EQ(3896, n);
     EXPECT_EQ(n, sizeof(crc_metablock_t));
 }
 

--- a/src/unittest/mock_file.cc
+++ b/src/unittest/mock_file.cc
@@ -47,7 +47,7 @@ void mock_file_t::read_async(int64_t offset, size_t length, void *buf,
 
 void mock_file_t::write_async(int64_t offset, size_t length, const void *buf,
                               UNUSED file_account_t *account, linux_iocallback_t *cb,
-                              UNUSED wrap_in_datasyncs_t wrap_in_datasyncs) {
+                              UNUSED datasync_op ds_op) {
     guarantee(mode_ & mode_write);
     verify_aligned_file_access(data_->size(), offset, length, buf);
     guarantee(!(offset < 0
@@ -68,7 +68,7 @@ void mock_file_t::writev_async(int64_t offset, size_t length, scoped_array_t<iov
     iovec bufvec[1] = { { buf.get(), length } };
     fill_bufs_from_source(bufvec, 1, bufs.data(), bufs.size(), 0);
 
-    write_async(offset, length, buf.get(), account, cb, NO_DATASYNCS);
+    write_async(offset, length, buf.get(), account, cb, datasync_op::no_datasyncs);
 }
 
 bool mock_file_t::coop_lock_and_check() {

--- a/src/unittest/mock_file.hpp
+++ b/src/unittest/mock_file.hpp
@@ -28,7 +28,7 @@ public:
                     file_account_t *account, linux_iocallback_t *cb);
     void write_async(int64_t offset, size_t length, const void *buf,
                      file_account_t *account, linux_iocallback_t *cb,
-                     wrap_in_datasyncs_t wrap_in_datasyncs);
+                     datasync_op ds_op);
     void writev_async(int64_t offset, size_t length, scoped_array_t<iovec> &&bufs,
                       file_account_t *account, linux_iocallback_t *cb);
 

--- a/src/unittest/serializer_test.cc
+++ b/src/unittest/serializer_test.cc
@@ -47,7 +47,7 @@ void run_AddDeleteRepeatedly(bool perform_index_write) {
             }
         } cb;
 
-        std::vector<counted_t<block_token_t> > tokens
+        std::vector<counted_t<block_token_t>> tokens
             = ser.block_writes(infos.data(), infos.size(), account.get(), &cb);
 
         // Wait for it to be written (because we're nice).


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Adds serializer checksumming as described in http://samuelhughes.com/blog/7.html

Note that we checksum block writes when they come into the serializer less than 64 KB at a time.  Particularly noteworthy is that with the new flush interval behavior for soft durability writes (which is sitting in pull request #6392), we won't wastefully checksum blocks of small soft durability writes.

The parameter 64 KB has not been tuned.  You might want to adjust it.

Also, the advantages of using 2x32-bit Fletcher checksums versus 4x16-bit Fletcher is something I have not investigated.  I think ZFS or XFS or something uses 4x16-bit -- maybe they had a reason.

In the long-run, note that you could checksum blocks "earlier" when they've been recently processed by the CPU (so they're fresh in cache), and we could differentially update a checksum when modifying portions of a b-tree node (so we don't have to load the entire 4K block into L1 cache).  That's one thing Fletcher checksums get for you.