### PR TITLE
Fix bluebird ENOENT issues, bring node back to 6.11.0.

### DIFF
--- a/mk/support/pkg/node.sh
+++ b/mk/support/pkg/node.sh
@@ -1,4 +1,4 @@
-version=8.9.1
+version=6.11.0
 
 src_url=http://nodejs.org/dist/v$version/node-v$version.tar.gz
-src_url_sha1=1aea0c0144b057e970e4e045734f29df3d62f0d8
+src_url_sha1=df31d0e4e2104b3a62342533af5fb879f321416b


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Downgrades node to 6.11.0, which is what it had previously been in v2.4.x and next.

This avoids the ENOENT issues on Ubuntu 17.04, and also v2.4.x and next.