### PR TITLE
Enable use of native Promise library for Node.js driver

### DIFF
--- a/drivers/javascript/cursor.coffee
+++ b/drivers/javascript/cursor.coffee
@@ -289,9 +289,9 @@ class IterableResult
             else
                 return @_next().then (data) ->
                     return data if pending.length < options.concurrency
-                    return Promise.any(pending)
-                    .catch Promise.AggregateError, (errs) -> throw errs[0]
-                    .return(data)
+                    return Promise.race(pending)
+                    .catch((err) -> throw err)
+                    .then(() -> data)
                 .then (data) ->
                     p = userCb(data).then ->
                         pending.splice pending.indexOf(p), 1

--- a/drivers/javascript/rethinkdb.coffee
+++ b/drivers/javascript/rethinkdb.coffee
@@ -13,3 +13,5 @@ rethinkdb._bluebird = require('bluebird')
 
 module.exports = rethinkdb
 module.exports.net = net
+module.exports.setPromise = (PromiseImplementation) ->
+  rethink._setPromise(PromiseImplementation)

--- a/drivers/javascript/util.coffee
+++ b/drivers/javascript/util.coffee
@@ -1,3 +1,4 @@
+Promise = require('bluebird')
 err = require('./errors')
 protodef = require('./proto-def')
 
@@ -122,6 +123,23 @@ mkSeq = (response, opts) -> recursivelyConvertPseudotype(response.r, opts)
 mkErr = (ErrClass, response, root) ->
     new ErrClass(mkAtom(response), root, response.b)
 
+module.exports.asCallback = (promise, callback) ->
+  if typeof callback !== 'function' return promise
+  promise.then((value) -> callback(null, value), callback)
+  promise
+
+module.exports.fromCallback = (fn) ->
+  new Promise((resolve, reject) ->
+    try
+      fn (error, result) ->
+        if error
+          reject error
+        else
+          resolve result
+    catch error
+      reject error
+  )
+
 errorClass = (errorType) =>
     switch errorType
         when protoErrorType.QUERY_LOGIC         then err.ReqlQueryLogicError
@@ -140,3 +158,4 @@ module.exports.mkAtom = mkAtom
 module.exports.mkSeq = mkSeq
 module.exports.mkErr = mkErr
 module.exports.errorClass = errorClass
+module.exports._setPromise = (PromiseImplementation) -> Promise = PromiseImplementation;


### PR DESCRIPTION
fixes #6459

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Adds a `setPromise` method to the exported `r` object which overrides the promise implementation in the `ast`, `cursor`, and `net` files of the JavaScript driver.
