### PR TITLE
Add basic 'make test' target.

### DIFF
--- a/mk/README.md
+++ b/mk/README.md
@@ -89,6 +89,11 @@ Drivers
 
 * `make drivers`: Build all the drivers.
 
+Test
+---
+
+* `make test`: Invokes `./test/run`
+
 Dependencies
 ---
 

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -76,3 +76,8 @@ endif
 
 .PHONY: generate
 generate: generate-web-assets-cc generate-headers
+
+.PHONY: test
+test: $(BUILD_DIR)/rethinkdb $(BUILD_DIR)/rethinkdb-unittest web-assets rb-driver py-driver
+	$P RUN-TESTS
+	MAKEFLAGS= $(TOP)/test/run -b $(BUILD_DIR)


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Adds back a basic 'make test' target, thanks to @lbguilherme's comment in #6582.  People might need help finding out how to run tests, otherwise.

Left out the options and such, to avoid bloat.