### PR TITLE
Add support for ARM64/AARCH64

### DIFF
--- a/configure
+++ b/configure
@@ -102,7 +102,7 @@ configure_unixlike () {
     case "${MACHINE%%-*}" in
         x86_64|i?86)
             true ;;
-        arm*)
+        arm*|arm64*|aarch64*)
             var_append LDFLAGS -ldl
             final_warning="ARM support is still experimental" ;;
         s390x)

--- a/mk/support/pkg/v8.sh
+++ b/mk/support/pkg/v8.sh
@@ -129,11 +129,13 @@ pkg_install () {
     raspberry_pi_gypflags='-Darm_version=6 -Darm_fpu=vfpv2'
     host=$($CXX -dumpmachine)
     case ${host%%-*} in
-        i?86)   arch=ia32 ;;
-        x86_64) arch=x64 ;;
-        arm*)   arch=arm; arch_gypflags=$raspberry_pi_gypflags ;;
-        s390x)  arch=s390x ;;
-        *)      arch=native ;;
+        i?86)    arch=ia32 ;;
+        x86_64)  arch=x64 ;;
+        arm64)   arch=arm64 ;;
+        aarch64) arch=aarch64 ;;
+        arm*)    arch=arm; arch_gypflags=$raspberry_pi_gypflags ;;
+        s390x)   arch=s390x ;;
+        *)       arch=native ;;
     esac
     mode=release
     if [[ "$arch" = "s390x" ]]; then

--- a/mk/support/pkg/v8.sh
+++ b/mk/support/pkg/v8.sh
@@ -126,14 +126,14 @@ pkg_install () {
         export GYP_DEFINES='mac_deployment_target=10.7'
     fi
     arch_gypflags=
-    raspberry_pi_gypflags='-Darm_version=6 -Darm_fpu=vfpv2'
+    arm_gypflags='-Darm_version=6 -Darm_fpu=vfpv2'
     host=$($CXX -dumpmachine)
     case ${host%%-*} in
         i?86)    arch=ia32 ;;
         x86_64)  arch=x64 ;;
-        arm64)   arch=arm64 ;;
-        aarch64) arch=aarch64 ;;
-        arm*)    arch=arm; arch_gypflags=$raspberry_pi_gypflags ;;
+        arm64)   arch=arm64; arch_gypflags=$arm_gypflags ;;
+        aarch64) arch=aarch64; arch_gypflags=$arm_gypflags ;;
+        arm*)    arch=arm; arch_gypflags=$arm_gypflags ;;
         s390x)   arch=s390x ;;
         *)       arch=native ;;
     esac

--- a/src/arch/runtime/context_switching.cc
+++ b/src/arch/runtime/context_switching.cc
@@ -288,7 +288,7 @@ artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_
     // Note: r12 is also stored, in the 'caller frame' slot above the return
     // address.
     sp -= 8; // r4-r11.
-#elif defined(__arm64__)
+#elif defined(__arm64__) || defined(__aarch64__)
     sp -= 20; // d8-d15 + x19-x30 + x30
 #elif defined(__s390x__)
     sp -= 16; // r6-r13 and f8-f15.

--- a/src/arch/runtime/context_switching.cc
+++ b/src/arch/runtime/context_switching.cc
@@ -260,6 +260,10 @@ artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_
 #elif defined(__arm__)
     // This slot is used to store r12.
     const size_t min_frame = 1;
+#elif defined(__arm64__)
+    // The ARM64 ABI requires the stack pointer to always be 16-byte-aligned at
+    // all registers.
+    const size_t min_frame = 1;
 #endif
     // Zero the caller stack frame. Prevents Valgrind complaining about uninitialized
     // value errors when throwing an uncaught exception.
@@ -284,6 +288,8 @@ artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_
     // Note: r12 is also stored, in the 'caller frame' slot above the return
     // address.
     sp -= 8; // r4-r11.
+#elif defined(__arm64__)
+    sp -= 20; // d8-d15 + x19-x30 + x30
 #elif defined(__s390x__)
     sp -= 16; // r6-r13 and f8-f15.
 #else
