### PR TITLE
Build error/warning fixes for 2.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ last_tested_versions
 /RethinkDB.sdf
 /RethinkDB.vcxproj.*
 /precompiled
+/.vscode

--- a/mk/support/pkg/node.sh
+++ b/mk/support/pkg/node.sh
@@ -1,4 +1,4 @@
-
-version=0.12.2
+version=8.9.1
 
 src_url=http://nodejs.org/dist/v$version/node-v$version.tar.gz
+src_url_sha1=1aea0c0144b057e970e4e045734f29df3d62f0d8

--- a/src/rdb_protocol/artificial_table/artificial_table.cc
+++ b/src/rdb_protocol/artificial_table/artificial_table.cc
@@ -118,7 +118,7 @@ scoped_ptr_t<ql::reader_t> artificial_table_t::read_all_with_sindexes(
 
     guarantee(items.get_type() == ql::datum_t::type_t::R_ARRAY);
     for (size_t i = 0; i < items.arr_size(); ++i) {
-        items_vector.push_back(std::move(items.get(i)));
+        items_vector.push_back(items.get(i));
     }
 
     return make_scoped<ql::vector_reader_t>(std::move(items_vector));

--- a/src/rdb_protocol/datum_stream.hpp
+++ b/src/rdb_protocol/datum_stream.hpp
@@ -836,7 +836,7 @@ public:
         }
         items.clear();
         finished = true;
-        return std::move(rget_items);
+        return rget_items;
     }
     virtual bool is_finished() const {
         return finished;


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Fixes node build errors by upgrading node to latest version.
Also removes some pessimizing moves that add noisy (and legitimate) warnings to the build process.