### PR TITLE
Avoid some uses of wall-clock time

### DIFF
--- a/src/arch/io/disk/stats_2.cc
+++ b/src/arch/io/disk/stats_2.cc
@@ -6,8 +6,8 @@
 
 void debug_print(printf_buffer_t *buf,
                  const stats_diskmgr_2_action_t &action) {
-    buf->appendf("stats_diskmgr_2_action{start_time=%" PRIu64 "}<",
-                 action.start_time);
+    buf->appendf("stats_diskmgr_2_action{start_time=%" PRIi64 "}<",
+                 action.start_time.nanos);
     const pool_diskmgr_t::action_t &parent_action = action;
     debug_print(buf, parent_action);
 }

--- a/src/arch/io/timer/timer_kqueue_provider.cc
+++ b/src/arch/io/timer/timer_kqueue_provider.cc
@@ -32,7 +32,7 @@ timer_kqueue_provider_t::~timer_kqueue_provider_t() {
 }
 
 void timer_kqueue_provider_t::schedule_oneshot(const int64_t next_time_in_nanos, timer_provider_callback_t *const cb) {
-    const int64_t time_difference = next_time_in_nanos - static_cast<int64_t>(get_ticks());
+    const int64_t time_difference = next_time_in_nanos - get_ticks().nanos;
     const int64_t wait_nanos = std::max<int64_t>(1, time_difference);
 
     struct kevent64_s event;

--- a/src/arch/io/timer/timer_signal_provider.cc
+++ b/src/arch/io/timer/timer_signal_provider.cc
@@ -70,7 +70,7 @@ void timer_signal_provider_t::schedule_oneshot(int64_t next_time_in_nanos, timer
     // relative timer, but that would make our code fragilely depend on get_ticks() using
     // CLOCK_MONOTONIC.
 
-    const int64_t ticks = get_ticks();
+    const int64_t ticks = get_ticks().nanos;
     const int64_t time_diff = next_time_in_nanos - ticks;
     const int64_t wait_time = std::max<int64_t>(1, time_diff);
 

--- a/src/arch/io/timer/timer_windows_provider.cc
+++ b/src/arch/io/timer/timer_windows_provider.cc
@@ -26,7 +26,7 @@ timer_windows_provider_t::~timer_windows_provider_t() {
 }
 
 void timer_windows_provider_t::schedule_oneshot(const int64_t next_time_in_nanos, timer_provider_callback_t *const cb) {
-    debugf_timer("[%p] scheduled in %" PRIi64 "ns\n", this, next_time_in_nanos - get_ticks());
+    debugf_timer("[%p] scheduled in %" PRIi64 "ns\n", this, next_time_in_nanos - get_ticks().nanos);
     event_queue->reset_timer(next_time_in_nanos, cb);
 }
 

--- a/src/arch/io/timer/timerfd_provider.cc
+++ b/src/arch/io/timer/timerfd_provider.cc
@@ -39,7 +39,7 @@ void timerfd_provider_t::schedule_oneshot(const int64_t next_time_in_nanos, time
     // but that would mean this code depends on the fact that get_ticks() is implemented in terms of
     // CLOCK_MONOTONIC.
 
-    const int64_t time_difference = next_time_in_nanos - static_cast<int64_t>(get_ticks());
+    const int64_t time_difference = next_time_in_nanos - get_ticks().nanos;
     const int64_t wait_nanos = std::max<int64_t>(1, time_difference);
 
     struct itimerspec spec;

--- a/src/arch/timer.cc
+++ b/src/arch/timer.cc
@@ -45,7 +45,7 @@ void timer_handler_t::on_oneshot() {
     // If the timer_provider tends to return its callback a touch early, we don't want to make a
     // bunch of calls to it, returning a tad early over and over again, leading up to a ticks
     // threshold.  So we bump the real time up to the threshold when processing the priority queue.
-    int64_t real_ticks = get_ticks();
+    int64_t real_ticks = get_ticks().nanos;
     int64_t ticks = std::max(real_ticks, expected_oneshot_time_in_nanos);
 
     while (!token_queue.empty() && token_queue.peek()->next_time_in_nanos <= ticks) {
@@ -76,7 +76,7 @@ timer_token_t *timer_handler_t::add_timer_internal(const int64_t ms, timer_callb
     const int64_t nanos = ms * MILLION;
     rassert(nanos > 0);
 
-    const int64_t next_time_in_nanos = get_ticks() + nanos;
+    const int64_t next_time_in_nanos = get_ticks().nanos + nanos;
 
     timer_token_t *const token = new timer_token_t;
     token->interval_nanos = once ? 0 : nanos;

--- a/src/buffer_cache/cache_balancer.cc
+++ b/src/buffer_cache/cache_balancer.cc
@@ -9,7 +9,7 @@
 
 const uint64_t alt_cache_balancer_t::rebalance_check_interval_ms = 20;
 const uint64_t alt_cache_balancer_t::rebalance_access_count_threshold = 100;
-const uint64_t alt_cache_balancer_t::rebalance_timeout_ms = 500;
+const int64_t alt_cache_balancer_t::rebalance_timeout_ms = 500;
 
 const double alt_cache_balancer_t::read_ahead_proportion = 0.9;
 
@@ -25,14 +25,14 @@ alt_cache_balancer_t::alt_cache_balancer_t(
     total_cache_size_watchable(_total_cache_size_watchable),
     rebalance_timer(make_scoped<repeating_timer_t>(rebalance_check_interval_ms, this)),
     rebalance_timer_state(rebalance_timer_state_t::normal),
-    last_rebalance_time(0),
+    last_rebalance_time{0},
     read_ahead_ok(true),
     bytes_toward_read_ahead_limit(0),
     per_thread_data(get_num_threads()),
     rebalance_pumper([this](signal_t *interruptor) { rebalance_blocking(interruptor); }),
     cache_size_change_subscription(
         [this]() {
-            last_rebalance_time = 0;
+            last_rebalance_time = kiloticks_t{0};
             wake_up_activity_happened();
             rebalance_pumper.notify();
         })
@@ -137,9 +137,9 @@ void alt_cache_balancer_t::rebalance_blocking(UNUSED signal_t *interruptor) {
     //  1. At least rebalance_timeout_ms milliseconds have passed
     //  2. At least access_count_threshold accesses have occurred
     // since the last rebalance.
-    microtime_t now = current_microtime();
+    kiloticks_t now = get_kiloticks();
 
-    if (now < last_rebalance_time + (rebalance_timeout_ms * 1000) &&
+    if (now.micros < last_rebalance_time.micros + (rebalance_timeout_ms * 1000) &&
         total_access_count < rebalance_access_count_threshold) {
         rebalance_timer_state = rebalance_timer_state_t::normal;
         return;

--- a/src/buffer_cache/cache_balancer.hpp
+++ b/src/buffer_cache/cache_balancer.hpp
@@ -110,7 +110,7 @@ private:
 
     // Constants to control how often we rebalance
     static const uint64_t rebalance_access_count_threshold;
-    static const uint64_t rebalance_timeout_ms;
+    static const int64_t rebalance_timeout_ms;
     static const uint64_t rebalance_check_interval_ms;
 
     // Controls how much read ahead is allowed out of total cache size
@@ -170,7 +170,7 @@ private:
     };
     rebalance_timer_state_t rebalance_timer_state;
 
-    microtime_t last_rebalance_time;
+    kiloticks_t last_rebalance_time;
     bool read_ahead_ok;
     uint64_t bytes_toward_read_ahead_limit;
 

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -710,14 +710,14 @@ void query_server_t::handle(const http_req_t &req,
                 ticks_t start = get_ticks();
                 // We don't throttle HTTP queries.
                 handler->run_query(query.get(), &response, &true_interruptor);
-                ticks_t ticks = get_ticks() - start;
+                ticks_t ticks = ticks_t{get_ticks().nanos - start.nanos};
 
                 if (!response.profile()) {
                     ql::datum_array_builder_t array_builder(
                         ql::configured_limits_t::unlimited);
                     ql::datum_object_builder_t object_builder;
                     object_builder.overwrite("duration(ms)",
-                        ql::datum_t(static_cast<double>(ticks) / MILLION));
+                        ql::datum_t(static_cast<double>(ticks.nanos) / MILLION));
                     array_builder.add(std::move(object_builder).to_datum());
                     response.set_profile(std::move(array_builder).to_datum());
                 }

--- a/src/clustering/administration/jobs/manager.cc
+++ b/src/clustering/administration/jobs/manager.cc
@@ -69,9 +69,12 @@ void jobs_manager_t::on_get_job_reports(
 
     auto lock = drainer.lock();
 
-    // Note, as `time` is retrieved here a job may actually report to be started after
-    // fetching the time, leading to a negative duration which we round to zero.
+    // Note, as `time` (or `kticks`) is retrieved here a job may actually report to be
+    // started after fetching the time, leading to a negative duration which we round to
+    // zero.
     microtime_t time = current_microtime();
+    // We have some microtime_t values and we also have some kiloticks_t values.
+    kiloticks_t kticks = get_kiloticks();
 
     pmap(get_num_threads(), [&](int32_t threadnum) {
         // Here we need to store `query_job_report_t` locally to prevent multiple threads
@@ -93,7 +96,7 @@ void jobs_manager_t::on_get_job_reports(
 
                     query_job_reports_inner.emplace_back(
                         pair.second->job_id,
-                        time - std::min(pair.second->start_time, time),
+                        kticks.micros - std::min(pair.second->start_time.micros, kticks.micros),
                         server_id,
                         query_cache->get_client_addr_port(),
                         std::move(render),

--- a/src/clustering/administration/tables/generate_config.cc
+++ b/src/clustering/administration/tables/generate_config.cc
@@ -18,7 +18,7 @@ public:
     void maybe_yield(signal_t *interruptor) {
         ticks_t now = get_ticks();
         /* We yield every 10ms. */
-        if (now > t + secs_to_ticks(1) / 100) {
+        if (now.nanos > t.nanos + secs_to_ticks(1).nanos / 100) {
             coro_t::yield();
             t = now;
         }

--- a/src/concurrency/watchdog_timer.cc
+++ b/src/concurrency/watchdog_timer.cc
@@ -48,7 +48,7 @@ void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
     try {
         for (;;) {
             ticks_t now = get_ticks();
-            if (now > next_threshold) {
+            if (now.nanos > next_threshold.nanos) {
                 ASSERT_NO_CORO_WAITING;
                 if (num_blockers == 0) {
                     state = state_t::TRIGGERED;
@@ -59,13 +59,13 @@ void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
                 /* Wait a bit before calling `callback()` again */
                 set_next_threshold();
             }
-            if (next_threshold > now + max_timeout_ms * MILLION) {
+            if (next_threshold.nanos > now.nanos + max_timeout_ms * MILLION) {
                 /* This can only happen if the system clock goes backwards. Rather than
                 wait until the system clock catches up to its old value, we reset
                 `next_threshold` to only `max_timeout_ms` in the future. */
-                next_threshold = now + max_timeout_ms * MILLION;
+                next_threshold.nanos = now.nanos + max_timeout_ms * MILLION;
             }
-            nap((next_threshold - now) / MILLION, keepalive.get_drain_signal());
+            nap((next_threshold.nanos - now.nanos) / MILLION, keepalive.get_drain_signal());
         }
     } catch (const interrupted_exc_t &) {
         /* `watchdog_timer_t` is being destroyed */
@@ -74,6 +74,6 @@ void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
 
 void watchdog_timer_t::set_next_threshold() {
     int timeout_ms = min_timeout_ms + randint(max_timeout_ms - min_timeout_ms + 1);
-    next_threshold = get_ticks() + timeout_ms * MILLION;
+    next_threshold = ticks_t{get_ticks().nanos + timeout_ms * MILLION};
 }
 

--- a/src/concurrency/watchdog_timer.cc
+++ b/src/concurrency/watchdog_timer.cc
@@ -47,7 +47,7 @@ void watchdog_timer_t::notify() {
 void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
     try {
         for (;;) {
-            microtime_t now = current_microtime();
+            ticks_t now = get_ticks();
             if (now > next_threshold) {
                 ASSERT_NO_CORO_WAITING;
                 if (num_blockers == 0) {
@@ -59,13 +59,13 @@ void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
                 /* Wait a bit before calling `callback()` again */
                 set_next_threshold();
             }
-            if (next_threshold > now + max_timeout_ms * 1000) {
+            if (next_threshold > now + max_timeout_ms * MILLION) {
                 /* This can only happen if the system clock goes backwards. Rather than
                 wait until the system clock catches up to its old value, we reset
                 `next_threshold` to only `max_timeout_ms` in the future. */
-                next_threshold = now + max_timeout_ms * 1000;
+                next_threshold = now + max_timeout_ms * MILLION;
             }
-            nap((next_threshold - now) / 1000, keepalive.get_drain_signal());
+            nap((next_threshold - now) / MILLION, keepalive.get_drain_signal());
         }
     } catch (const interrupted_exc_t &) {
         /* `watchdog_timer_t` is being destroyed */
@@ -74,6 +74,6 @@ void watchdog_timer_t::run(auto_drainer_t::lock_t keepalive) {
 
 void watchdog_timer_t::set_next_threshold() {
     int timeout_ms = min_timeout_ms + randint(max_timeout_ms - min_timeout_ms + 1);
-    next_threshold = current_microtime() + timeout_ms * 1000;
+    next_threshold = get_ticks() + timeout_ms * MILLION;
 }
 

--- a/src/concurrency/watchdog_timer.hpp
+++ b/src/concurrency/watchdog_timer.hpp
@@ -46,10 +46,10 @@ private:
     void set_next_threshold();
     int min_timeout_ms, max_timeout_ms;
     std::function<void()> callback;
-    microtime_t next_threshold;
+    ticks_t next_threshold;
     int num_blockers;
     state_t state;
-    
+
     auto_drainer_t drainer;
 };
 

--- a/src/extproc/js_runner.cc
+++ b/src/extproc/js_runner.cc
@@ -57,10 +57,10 @@ public:
 
     struct func_info_t {
         explicit func_info_t(js_id_t _id) :
-            id(_id), timestamp(current_microtime()) { }
+            id(_id), timestamp(get_kiloticks()) { }
 
         js_id_t id;
-        microtime_t timestamp;
+        kiloticks_t timestamp;
     };
 
     std::map<std::string, func_info_t> id_cache;
@@ -250,7 +250,7 @@ void js_runner_t::trim_cache() {
 
     auto oldest_func = job_data->id_cache.begin();
     for (auto it = ++job_data->id_cache.begin(); it != job_data->id_cache.end(); ++it) {
-        if (it->second.timestamp < oldest_func->second.timestamp) {
+        if (it->second.timestamp.micros < oldest_func->second.timestamp.micros) {
             oldest_func = it;
         }
     }

--- a/src/http/file_app.cc
+++ b/src/http/file_app.cc
@@ -54,13 +54,13 @@ void file_http_app_t::handle(const http_req_t &req, http_res_t *result, signal_t
     time_t expires;
 #ifndef NDEBUG
     // In debug mode, do not cache static web assets
-    expires = get_secs() - 31536000; // Some time in the past (one year ago)
+    expires = get_realtime_secs() - 31536000; // Some time in the past (one year ago)
 #else
     // In release mode, cache static web assets except index.html
     if (filename == "/index.html") {
-        expires = get_secs() - 31536000; // Some time in the past (one year ago)
+        expires = get_realtime_secs() - 31536000; // Some time in the past (one year ago)
     } else {
-        expires = get_secs() + 31536000; // One year from now
+        expires = get_realtime_secs() + 31536000; // One year from now
     }
 #endif
     result->add_header_line("Expires", http_format_date(expires));

--- a/src/perfmon/perfmon.cc
+++ b/src/perfmon/perfmon.cc
@@ -73,7 +73,8 @@ perfmon_sampler_t::perfmon_sampler_t(ticks_t _length, bool _include_rate)
     : perfmon_perthread_t<stats_t>(), thread_data(new thread_info_t[MAX_THREADS]), length(_length), include_rate(_include_rate)
 {
     for (int i = 0; i < MAX_THREADS; i++) {
-        thread_data[i].current_interval = get_ticks() / length;
+        // TODO: Why is current_interval an int?
+        thread_data[i].current_interval = get_ticks().nanos / length.nanos;
     }
 }
 
@@ -82,7 +83,8 @@ perfmon_sampler_t::~perfmon_sampler_t() {
 }
 
 void perfmon_sampler_t::update(ticks_t now) {
-    int interval = now / length;
+    // TODO: Why is this an int?
+    int interval = now.nanos / length.nanos;
     rassert(get_thread_id().threadnum >= 0);
     thread_info_t *thread = &thread_data[get_thread_id().threadnum];
 
@@ -245,12 +247,13 @@ perfmon_rate_monitor_t::perfmon_rate_monitor_t(ticks_t _length)
     : perfmon_perthread_t<double>(), length(_length)
 {
     for (int i = 0; i < MAX_THREADS; i++) {
-        thread_data[i].value.current_interval = get_ticks() / length;
+        thread_data[i].value.current_interval = get_ticks().nanos / length.nanos;
     }
 }
 
 void perfmon_rate_monitor_t::update(ticks_t now) {
-    int interval = now / length;
+    // TODO: Why is this an int?
+    int interval = now.nanos / length.nanos;
     rassert(get_thread_id().threadnum >= 0);
     thread_info_t &thread = thread_data[get_thread_id().threadnum].value;
 
@@ -280,7 +283,7 @@ void perfmon_rate_monitor_t::get_thread_stat(double *stat) {
     ticks_t now = get_ticks();
     update(now);
 
-    double ratio = 1.0 - (static_cast<double>(now % length) / length);
+    double ratio = 1.0 - (static_cast<double>(now.nanos % length.nanos) / length.nanos);
 
     // Return a rolling average of the current count plus the last count
     thread_info_t &thread = thread_data[get_thread_id().threadnum].value;
@@ -313,14 +316,14 @@ void perfmon_duration_sampler_t::begin(ticks_t *v) {
     if (global_full_perfmon || ignore_global_full_perfmon) {
         *v = get_ticks();
     } else {
-        *v = 0;
+        *v = ticks_t{0};
     }
 }
 
 void perfmon_duration_sampler_t::end(ticks_t *v) {
     --active;
-    if (*v != 0) {
-        recent.record(ticks_to_secs(get_ticks() - *v));
+    if (v->nanos != 0) {
+        recent.record(ticks_to_secs(ticks_t{get_ticks().nanos - v->nanos}));
     }
 }
 

--- a/src/rdb_protocol/artificial_table/cfeed_backend.cc
+++ b/src/rdb_protocol/artificial_table/cfeed_backend.cc
@@ -30,7 +30,7 @@ void cfeed_artificial_table_backend_t::machinery_t::send_all_stop() {
 
 void cfeed_artificial_table_backend_t::machinery_t::maybe_remove() {
     assert_thread();
-    last_subscriber_time = current_microtime();
+    last_subscriber_time = get_kiloticks();
     /* The `cfeed_artificial_table_backend_t` has a repeating timer that will eventually
     clean us up */
 }
@@ -150,8 +150,8 @@ void cfeed_artificial_table_backend_t::maybe_remove_machinery() {
     for (auto &machinery : machineries) {
         if (machinery.second.has() &&
                 machinery.second->can_be_removed() &&
-                machinery.second->last_subscriber_time +
-                    machinery_expiration_secs * MILLION < current_microtime()) {
+                machinery.second->last_subscriber_time.micros +
+                    machinery_expiration_secs * MILLION < get_kiloticks().micros) {
             auth::user_context_t user_context = machinery.first;
             auto_drainer_t::lock_t keepalive(&drainer);
             coro_t::spawn_sometime([this, user_context, keepalive /* important to capture */]() {

--- a/src/rdb_protocol/artificial_table/cfeed_backend.hpp
+++ b/src/rdb_protocol/artificial_table/cfeed_backend.hpp
@@ -38,7 +38,7 @@ protected:
                 auth::user_context_t const &user_context)
             : ql::changefeed::artificial_t(table_id, name_resolver),
               m_user_context(user_context),
-              last_subscriber_time(current_microtime()) {
+              last_subscriber_time(get_kiloticks()) {
         }
         virtual ~machinery_t() { }
 
@@ -71,7 +71,7 @@ protected:
         void maybe_remove();
         /* If we don't have any subscribers, this is the time the last one disconnected.
         */
-        microtime_t last_subscriber_time;
+        kiloticks_t last_subscriber_time;
     };
 
     cfeed_artificial_table_backend_t(

--- a/src/rdb_protocol/batching.cc
+++ b/src/rdb_protocol/batching.cc
@@ -14,7 +14,7 @@ static const int64_t DEFAULT_MIN_ELS = 1;
 static const int64_t DEFAULT_FIRST_SCALEDOWN = 4;
 static const int64_t DEFAULT_MAX_SIZE = MEGABYTE;
 // The maximum duration of a batch in microseconds.
-static const int64_t DEFAULT_MAX_DURATION = 500 * 1000;
+static const kiloticks_t DEFAULT_MAX_DURATION{500 * 1000};
 // These numbers are sort of arbitrary, but they seem to work. See `scale_down()`
 // for an explanation.
 static const int64_t DIVISOR_SCALING_FACTOR = 8;
@@ -32,8 +32,8 @@ batchspec_t::batchspec_t(
     int64_t _max_els,
     int64_t _max_size,
     int64_t _first_scaledown,
-    int64_t _max_dur,
-    microtime_t _start_time)
+    kiloticks_t _max_dur,
+    kiloticks_t _start_time)
     : batch_type(_batch_type),
       min_els(_min_els),
       max_els(_max_els),
@@ -46,7 +46,7 @@ batchspec_t::batchspec_t(
     r_sanity_check(min_els >= 1);
     r_sanity_check(max_els >= min_els);
     r_sanity_check(max_size >= 1);
-    r_sanity_check(max_dur >= 0);
+    r_sanity_check(max_dur.micros >= 0);
 }
 
 batchspec_t batchspec_t::default_for(batch_type_t batch_type) {
@@ -56,7 +56,7 @@ batchspec_t batchspec_t::default_for(batch_type_t batch_type) {
                        DEFAULT_MAX_SIZE,
                        DEFAULT_FIRST_SCALEDOWN,
                        DEFAULT_MAX_DURATION,
-                       current_microtime());
+                       get_kiloticks());
 }
 
 batchspec_t batchspec_t::all() {
@@ -65,8 +65,8 @@ batchspec_t batchspec_t::all() {
                        std::numeric_limits<decltype(batchspec_t().max_els)>::max(),
                        std::numeric_limits<decltype(batchspec_t().max_size)>::max(),
                        1,
-                       0,  // Ignored when batch_type is TERMINAL.
-                       current_microtime());
+                       kiloticks_t{0},  // Ignored when batch_type is TERMINAL.
+                       get_kiloticks());
 }
 
 static bool set_if_present(const char *argname, env_t *env, datum_t * dest) {
@@ -105,7 +105,7 @@ batchspec_t batchspec_t::user(batch_type_t batch_type, env_t *env) {
     int64_t first_sd = first_scaledown_d.has()
                        ? first_scaledown_d.as_int()
                        : DEFAULT_FIRST_SCALEDOWN;
-    int64_t max_dur = DEFAULT_MAX_DURATION;
+    kiloticks_t max_dur = DEFAULT_MAX_DURATION;
     if (max_dur_d.has()) {
         rcheck_target(
             &max_dur_d,
@@ -123,7 +123,7 @@ batchspec_t batchspec_t::user(batch_type_t batch_type, env_t *env) {
                       PR_RECONSTRUCTABLE_DOUBLE "`).",
                       max_dur_d.as_num()));
 
-        max_dur = static_cast<int64_t>(max_dur_d.as_num() * SECS_TO_USECS);
+        max_dur.micros = static_cast<int64_t>(max_dur_d.as_num() * SECS_TO_USECS);
     }
     // Protect the user in case they're a dork.  Normally we would do rfail and
     // trigger exceptions, but due to NOTHROWs above this may not be safe.
@@ -134,7 +134,7 @@ batchspec_t batchspec_t::user(batch_type_t batch_type, env_t *env) {
                        max_size,
                        first_sd,
                        max_dur,
-                       current_microtime());
+                       get_kiloticks());
 }
 
 batchspec_t batchspec_t::with_new_batch_type(batch_type_t new_batch_type) const {
@@ -147,7 +147,7 @@ batchspec_t batchspec_t::with_min_els(int64_t new_min_els) const {
                        first_scaledown_factor, max_dur, start_time);
 }
 
-batchspec_t batchspec_t::with_max_dur(int64_t new_max_dur) const {
+batchspec_t batchspec_t::with_max_dur(kiloticks_t new_max_dur) const {
     return batchspec_t(batch_type, min_els, max_els, max_size,
                        first_scaledown_factor, new_max_dur, start_time);
 }
@@ -222,19 +222,19 @@ batcher_t batchspec_t::to_batcher() const {
         || batch_type != batch_type_t::NORMAL_FIRST
             ? max_size
             : std::max<int64_t>(1, max_size / first_scaledown_factor);
-    microtime_t cur_time = current_microtime();
-    microtime_t end_time;
+    kiloticks_t cur_time = get_kiloticks();
+    kiloticks_t end_time;
     switch (batch_type) {
     case batch_type_t::NORMAL:
-        end_time = std::max(cur_time + (cur_time - start_time), start_time + max_dur);
+        end_time.micros = std::max(cur_time.micros + (cur_time.micros - start_time.micros), start_time.micros + max_dur.micros);
         break;
     case batch_type_t::NORMAL_FIRST:
-        end_time = std::max(start_time + (max_dur / first_scaledown_factor),
-                            cur_time + (max_dur / (first_scaledown_factor * 2)));
+        end_time.micros = std::max(start_time.micros + (max_dur.micros / first_scaledown_factor),
+                                   cur_time.micros + (max_dur.micros / (first_scaledown_factor * 2)));
         break;
     case batch_type_t::SINDEX_CONSTANT: // fallthru
     case batch_type_t::TERMINAL:
-        end_time = std::numeric_limits<decltype(end_time)>::max();
+        end_time.micros = std::numeric_limits<decltype(end_time.micros)>::max();
         break;
     default: unreachable();
     }
@@ -252,14 +252,15 @@ void serialize(write_message_t *wm, const batchspec_t &batchspec) {
     serialize<W>(wm, batchspec.max_els);
     serialize<W>(wm, batchspec.max_size);
     serialize<W>(wm, batchspec.first_scaledown_factor);
-    serialize<W>(wm, batchspec.max_dur);
+    serialize<W>(wm, batchspec.max_dur.micros);
 
-    // Here we serialize the duration instead of the `start_time` to account for
-    // clocks being out of sync between machines.
-    microtime_t current_time = current_microtime();
-    static_assert(sizeof(uint64_t) >= sizeof(microtime_t),
+    // Here we serialize the duration instead of the `start_time` to account for clocks
+    // being out of sync between processes.  (Before, we needed this same logic for
+    // wall-clock time.  It's a hack that we serialize a "batchspec" this way.)
+    kiloticks_t current_kiloticks = get_kiloticks();
+    static_assert(sizeof(uint64_t) >= sizeof(current_kiloticks),
                   "Incorrect type for duration, it might overflow");
-    uint64_t duration = current_time - std::min(batchspec.start_time, current_time);
+    uint64_t duration = current_kiloticks.micros - std::min(batchspec.start_time.micros, current_kiloticks.micros);
     serialize<W>(wm, duration);
 }
 INSTANTIATE_SERIALIZE_FOR_CLUSTER(batchspec_t);
@@ -282,15 +283,15 @@ archive_result_t deserialize(read_stream_t *s, batchspec_t *batchspec) {
     if (bad(res)) { return res; }
     res = deserialize<W>(s, deserialize_deref(batchspec->first_scaledown_factor));
     if (bad(res)) { return res; }
-    res = deserialize<W>(s, deserialize_deref(batchspec->max_dur));
+    res = deserialize<W>(s, deserialize_deref(batchspec->max_dur.micros));
     if (bad(res)) { return res; }
 
     uint64_t duration = 0;
-    static_assert(sizeof(uint64_t) >= sizeof(microtime_t),
+    static_assert(sizeof(uint64_t) >= sizeof(kiloticks_t),
                   "Incorrect type for duration, it might overflow");
     res = deserialize<W>(s, &duration);
     if (bad(res)) { return res; }
-    batchspec->start_time = current_microtime() - duration;
+    batchspec->start_time.micros = get_kiloticks().micros - duration;
 
     return res;
 }
@@ -302,7 +303,7 @@ bool batcher_t::should_send_batch(ignore_latency_t ignore_latency) const {
     return els_left <= 0
         || (size_left <= 0 && min_els_left <= 0)
         || (ignore_latency == ignore_latency_t::NO
-            && (current_microtime() >= end_time && seen_one_el));
+            && (get_kiloticks().micros >= end_time.micros && seen_one_el));
 }
 
 batcher_t::batcher_t(
@@ -310,7 +311,7 @@ batcher_t::batcher_t(
     int64_t min_els,
     int64_t max_els,
     int64_t max_size,
-    microtime_t _end_time)
+    kiloticks_t _end_time)
     : batch_type(_batch_type),
       seen_one_el(false),
       min_els_left(min_els),

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -3267,7 +3267,7 @@ subscription_t::get_els(batcher_t *batcher,
         if (batcher->get_batch_type() == batch_type_t::NORMAL_FIRST) {
             batch_timer = make_scoped<signal_timer_t>(0);
         } else if (return_empty_normal_batches == return_empty_normal_batches_t::YES) {
-            batch_timer = make_scoped<signal_timer_t>(batcher->microtime_left() / 1000);
+            batch_timer = make_scoped<signal_timer_t>(batcher->kiloticks_left().micros / 1000);
         }
         // If we have to wait, wait.
         if (min_interval > 0.0

--- a/src/rdb_protocol/query_cache.cc
+++ b/src/rdb_protocol/query_cache.cc
@@ -373,7 +373,7 @@ query_cache_t::entry_t::entry_t(query_params_t *query_params,
         term_storage(std::move(query_params->term_storage)),
         global_optargs(std::move(_global_optargs)),
         deterministic_time(_deterministic_time),
-        start_time(current_microtime()),
+        start_time(get_kiloticks()),
         term_tree(std::move(_term_tree)),
         has_sent_batch(false) { }
 

--- a/src/rdb_protocol/query_cache.hpp
+++ b/src/rdb_protocol/query_cache.hpp
@@ -123,7 +123,7 @@ private:
         // time, but we can't compute one from the other because pseudo::time_now() uses
         // boost::posix_time.
         const ql::datum_t deterministic_time;
-        const microtime_t start_time;
+        const kiloticks_t start_time;
 
         cond_t persistent_interruptor;
 

--- a/src/time.cc
+++ b/src/time.cc
@@ -45,7 +45,7 @@ microtime_t current_microtime() {
 #endif
 
 ticks_t secs_to_ticks(time_t secs) {
-    return static_cast<ticks_t>(secs) * BILLION;
+    return ticks_t{static_cast<int64_t>(secs) * BILLION};
 }
 
 #ifdef __MACH__
@@ -180,7 +180,7 @@ bool operator>=(const struct timespec &t1, const struct timespec &t2) {
 
 ticks_t get_ticks() {
     timespec tv = clock_monotonic();
-    ticks_t ticks = secs_to_ticks(tv.tv_sec) + tv.tv_nsec;
+    ticks_t ticks = { secs_to_ticks(tv.tv_sec).nanos + int64_t(tv.tv_nsec) };
     return ticks;
 }
 
@@ -190,6 +190,6 @@ time_t get_realtime_secs() {
 }
 
 double ticks_to_secs(ticks_t ticks) {
-    return ticks / static_cast<double>(BILLION);
+    return ticks.nanos / static_cast<double>(BILLION);
 }
 

--- a/src/time.cc
+++ b/src/time.cc
@@ -184,6 +184,10 @@ ticks_t get_ticks() {
     return ticks;
 }
 
+kiloticks_t get_kiloticks() {
+    return kiloticks_t{get_ticks().nanos / 1000};
+}
+
 time_t get_realtime_secs() {
     timespec tv = clock_realtime();
     return tv.tv_sec;

--- a/src/time.cc
+++ b/src/time.cc
@@ -184,7 +184,7 @@ ticks_t get_ticks() {
     return ticks;
 }
 
-time_t get_secs() {
+time_t get_realtime_secs() {
     timespec tv = clock_realtime();
     return tv.tv_sec;
 }

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -4,11 +4,18 @@
 #include <stdint.h>
 #include <time.h>
 
-typedef uint64_t microtime_t;
-
-microtime_t current_microtime();
-
+// Monotonic timer.  USE THIS!
 timespec clock_monotonic();
+
+// get_ticks() is a wrapper around clock_monotonic() which returns a straight-up 64-bit
+// nanosecond counter.
+struct ticks_t {
+    int64_t nanos;
+};
+ticks_t get_ticks();
+
+// Real-time wallclock timer.  Non-monotonic, could step backwards or forwards.  Don't
+// use this, unless you want to use this.
 timespec clock_realtime();
 
 void add_to_timespec(timespec *ts, int32_t nanoseconds);
@@ -18,13 +25,15 @@ bool operator>(const struct timespec &t1, const struct timespec &t2);
 bool operator<=(const struct timespec &t1, const struct timespec &t2);
 bool operator>=(const struct timespec &t1, const struct timespec &t2);
 
-struct ticks_t {
-    int64_t nanos;
-};
 ticks_t secs_to_ticks(time_t secs);
-ticks_t get_ticks();
 double ticks_to_secs(ticks_t ticks);
 
+// Wall-clock time in seconds.
 time_t get_realtime_secs();
+
+// Old legacy crap.  Wall-clock, non-monotonic time.
+typedef uint64_t microtime_t;
+microtime_t current_microtime();
+
 
 #endif  // TIME_HPP_

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -21,8 +21,8 @@ bool operator>=(const struct timespec &t1, const struct timespec &t2);
 typedef uint64_t ticks_t;
 ticks_t secs_to_ticks(time_t secs);
 ticks_t get_ticks();
-time_t get_secs();
 double ticks_to_secs(ticks_t ticks);
 
+time_t get_realtime_secs();
 
 #endif  // TIME_HPP_

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -18,7 +18,9 @@ bool operator>(const struct timespec &t1, const struct timespec &t2);
 bool operator<=(const struct timespec &t1, const struct timespec &t2);
 bool operator>=(const struct timespec &t1, const struct timespec &t2);
 
-typedef uint64_t ticks_t;
+struct ticks_t {
+    int64_t nanos;
+};
 ticks_t secs_to_ticks(time_t secs);
 ticks_t get_ticks();
 double ticks_to_secs(ticks_t ticks);

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -38,7 +38,7 @@ double ticks_to_secs(ticks_t ticks);
 // Wall-clock time in seconds.
 time_t get_realtime_secs();
 
-// Old legacy crap.  Wall-clock, non-monotonic time.
+// Wall-clock time in microseconds.
 typedef uint64_t microtime_t;
 microtime_t current_microtime();
 

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -14,6 +14,13 @@ struct ticks_t {
 };
 ticks_t get_ticks();
 
+// get_kiloticks() is get_ticks() / 1000.  Used in migrating from legacy wall-clock
+// current_microtime().
+struct kiloticks_t {
+    int64_t micros;
+};
+kiloticks_t get_kiloticks();
+
 // Real-time wallclock timer.  Non-monotonic, could step backwards or forwards.  Don't
 // use this, unless you want to use this.
 timespec clock_realtime();

--- a/src/unittest/clustering_utils_raft.cc
+++ b/src/unittest/clustering_utils_raft.cc
@@ -409,7 +409,7 @@ void dummy_raft_traffic_generator_t::do_changes(auto_drainer_t::lock_t keepalive
 void do_writes_raft(dummy_raft_cluster_t *cluster, int expect, int ms) {
 #ifdef ENABLE_RAFT_DEBUG
     RAFT_DEBUG("begin do_writes(%d, %d)\n", expect, ms);
-    microtime_t start = current_microtime();
+    kiloticks_t start = get_kiloticks();
 #endif /* ENABLE_RAFT_DEBUG */
 
     std::set<uuid_u> committed_changes;
@@ -438,7 +438,7 @@ void do_writes_raft(dummy_raft_cluster_t *cluster, int expect, int ms) {
         ADD_FAILURE() << "completed only " << committed_changes.size() << "/" << expect
             << " changes in " << ms << "ms";
     }
-    RAFT_DEBUG("end do_writes() in %" PRIu64 "ms\n", (current_microtime() - start) / 1000);
+    RAFT_DEBUG("end do_writes() in %" PRIu64 "ms\n", (get_kiloticks().micros - start.micros) / 1000);
 }
 
 }   /* namespace unittest */

--- a/src/unittest/rdb_protocol.cc
+++ b/src/unittest/rdb_protocol.cc
@@ -985,7 +985,7 @@ TPTEST(RDBProtocol, ArtificialChangefeeds) {
     for (const auto &pair : bundles) {
         ql::batchspec_t bs(ql::batchspec_t::all()
                            .with_new_batch_type(ql::batch_type_t::NORMAL)
-                           .with_max_dur(1000));
+                           .with_max_dur(kiloticks_t{1000}));
         size_t i = pair.first;
         std::vector<ql::datum_t> p0, p10, rng;
         p0 = pair.second.point_0->next_batch(&env, bs);

--- a/src/unittest/timer_test.cc
+++ b/src/unittest/timer_test.cc
@@ -33,7 +33,7 @@ void walk_wait_times(int i, uint64_t *mse) {
         ticks_t t1 = get_ticks();
         nap(expected_ms);
         ticks_t t2 = get_ticks();
-        int64_t actual_ns = t2 - t1;
+        int64_t actual_ns = t2.nanos - t1.nanos;
         int64_t error_ns = actual_ns - expected_ms * MILLION;
 
         EXPECT_LT(llabs(error_ns), max_error_ms * MILLION)


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This replaces some inappropriate uses of wall-clock time, users of `current_microtime`.  Instead they use a monotonic timer.

This fixes honest-to-god bugs in the presence of backwards-stepping wallclock time.