@@ -488,6 +494,21 @@ asm(
     "push {r12}\n"
     "push {r14}\n"
     "push {r4-r11}\n"
+#elif defined(__arm64__) || defined(__aarch64__)
+    // Preserve d8-d15 + x19-x29 and the return address (x30).
+    // Note: x30 is stored twice due to alignment requirements
+    "sub sp, sp, #0xb0\n"
+    "stp d8,  d9,  [sp, #0x00]\n"
+    "stp d10, d11, [sp, #0x10]\n"
+    "stp d12, d13, [sp, #0x20]\n"
+    "stp d14, d15, [sp, #0x30]\n"
+    "stp x19, x20, [sp, #0x40]\n"
+    "stp x21, x22, [sp, #0x50]\n"
+    "stp x23, x24, [sp, #0x60]\n"
+    "stp x25, x26, [sp, #0x70]\n"
+    "stp x27, x28, [sp, #0x80]\n"
+    "stp x29, x30, [sp, #0x90]\n"
+    "str x30, [sp, #0xa0]\n"
 #elif defined(__s390x__)
     // Preserve r6-r13, the return address (r14), and f8-f15.
     "aghi %r15, -136\n"
@@ -514,6 +535,10 @@ asm(
 #elif defined(__arm__)
     /* On ARM, the first argument is in `r0`. `r13` is the stack pointer. */
     "str r13, [r0]\n"
+#elif defined(__arm64__) || defined(__aarch64__)
+    /* On ARM64, the first argument is in `x0`. `sp` is the stack pointer and `x4` is a scratch register. */
+    "mov x4, sp\n"
+    "str x4, [x0]\n"
 #elif defined(__s390x__)
     /* On s390x, the first argument is in r2. r15 is the stack pointer. */
     "stg %r15, 0(%r2)\n"
@@ -531,6 +556,9 @@ asm(
 #elif defined(__arm__)
     /* On ARM, the second argument is in `r1` */
     "mov r13, r1\n"
+#elif defined(__arm64__) || defined(__aarch64__)
+    /* On ARM64, the second argument is in `x1` */
+    "mov sp, x1\n"
 #elif defined(__s390x__)
     /* On s390x, the second argument is in r3 */
     "lgr %r15, %r3\n"
@@ -552,6 +580,19 @@ asm(
     "pop {r4-r11}\n"
     "pop {r14}\n"
     "pop {r12}\n"
+#elif defined(__arm64__) || defined(__aarch64__)
+    "ldp d8,  d9,  [sp, #0x00]\n"
+    "ldp d10, d11, [sp, #0x10]\n"
+    "ldp d12, d13, [sp, #0x20]\n"
+    "ldp d14, d15, [sp, #0x30]\n"
+    "ldp x19, x20, [sp, #0x40]\n"
+    "ldp x21, x22, [sp, #0x50]\n"
+    "ldp x23, x24, [sp, #0x60]\n"
+    "ldp x25, x26, [sp, #0x70]\n"
+    "ldp x27, x28, [sp, #0x80]\n"
+    "ldp x29, x30, [sp, #0x90]\n"
+    "ldr x4, [sp, #0xa0]\n"
+    "add sp, sp, #0xb0\n"
 #elif defined(__s390x__)
     "lmg %r6, %r14, 64(%r15)\n"
     "ld %f8, 0(%r15)\n"
@@ -575,6 +616,10 @@ asm(
     /* Above, we popped `LR` (`r14`) off the stack, so the bx instruction will
     jump to the correct return address. */
     "bx r14\n"
+#elif defined(__arm64__) || defined(__aarch64__)
+    /* Above, we stored the `x30` the return address in a variable register `x4` so the ret instruction will
+    return it to jump. */
+    "ret x4\n"
 #elif defined(__s390x__)
     /* Above, we popped the return address (r14) off the stack. */
     "br %r14\n"

--- a/src/arch/runtime/coroutines.hpp
+++ b/src/arch/runtime/coroutines.hpp
@@ -17,7 +17,7 @@
 // Enable cross-coroutine backtraces in debug mode, or when coro profiling is enabled.
 // We don't enable it on ARM, because taking backtraces currently isn't working
 // reliably and sometimes causes crashes.
-#if (!defined(NDEBUG) && !defined(__MACH__) && !defined(__arm__)) \
+#if (!defined(NDEBUG) && !defined(__MACH__) && !defined(__arm__) && !defined(__arm64__) && !defined(__aarch64__))  \
     || defined(ENABLE_CORO_PROFILER)
 #define CROSS_CORO_BACKTRACES            1
 #endif

--- a/src/rapidjson/allocators.h
+++ b/src/rapidjson/allocators.h
@@ -107,7 +107,7 @@ public:
 // RethinkDB patch: The MemoryPoolAllocator doesn't currently work properly on
 // ARM. See https://github.com/rethinkdb/rethinkdb/issues/4839
 // and https://github.com/miloyip/rapidjson/issues/388 .
-#if defined(__arm__) || defined(__arm64__) || !defined(__aarch64__)
+#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
 #define MAYBE_POOL_ALLOCATOR RAllocator
 #else
 #define MAYBE_POOL_ALLOCATOR MemoryPoolAllocator<>

--- a/src/rapidjson/allocators.h
+++ b/src/rapidjson/allocators.h
@@ -107,7 +107,7 @@ public:
 // RethinkDB patch: The MemoryPoolAllocator doesn't currently work properly on
 // ARM. See https://github.com/rethinkdb/rethinkdb/issues/4839
 // and https://github.com/miloyip/rapidjson/issues/388 .
-#if defined(__arm__)
+#if defined(__arm__) || defined(__arm64__) || !defined(__aarch64__)
 #define MAYBE_POOL_ALLOCATOR RAllocator
 #else
 #define MAYBE_POOL_ALLOCATOR MemoryPoolAllocator<>

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -100,7 +100,7 @@ static bool resolve_protocol_version(const std::string &remote_version_string,
     return false;
 }
 
-#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__)
+#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__) || defined(__arm64__) || !defined(__aarch64__)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("64bit");
 #elif defined (__i386__) || defined(__arm__) || defined(_WIN32)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("32bit");

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -100,7 +100,7 @@ static bool resolve_protocol_version(const std::string &remote_version_string,
     return false;
 }
 
-#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__) || defined(__arm64__) || !defined(__aarch64__)
+#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__) || defined(__arm64__) || defined(__aarch64__)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("64bit");
 #elif defined (__i386__) || defined(__arm__) || defined(_WIN32)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("32bit");


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

This adds the necessary assembly to support ARM64 and AARCH64. I need help getting tests setup on other platforms as I've primarily tested this assembly on an iPhone 6s.

This resolves #5265 