### PR TITLE
Modify error info when creating index failed

### DIFF
--- a/src/clustering/administration/real_reql_cluster_interface.cc
+++ b/src/clustering/administration/real_reql_cluster_interface.cc
@@ -1289,7 +1289,7 @@ bool real_reql_cluster_interface_t::sindex_create(
             query_state_t::FAILED};
         return false;
     } CATCH_NAME_ERRORS(db->name, name, error_out)
-      CATCH_OP_ERRORS(db->name, name, error_out,
+      CATCH_OP_ERRORS(db->name, table.c_str(), error_out,
         "The secondary index was not created.",
         "The secondary index may or may not have been created.")
 }


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
When creating a secondary index failed, the error log would be something like this:
> The server(s) hosting table abc.in are currently unreachable. The secondary index was not created. If youdo not expect the server(s) to recover, you can use emergency_repair to restore availability of the table.

Where actually `abc` is the name of the db and `in` is the name of the index, but the log starts with 'server(s) hosting table'. This really confuses users and I would think that `in` is the name of the table, not the index.
