### PR TITLE
Fix building on Windows in next

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -18,6 +18,7 @@
 
       setup.exe -q -P make
       setup.exe -q -P curl
+      setup.exe -q -P wget
       setup.exe -q -P patch
       setup.exe -q -P git
 

--- a/mk/rethinkdb.vcxproj.xsl
+++ b/mk/rethinkdb.vcxproj.xsl
@@ -155,6 +155,7 @@
               ssleay32.lib; libeay32.lib;
               v8_base_0.lib; v8_base_1.lib; v8_base_2.lib; v8_base_3.lib;
               v8_snapshot.lib; v8_libbase.lib; v8_libplatform.lib;
+              icui18n.lib; icuuc.lib;
               <xsl:if test="@configuration = 'Debug'">
                 gtest.lib;
               </xsl:if>

--- a/src/arch/runtime/event_queue/iocp.cc
+++ b/src/arch/runtime/event_queue/iocp.cc
@@ -83,7 +83,7 @@ void iocp_event_queue_t::post_event(linux_event_callback_t *cb) {
 void iocp_event_queue_t::reset_timer(int64_t next_time_in_nanos_,
                                      timer_provider_callback_t *cb) {
     rassert(cb != nullptr);
-    next_time_in_nanos = next_time_in_nanos_;
+    next_time.nanos = next_time_in_nanos_;
     timer_cb = cb;
 }
 
@@ -100,7 +100,7 @@ void iocp_event_queue_t::run() {
 
         DWORD wait_ms;
         if (timer_cb != nullptr) {
-            int64_t wait_ns = next_time_in_nanos - get_ticks();
+            int64_t wait_ns = next_time.nanos - get_ticks().nanos;
             if (wait_ns <= 0) {
                 wait_ms = 0;
             } else {
@@ -122,7 +122,7 @@ void iocp_event_queue_t::run() {
         DWORD error = res ? NO_ERROR : GetLastError();
 
         if (timer_cb != nullptr &&
-              (error == WAIT_TIMEOUT || next_time_in_nanos < get_ticks())) {
+              (error == WAIT_TIMEOUT || next_time.nanos < get_ticks().nanos)) {
             debugf_queue("[%p] trigger timer callback\n", this);
             timer_provider_callback_t *cb = timer_cb;
             timer_cb = nullptr;

--- a/src/arch/runtime/event_queue/iocp.hpp
+++ b/src/arch/runtime/event_queue/iocp.hpp
@@ -30,7 +30,7 @@ public:
     void run();
 
 private:
-    ticks_t next_time_in_nanos;
+    ticks_t next_time;
     timer_provider_callback_t *timer_cb;
 
     linux_thread_t *thread;

--- a/src/arch/timing.cc
+++ b/src/arch/timing.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "arch/timing.hpp"
 
+#include <algorithm>
 #include <functional>
 
 #include "arch/arch.hpp"

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iterator>
 #include <stack>
 
 #include "arch/runtime/coroutines.hpp"

--- a/src/rdb_protocol/geo/s2/base/logging.h
+++ b/src/rdb_protocol/geo/s2/base/logging.h
@@ -112,9 +112,17 @@ class LogMessageFatal : public LogMessage {
  public:
   LogMessageFatal(const char* file, int line)
     : LogMessage(file, line) { }
+#ifdef _MSC_VER
+#pragma warning(push)
+  // Silences "destructor never returns, potential memory leak"
+#pragma warning(disable: 4722)
+#endif
   NORETURN ~LogMessageFatal() {
     crash("Fatal S2 error: %s", str.str().c_str());
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
  private:
   DISALLOW_COPY_AND_ASSIGN(LogMessageFatal);
 };

--- a/src/unittest/timer_test.cc
+++ b/src/unittest/timer_test.cc
@@ -76,7 +76,8 @@ TPTEST(TimerTest, TestChangeInterval) {
     int64_t expected[] = { 5, 10, 20, 40, 65 };
     int64_t naps[] = {0,  0,  0,  25, 0};
     int64_t ms[] = { 10, 20, 30, 10, 50};
-    repeating_timer_t timer(10, [&]() {
+    std::unique_ptr<repeating_timer_t> timer;
+    timer = std::make_unique<repeating_timer_t>(10, [&]() {
         coro_t::spawn_now_dangerously([&]() {
             ASSERT_LT(count, 5);
             ticks_t ticks = get_ticks();
@@ -84,11 +85,11 @@ TPTEST(TimerTest, TestChangeInterval) {
             EXPECT_LT(std::abs(diff - expected[count] * MILLION),
                       max_error_ms * MILLION);
             nap(naps[count]);
-            timer.change_interval(ms[count]);
+            timer->change_interval(ms[count]);
             ++count;
         });
     });
-    timer.change_interval(5);
+    timer->change_interval(5);
     nap(70);
 }
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This fixes building on Windows.

Some things broke from the recent ticks_t refactor, and also the removal of the ICU dependency made us mistakenly not link against ICU's libraries (which we should do because v8 still uses them).