### PR TITLE
edit RethinkDB license info so that GitHub recognizes it

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,12 +1,3 @@
-RethinkDB Database System
-
-Copyright 2010-present, The Linux Foundation, portions copyright Google and 
-others and used with permission or subject to their respective license
-agreements.
-
-The software is released under the terms of the Apache License, version 2.0.
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -195,7 +186,7 @@ The software is released under the terms of the Apache License, version 2.0.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The Linux Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Donors
 * [DNSimple](https://dnsimple.com) provides DNS services for the RethinkDB project.
 * [ZeroTier](https://www.zerotier.com) sponsored the development of per-table configurable write aggregation including the ability to set write delay to infinite to create a memory-only table ([PR #6392](https://github.com/rethinkdb/rethinkdb/pull/6392))
 
+Licensing
+---------
+
+RethinkDB is licensed by the Linux Foundation under the open-source Apache 2.0 license. Portions of the software are licensed by Google and others and used with permission or subject to their respective license agreements.
+
 Where's the changelog?
 ----------------------
 We keep [a list of changes and feature explanations here](NOTES.md).


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=rethink-db)

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit updates the COPYRIGHT file so that it now contains only the
full text of the Apache license and references The Linux Foundation as
the copyright holder. The info that was formerly stored at the top of
COPYRIGHT has now been moved to the README under a new "Licensing"
section.

Collectively, these changes allow Licensee to successfully identify the
license type of RethinkDB as Apache.