### PR TITLE
Make the free list use a single linked list

### DIFF
--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@ init () {
     min_browserify_version=13.0.0
     max_browserify_version=13.1.0
     min_python_version=2.6.0
-    
+
     osx_min_version=10.9
 
     min_msbuild_version=14.0
@@ -30,8 +30,8 @@ init () {
     must_fetch_list='bluebird v8'
     please_fetch_list="handlebars gtest re2 $must_fetch_list"
 
-    optional_libs="gtest termcap boost_system"
-    required_libs="protobuf v8 re2 z crypto ssl curl"
+    optional_libs="gtest termcap"
+    required_libs="protobuf v8 re2 z crypto ssl curl boost_system"
     other_libs="tcmalloc jemalloc"
     all_libs="$required_libs $optional_libs $other_libs"
     default_static="tcmalloc jemalloc"

--- a/src/buffer_cache/free_list.hpp
+++ b/src/buffer_cache/free_list.hpp
@@ -1,7 +1,9 @@
 #ifndef BUFFER_CACHE_FREE_LIST_HPP_
 #define BUFFER_CACHE_FREE_LIST_HPP_
 
-#include "containers/segmented_vector.hpp"
+#include <forward_list>
+#include <boost/pool/pool_alloc.hpp>
+
 #include "serializer/types.hpp"
 
 namespace alt {
@@ -22,10 +24,12 @@ public:
     void acquire_chosen_block_id(block_id_t block_id);
 
 private:
+    typedef std::forward_list<block_id_t, boost::pool_allocator<block_id_t>> block_ids_container;
+
     block_id_t next_new_block_id_;
-    segmented_vector_t<block_id_t> free_ids_;
+    block_ids_container free_ids_;
     block_id_t next_new_aux_block_id_;
-    segmented_vector_t<block_id_t> free_aux_ids_;
+    block_ids_container free_aux_ids_;
     DISABLE_COPYING(free_list_t);
 };
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
I removed the usage of segmented vector from the free list. Instead I replaced it with a single linked list that uses a pool allocator.
I don't think a segmented vector should have been used here in the first place because we don't use it as a vector.

I need to measure this somehow.