### PR TITLE
Avoid throwing exceptions on non existence in get_field & bracket

### DIFF
--- a/src/rdb_protocol/optargs.cc
+++ b/src/rdb_protocol/optargs.cc
@@ -39,6 +39,7 @@ scoped_ptr_t<val_t> global_optargs_t::get_optarg(env_t *env, const std::string &
 static const std::set<std::string> acceptable_optargs({
     "_EVAL_FLAGS_",
     "_NO_RECURSE_",
+    "_NON_EXISTENCE_NULL_",
     "_SHORTCUT_",
     "array_limit",
     "attempts",


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

#6352 and #4271 outline a lot more detail but currently non existence in `get_field` and `bracket` terms throw exceptions, these exceptions are caught by `default` but at the cost of about 10-20 microseconds per exception.

When doing large filters this can add up to huge overheads.

Unfortunately it's impossible to optimise this away in all cases, there really are cases where we need the exception to unwind the stack and back out to the `default` term. However, most users are probably using simple queries like `r.expr({name: {first_name: "Robert", last_name: "Payne"}})("first")("middle").default("Unknown")` where the `get_field` and `bracket` terms are immediately followed by the `default` term.

This PR addresses those use cases by re-writing the `default` term when it is preceded by either a `get_field` or `bracket`. It adds an internal optarg that is used at eval time to return null rather than throw an exception.

In addition the `get_field` and `bracket` terms also re-write themselves copying this optarg if their preceeding term is either a `get_field` or `bracket`. This allows chained uninterrupted `get_field` and `bracket` terms to take advantage of this optimisation.

In my case this cuts down execution time by roughly half and since it uses the optarg it's impact is fairly small as it defaults back to throwing exceptions when it cannot optimise it away such as `r.expr({name: {first_name: "Robert", last_name: "Payne"}})("first").map(x => x.toUpperCase()).default("Unknown")`