### PR TITLE
Update jemalloc-4.1.0.tar.bz2 URL

### DIFF
--- a/mk/support/pkg/jemalloc.sh
+++ b/mk/support/pkg/jemalloc.sh
@@ -1,7 +1,7 @@
 
 version=4.1.0
 
-src_url=http://www.canonware.com/download/jemalloc/jemalloc-$version.tar.bz2
+src_url=https://github.com/jemalloc/jemalloc/releases/download/$version/jemalloc-$version.tar.bz2
 
 pkg_install () {
     configure_flags="--libdir=${install_dir}/lib"


### PR DESCRIPTION
 Github seems more reliable than Canonware.  In v2.4.x and next we
use a Github URL.

- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
