### PR TITLE
Fix auth permissions bug

### DIFF
--- a/src/clustering/administration/auth/permissions.cc
+++ b/src/clustering/administration/auth/permissions.cc
@@ -145,7 +145,7 @@ void permissions_t::set_config(tribool config) {
 }
 
 void permissions_t::set_connect(tribool connect) {
-    guarantee(m_connect == make_optional(tribool::True));
+    guarantee(m_connect.has_value());
     m_connect.set(connect);
 }
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

When conversion from boost optional to homegrown optional was done an existence gaurantee check was changed to a truthy check which causes a crasher.
