### PR TITLE
Fix interrupt tests #6095

### DIFF
--- a/src/rdb_protocol/real_table.cc
+++ b/src/rdb_protocol/real_table.cc
@@ -224,11 +224,13 @@ optional<counted_t<const ql::func_t> > real_table_t::get_write_hook(
     ignore_write_hook_t ignore_write_hook) {
     optional<counted_t<const ql::func_t> > write_hook;
     table_config_and_shards_t config;
+    if (ignore_write_hook == ignore_write_hook_t::YES) {
+        return write_hook;
+    }
 
     m_table_meta_client->get_config(uuid, env->interruptor, &config);
 
-    if (config.config.write_hook &&
-        ignore_write_hook == ignore_write_hook_t::NO) {
+    if (config.config.write_hook) {
         write_hook.set(config.config.write_hook->func.compile_wire_func());
     }
     return write_hook;

--- a/src/unittest/rdb_interruptor.cc
+++ b/src/unittest/rdb_interruptor.cc
@@ -131,11 +131,12 @@ private:
     const bool should_exist;
 };
 
-TEST(RDBInterrupt, DISABLED_InsertOp) {
+TEST(RDBInterrupt, InsertOp) {
     ql::minidriver_t r(ql::backtrace_id_t::empty());
     ql::raw_term_t insert_term =
         r.db("db").table("table").insert(
-            r.object(r.optarg("id", "key"), r.optarg("value", "stuff"))).root_term();
+            r.object(r.optarg("id", "key"), r.optarg("value", "stuff")),
+            r.optarg("ignore_write_hook", r.boolean(true))).root_term();
 
     uint32_t eval_count;
     {
@@ -209,7 +210,7 @@ TEST(RDBInterrupt, GetOp) {
     }
 }
 
-TEST(RDBInterrupt, DISABLED_DeleteOp) {
+TEST(RDBInterrupt, DeleteOp) {
     uint32_t eval_count;
     std::set<ql::datum_t, optional_datum_less_t> initial_data;
 
@@ -220,7 +221,8 @@ TEST(RDBInterrupt, DISABLED_DeleteOp) {
 
     ql::minidriver_t r(ql::backtrace_id_t::empty());
     ql::raw_term_t delete_term =
-        r.db("db").table("table").get_("key").delete_().root_term();
+        r.db("db").table("table").get_("key").delete_(
+            r.optarg("ignore_write_hook", r.boolean(true))).root_term();
 
     {
         test_rdb_env_t test_env;


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

This fixes the disabled interrupt tests that were causing segfaults. The segfaults occurs because the unit test environment doesn't currently mock the `table_meta_client_t` so a get write hook causes a null pointer dereference and crashes the process.

Mocking the `table_meta_client_t` looked extremely extensive so instead I opted to alter the get_write_hook method to exit early if ignoring write hooks which prevents the nullptr from being used.

Addresses #6095 
