### PR TITLE
Remove unmaintained Scala and PHP drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ Besides our four official drivers, we also have many [third-party drivers](https
 * **Elixir:** [rethinkdb-elixir](https://github.com/hamiltop/rethinkdb-elixir)
 * **Go:** [GoRethink](https://github.com/dancannon/gorethink)
 * **Haskell:** [haskell-rethinkdb](https://github.com/atnnn/haskell-rethinkdb)
-* **PHP:** [php-rql](https://github.com/danielmewes/php-rql)
 * **Rust:** [reql](https://github.com/rust-rethinkdb/reql)
-* **Scala:** [rethink-scala](https://github.com/kclay/rethink-scala)
 
 Looking to explore what else RethinkDB offers or the specifics of ReQL? Check out [our RethinkDB docs](https://rethinkdb.com/docs/) and [ReQL API](https://rethinkdb.com/api/).
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This commit removes the Scala and PHP drivers, since they are unmaintained since nearly 2 years.
