### PR TITLE
Remove obsolete change feed test

### DIFF
--- a/test/rql_test/src/changefeeds/now.py_one.yaml
+++ b/test/rql_test/src/changefeeds/now.py_one.yaml
@@ -1,8 +1,0 @@
-desc: Test that r.now() is allowed before changes(), disallowed after.
-table_variable_name: tbl
-tests:
-
-    - py: tbl.changes().merge({'a': r.now()})
-      ot: err('ReqlQueryLogicError')
-
-    - py: tbl.merge({'a': r.now()}).changes()


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

This removes an obsolete test that is no longer needed due to restored determinism in r.now for change feeds.
