### PR TITLE
Add the startup flag --no-dns-resolution to fix issue #4600.

### DIFF
--- a/src/arch/address.cc
+++ b/src/arch/address.cc
@@ -149,14 +149,17 @@ std::set<ip_address_t> hostname_to_ips(const std::string &host) {
 }
 
 std::set<ip_address_t> get_local_ips(const std::set<ip_address_t> &filter,
-                                     local_ip_filter_t filter_type) {
+                                     local_ip_filter_t filter_type, 
+                                     bool ifaddr_only) {
     std::set<ip_address_t> all_ips;
     std::set<ip_address_t> filtered_ips;
 
-    try {
-        all_ips = hostname_to_ips(str_gethostname());
-    } catch (const host_lookup_exc_t &ex) {
-        // Continue on, this probably means there's no DNS entry for this host
+    if (!ifaddr_only) {
+        try {
+            all_ips = hostname_to_ips(str_gethostname());
+        } catch (const host_lookup_exc_t &ex) {
+            // Continue on, this probably means there's no DNS entry for this host
+        }
     }
 
 #ifdef _WIN32

--- a/src/arch/address.hpp
+++ b/src/arch/address.hpp
@@ -109,7 +109,8 @@ enum class local_ip_filter_t {
 };
 
 std::set<ip_address_t> get_local_ips(const std::set<ip_address_t> &filter,
-                                     local_ip_filter_t filter_type);
+                                     local_ip_filter_t filter_type, 
+                                     bool ifaddr_only);
 
 class port_t {
 public:

--- a/src/clustering/administration/main/serve.cc
+++ b/src/clustering/administration/main/serve.cc
@@ -66,7 +66,8 @@ std::string service_address_ports_t::get_addresses_string(
     // Get the actual list for printing if we're listening on all addresses.
     if (is_bind_all(actual_addresses)) {
         actual_addresses = get_local_ips(std::set<ip_address_t>(),
-                                         local_ip_filter_t::ALL);
+                                         local_ip_filter_t::ALL,
+                                         false);
     }
 
     for (std::set<ip_address_t>::const_iterator i = actual_addresses.begin(); i != actual_addresses.end(); ++i) {

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -199,7 +199,8 @@ static peer_address_t our_peer_address(std::set<ip_address_t> local_addresses,
         // Otherwise we need to use the local addresses with the cluster port
         if (local_addresses.empty()) {
             local_addresses = get_local_ips(std::set<ip_address_t>(),
-                                            local_ip_filter_t::ALL);
+                                            local_ip_filter_t::ALL,
+                                            false);
         }
         for (auto it = local_addresses.begin();
              it != local_addresses.end(); ++it) {

--- a/src/unittest/unittest_utils.cc
+++ b/src/unittest/unittest_utils.cc
@@ -163,7 +163,8 @@ void let_stuff_happen() {
 
 std::set<ip_address_t> get_unittest_addresses() {
     return get_local_ips(std::set<ip_address_t>(),
-                         local_ip_filter_t::MATCH_FILTER_OR_LOOPBACK);
+                         local_ip_filter_t::MATCH_FILTER_OR_LOOPBACK,
+                         false);
 }
 
 void run_in_thread_pool(const std::function<void()> &fun, int num_workers) {


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This pull request adds a startup flag to tell rethinkdb to skip resolving hostnames via the dns server. This is being submitted as a possible fix to Issue 4600 where a misconfigured DNS server causes a startup delay for the database.