### PR TITLE
Increase limit of open files for init.d script

### DIFF
--- a/packaging/assets/init/rethinkdb
+++ b/packaging/assets/init/rethinkdb
@@ -17,6 +17,10 @@
 set -e -u
 umask 022
 
+# Make sure limit of open files is high (see issue #4447)
+ulimit -Hn 1000000
+ulimit -Sn 1000000
+
 itask="${1:-}"
 
 rtdbbin=/usr/bin/rethinkdb ;


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

**This limit caused our production database to take an epic downtime during heavy load.** Whenever restarted, it would fail because it would not be able to accept clients. Our application keeps a connection pool limited to 6K connections. By default the limit is only 4K connections, which is not ok for a production system.

Fixes #4447 and #5302