### PR TITLE
Fix build warnings in v2.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ last_tested_versions
 /RethinkDB.sdf
 /RethinkDB.vcxproj.*
 /precompiled
+/.vscode

--- a/src/client_protocol/json.cc
+++ b/src/client_protocol/json.cc
@@ -10,7 +10,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "rdb_protocol/rdb_backtrace.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/query_params.hpp"
 #include "rdb_protocol/response.hpp"
 #include "rdb_protocol/term_storage.hpp"

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -38,7 +38,7 @@
 #include "rpc/semilattice/view.hpp"
 #include "time.hpp"
 
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/query_server.hpp"
 #include "rdb_protocol/query_cache.hpp"
 #include "rdb_protocol/response.hpp"

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -4,7 +4,7 @@
 #include <inttypes.h>
 
 #include "arch/runtime/runtime.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "time.hpp"
 #include "utils.hpp"
 

--- a/src/rdb_protocol/artificial_table/artificial_table.cc
+++ b/src/rdb_protocol/artificial_table/artificial_table.cc
@@ -118,7 +118,7 @@ scoped_ptr_t<ql::reader_t> artificial_table_t::read_all_with_sindexes(
 
     guarantee(items.get_type() == ql::datum_t::type_t::R_ARRAY);
     for (size_t i = 0; i < items.arr_size(); ++i) {
-        items_vector.push_back(std::move(items.get(i)));
+        items_vector.push_back(items.get(i));
     }
 
     return make_scoped<ql::vector_reader_t>(std::move(items_vector));

--- a/src/rdb_protocol/datum_stream.hpp
+++ b/src/rdb_protocol/datum_stream.hpp
@@ -836,7 +836,7 @@ public:
         }
         items.clear();
         finished = true;
-        return std::move(rget_items);
+        return rget_items;
     }
     virtual bool is_finished() const {
         return finished;

--- a/src/rdb_protocol/error.hpp
+++ b/src/rdb_protocol/error.hpp
@@ -9,7 +9,7 @@
 
 #include "containers/archive/archive.hpp"
 #include "containers/scoped.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rpc/serialize_macros.hpp"
 
 namespace ql {

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -6,7 +6,7 @@
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/minidriver.hpp"
 #include "rdb_protocol/pseudo_literal.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/term_walker.hpp"
 #include "stl_utils.hpp"
 

--- a/src/rdb_protocol/minidriver.hpp
+++ b/src/rdb_protocol/minidriver.hpp
@@ -9,7 +9,7 @@
 
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/env.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/sym.hpp"
 #include "rdb_protocol/term_storage.hpp"
 

--- a/src/rdb_protocol/protocol.cc
+++ b/src/rdb_protocol/protocol.cc
@@ -18,7 +18,7 @@
 #include "rdb_protocol/distribution_progress.hpp"
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/func.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/store.hpp"
 
 #include "debug.hpp"

--- a/src/rdb_protocol/ql2proto.hpp
+++ b/src/rdb_protocol/ql2proto.hpp
@@ -1,0 +1,11 @@
+// Copyright 2017 Sam Hughes, all rights reserved.
+#ifndef RDB_PROTOCOL_QL2PROTO_HPP_
+#define RDB_PROTOCOL_QL2PROTO_HPP_
+
+// The purpose of this file is to silence a GCC warning that this
+// symbol is used but not defined (-Wundef), in the protobuf header.
+
+#define PROTOBUF_INLINE_NOT_IN_HEADERS 0
+#include "rdb_protocol/ql2.pb.h"
+
+#endif  // RDB_PROTOCOL_QL2PROTO_HPP_

--- a/src/rdb_protocol/query_cache.hpp
+++ b/src/rdb_protocol/query_cache.hpp
@@ -24,7 +24,7 @@
 #include "rdb_protocol/rdb_backtrace.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/env.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/query_params.hpp"
 #include "rdb_protocol/term.hpp"
 #include "rdb_protocol/term_storage.hpp"

--- a/src/rdb_protocol/query_params.hpp
+++ b/src/rdb_protocol/query_params.hpp
@@ -6,7 +6,7 @@
 #include "containers/intrusive_list.hpp"
 #include "containers/scoped.hpp"
 #include "rdb_protocol/error.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 namespace ql {
 

--- a/src/rdb_protocol/query_server.cc
+++ b/src/rdb_protocol/query_server.cc
@@ -3,7 +3,7 @@
 
 #include "perfmon/perfmon.hpp"
 #include "rdb_protocol/rdb_backtrace.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/query_cache.hpp"
 #include "rdb_protocol/query_params.hpp"
 #include "rdb_protocol/response.hpp"

--- a/src/rdb_protocol/rdb_backtrace.hpp
+++ b/src/rdb_protocol/rdb_backtrace.hpp
@@ -7,7 +7,7 @@
 
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/error.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 namespace ql {
 

--- a/src/rdb_protocol/response.hpp
+++ b/src/rdb_protocol/response.hpp
@@ -9,7 +9,7 @@
 #include <boost/optional.hpp>
 
 #include "rdb_protocol/datum.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 namespace ql {
 

--- a/src/rdb_protocol/term.hpp
+++ b/src/rdb_protocol/term.hpp
@@ -5,7 +5,7 @@
 #include "containers/counted.hpp"
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/error.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/val.hpp"
 #include "rdb_protocol/term_storage.hpp"
 

--- a/src/rdb_protocol/term_storage.hpp
+++ b/src/rdb_protocol/term_storage.hpp
@@ -15,7 +15,7 @@
 #include "rdb_protocol/rdb_backtrace.hpp"
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/error.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 namespace ql {
 

--- a/src/rdb_protocol/term_walker.cc
+++ b/src/rdb_protocol/term_walker.cc
@@ -5,7 +5,7 @@
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/minidriver.hpp"
 #include "rdb_protocol/pseudo_time.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/term_storage.hpp"
 
 namespace ql {

--- a/src/rdb_protocol/val.hpp
+++ b/src/rdb_protocol/val.hpp
@@ -14,7 +14,7 @@
 #include "rdb_protocol/geo/distances.hpp"
 #include "rdb_protocol/geo/lon_lat_types.hpp"
 #include "rdb_protocol/protocol.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 class ellipsoid_spec_t;
 

--- a/src/rdb_protocol/wire_func.cc
+++ b/src/rdb_protocol/wire_func.cc
@@ -7,7 +7,7 @@
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/protocol.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/term_walker.hpp"
 #include "stl_utils.hpp"
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -42,7 +42,7 @@
 #include "containers/printf_buffer.hpp"
 #include "debug.hpp"
 #include "logger.hpp"
-#include "rdb_protocol/ql2.pb.h"
+#include "rdb_protocol/ql2proto.hpp"
 
 void run_generic_global_startup_behavior() {
     // Make sure stderr is non-buffered


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

This fixes annoying build warnings (with modern Clang versions) in the v2.3.x branch.