### PR TITLE
Fix some slowdowns when using get_field and default

### DIFF
--- a/src/rdb_protocol/env.hpp
+++ b/src/rdb_protocol/env.hpp
@@ -157,6 +157,9 @@ public:
 
     rdb_context_t *get_rdb_ctx() { return rdb_ctx_; }
 
+    // This is set when inside a default term
+    bool eval_in_default = false;
+
 private:
     static const uint32_t EVALS_BEFORE_YIELD = 256;
     uint32_t evals_since_yield_;

--- a/src/rdb_protocol/terms/obj_or_seq.cc
+++ b/src/rdb_protocol/terms/obj_or_seq.cc
@@ -285,7 +285,16 @@ private:
     virtual scoped_ptr_t<val_t> obj_eval(
         scope_env_t *env, args_t *args, const scoped_ptr_t<val_t> &v0) const {
         datum_t d = v0->as_datum();
-        return new_val(d.get_field(args->arg(env, 1)->as_str()));
+        datum_t r;
+        if (env->env->eval_in_default) {
+            r = d.get_field(args->arg(env, 1)->as_str(), NOTHROW);
+            if (r.get_type() == datum_t::UNINITIALIZED) {
+                r = datum_t::null();
+            }
+        } else {
+            r = d.get_field(args->arg(env, 1)->as_str(), THROW);
+        }
+        return new_val(r);
     }
     virtual const char *name() const { return "get_field"; }
 };


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

I know v2.4.x is somewhat frozen but this is a small tweak for big performance gains when using `default` in conjunction with `get_field`.

It somewhat fixes #4271. I'd appreciate a code review here as I'm unsure the implications of doing a `catch (...)` to reset the env is there a better way to do this?