### PR TITLE
Use pre-generated src/gen/web_assets.cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ last_tested_versions
 /RethinkDB.vcxproj.filters
 /RethinkDB.vcxproj.user
 /RethinkDB.vcxproj.xml
-/precompiled
 *.xml
 *.iml
 /.vscode

--- a/admin/build.mk
+++ b/admin/build.mk
@@ -16,22 +16,6 @@ web-assets-watch:
 .PHONY: web-assets
 web-assets: $(ALL_WEB_ASSETS)
 
-ifeq (1,$(USE_PRECOMPILED_WEB_ASSETS))
-
-$(BUILD_ROOT_DIR)/bundle_assets/web_assets.cc: $(PRECOMPILED_DIR)/bundle_assets/web_assets.cc | $(BUILD_ROOT_DIR)/bundle_assets/.
-	$P CP
-	cp -f $< $@
-
-else # Don't use precompiled assets
-
-ifeq ($(OS),Windows)
-$(BUILD_ROOT_DIR)/bundle_assets/web_%.cc $(BUILD_ROOT_DIR)/bundle_assets/web_%.rc: $(TOP)/scripts/build-web-%-rc.py $(ALL_WEB_ASSETS) | $(BUILD_ROOT_DIR)/bundle_assets/.
-	$P GENERATE
-	$(TOP)/scripts/build-web-assets-rc.py $(WEB_ASSETS_BUILD_DIR) $(dir $@)
-else
-$(BUILD_ROOT_DIR)/bundle_assets/web_assets.cc: $(TOP)/scripts/compile-web-assets.py $(ALL_WEB_ASSETS) | $(BUILD_ROOT_DIR)/bundle_assets/.
-	$P GENERATE
-	$(TOP)/scripts/compile-web-assets.py $(WEB_ASSETS_BUILD_DIR) > $@
-endif
-
-endif
+.PHONY: generate-web-assets-cc
+generate-web-assets-cc: web-assets
+	$(TOP)/scripts/compile-web-assets.py $(TOP)/build/web_assets > src/gen/web_assets.cc

--- a/admin/generate.sh
+++ b/admin/generate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Call this from the parent directory with ./admin/generate.sh
+if [ ! -f admin/generate.sh ]; then
+    echo "Error: Call me from the rethinkdb project root directory"
+    exit 1
+fi
+
+mkdir -p build
+make build/web-assets
+./scripts/compile-web-assets.py build/web_assets > src/gen/web_assets.cc

--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ init () {
     web_assets_deps="npm coffee browserify bluebird"
     required_bin_deps="protoc python"
     optional_bin_deps="wget curl"
-    bin_deps="cxx $web_assets_deps $required_bin_deps $optional_bin_deps"
+    bin_deps="cxx $required_bin_deps $optional_bin_deps"
     all_deps="$bin_deps $all_libs boost"
 
     default_allocator_linux=jemalloc
@@ -131,17 +131,12 @@ configure_unixlike () {
 
     fi
     check_cxx11
-    check_precompiled_web
     for bin in $required_bin_deps; do
         require_dep $bin
         check_bin $bin
     done
     for bin in $web_assets_deps; do
-        if $enable_precompiled_web; then
-            optional_dep $bin
-        else
-            require_dep $bin
-        fi
+        require_dep $bin
         check_bin $bin
     done
     check_admin_deps
@@ -201,7 +196,6 @@ configure_windows () {
     var PTHREAD_LIBS
     var CROSS_COMPILING 0
     var CXX false
-    var USE_PRECOMPILED_WEB_ASSETS 0
     for pkg in protobuf curl v8 zlib re2 openssl gtest boost; do
         require_dep $pkg
         fetch_lib $pkg
@@ -279,7 +273,6 @@ read_args () {
     arg_sysconfdir=
     arg_localstatedir=
     custom_allocator=
-    enable_precompiled_web=
     use_ccache=false
 
     while [[ $# -ne 0 ]]; do
@@ -335,8 +328,6 @@ read_args () {
             --with-tcmalloc) $no_arg; set_custom_allocator tcmalloc ;;
             --with-jemalloc) $no_arg; set_custom_allocator jemalloc ;;
             --with-system-malloc) $no_arg; set_custom_allocator system ;;
-            --enable-precompiled-web) $no_arg; enable_precompiled_web=true ;;
-            --disable-precompiled-web) $no_arg; enable_precompiled_web=false ;;
             --ccache) $no_arg; use_ccache=true ;;
             --prefix) $has_arg; arg_prefix=$arg ;;
             --sysconfdir) $has_arg; arg_sysconfdir=$arg ;;
@@ -411,8 +402,6 @@ EOF
   --with-tcmalloc         Use TCMalloc
   --with-jemalloc         Use jemalloc (default on Linux)
   --with-system-malloc    Use the system malloc (default on OS X)
-  --enable-precompiled-web
-  --disable-precompiled-web Use precompiled web assets located in precompiled/web (default: autodetect)
   --ccache                Speed up the build using ccache
   --windows-platform      Windows platform: Win32 (32 bit, default) or x64 (64 bit)
 EOF
@@ -1342,18 +1331,6 @@ check_windows_platform () {
             *) var PLATFORM Win32 ;;
         esac
     fi
-}
-
-check_precompiled_web () {
-    optional "Precompiled web assets"
-    if [[ -z "$enable_precompiled_web" ]]; then
-        if test -d precompiled/bundle_assets; then
-            enable_precompiled_web=true
-        else
-            enable_precompiled_web=false
-        fi
-    fi
-    boolvar USE_PRECOMPILED_WEB_ASSETS $enable_precompiled_web
 }
 
 # The root of the source tree

--- a/drivers/build.mk
+++ b/drivers/build.mk
@@ -11,8 +11,4 @@ include $(DRIVERS_DIR)/java/build.mk
 drivers: js-driver rb-driver py-driver
 
 .PHONY: $(DRIVERS_DIR)/all
-ifeq (1,$(USE_PRECOMPILED_WEB_ASSETS))
-  $(DRIVERS_DIR)/all: rb-driver py-driver
-else
-  $(DRIVERS_DIR)/all: drivers
-endif
+$(DRIVERS_DIR)/all: drivers

--- a/mk/README.md
+++ b/mk/README.md
@@ -76,10 +76,6 @@ Web assets
 
 * `make web-assets`: Build only the web assets.
 
-* If there is a `precompiled/web` folder, the web assets will not be
-  rebuilt unless the `--disable-precompiled-web` flag is passed to
-  `./configure`
-
 * The web assets are compiled into the executable. To speed up
   development time and avoid rebuilding the executable, the
   `--web-static-directory` option can be used. For example:

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -83,3 +83,5 @@ else
   all: $(TOP)/src/all $(TOP)/drivers/all
 endif
 
+.PHONY: generate
+generate: generate-web-assets-cc

--- a/mk/packaging.mk
+++ b/mk/packaging.mk
@@ -187,8 +187,7 @@ $(DIST_DIR)/VERSION.OVERRIDE: FORCE | reset-dist-dir
 	$P ECHO "> $@"
 	echo -n $(RETHINKDB_CODE_VERSION) > $@
 
-PRECOMPILED_ASSETS := $(DIST_DIR)/precompiled/bundle_assets/web_assets.cc
-PRECOMPILED_ASSETS += $(DIST_DIR)/precompiled/proto/rdb_protocol/ql2.pb.h
+PRECOMPILED_ASSETS := $(DIST_DIR)/precompiled/proto/rdb_protocol/ql2.pb.h
 PRECOMPILED_ASSETS += $(DIST_DIR)/precompiled/proto/rdb_protocol/ql2.pb.cc
 
 .PRECIOUS: $(PRECOMPILED_ASSETS)

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -81,8 +81,6 @@ OBJ_DIR := $(BUILD_DIR)/obj
 WEB_ASSETS_DIR_NAME := web_assets
 WEB_ASSETS_BUILD_DIR := $(BUILD_ROOT_DIR)/$(WEB_ASSETS_DIR_NAME)
 
-PRECOMPILED_DIR := $(TOP)/precompiled
-
 ##### To rebuild when Makefiles change
 
 ifeq ($(IGNORE_MAKEFILE_CHANGES),1)

--- a/mk/rethinkdb.vcxproj.xsl
+++ b/mk/rethinkdb.vcxproj.xsl
@@ -171,8 +171,6 @@
         </ItemDefinitionGroup>
 
         <ItemGroup Condition="'$(Configuration)|$(Platform)'=='{@configuration}|{@platform}'">
-          <ResourceCompile Include="build\bundle_assets\web_assets.rc" />
-          <ClCompile Include="build\bundle_assets\web_assets.cc" />
           <ClCompile Include="build\proto\rdb_protocol\ql2.pb.cc" />
           <ClCompile Include="src\**\*.cc">
             <xsl:choose>

--- a/mk/windows.mk
+++ b/mk/windows.mk
@@ -27,8 +27,6 @@ LIB_DEPS := $(foreach dep, $(FETCH_LIST), $(SUPPORT_BUILD_DIR)/$(dep)_$($(dep)_V
 
 PROTO_DEPS := $(PROTO_DIR)/rdb_protocol/ql2.pb.h $(PROTO_DIR)/rdb_protocol/ql2.pb.cc
 
-WEB_ASSETS_DEPS := $(BUILD_ROOT_DIR)/bundle_assets/web_assets.cc $(BUILD_ROOT_DIR)/bundle_assets/web_assets.rc
-
 MSBUILD_FLAGS := /nologo /maxcpucount
 MSBUILD_FLAGS += /p:Configuration=$(CONFIGURATION)
 MSBUILD_FLAGS += /p:Platform=$(PLATFORM)
@@ -37,11 +35,11 @@ ifneq (1,$(VERBOSE))
   MSBUILD_FLAGS += /verbosity:minimal
 endif
 
-$/build/$(CONFIGURATION)_$(PLATFORM)/rethinkdb.exe: $/rethinkdb.vcxproj $(SOURCES_NOUNIT) $(LIB_DEPS) $(PROTO_DEPS) $(WEB_ASSETS_DEPS)
+$/build/$(CONFIGURATION)_$(PLATFORM)/rethinkdb.exe: $/rethinkdb.vcxproj $(SOURCES_NOUNIT) $(LIB_DEPS) $(PROTO_DEPS)
 	$P MSBUILD
 	"$(MSBUILD)" $(MSBUILD_FLAGS) $<
 
-$/build/$(CONFIGURATION)_$(PLATFORM)/rethinkdb-unittest.exe: $/rethinkdb-unittest.vcxproj $(SOURCES) $(LIB_DEPS) $(PROTO_DEPS) $(WEB_ASSETS_DEPS)
+$/build/$(CONFIGURATION)_$(PLATFORM)/rethinkdb-unittest.exe: $/rethinkdb-unittest.vcxproj $(SOURCES) $(LIB_DEPS) $(PROTO_DEPS)
 	$P MSBUILD
 	"$(MSBUILD)" $(MSBUILD_FLAGS) $<
 

--- a/src/build.mk
+++ b/src/build.mk
@@ -269,9 +269,9 @@ NAMES := $(patsubst $(SOURCE_DIR)/%.cc,%,$(SOURCES))
 DEPS := $(patsubst %,$(DEP_DIR)/%$(DEPS_POSTFIX).d,$(NAMES))
 OBJS := $(QL2_PROTO_OBJS) $(patsubst %,$(OBJ_DIR)/%.o,$(NAMES))
 
-SERVER_EXEC_OBJS := $(OBJ_DIR)/web_assets/web_assets.o $(QL2_PROTO_OBJS) $(patsubst $(SOURCE_DIR)/%.cc,$(OBJ_DIR)/%.o,$(SERVER_EXEC_SOURCES))
+SERVER_EXEC_OBJS := $(QL2_PROTO_OBJS) $(patsubst $(SOURCE_DIR)/%.cc,$(OBJ_DIR)/%.o,$(SERVER_EXEC_SOURCES))
 
-SERVER_NOMAIN_OBJS := $(OBJ_DIR)/web_assets/web_assets.o $(QL2_PROTO_OBJS) $(patsubst $(SOURCE_DIR)/%.cc,$(OBJ_DIR)/%.o,$(filter-out %/main.cc,$(SOURCES)))
+SERVER_NOMAIN_OBJS := $(QL2_PROTO_OBJS) $(patsubst $(SOURCE_DIR)/%.cc,$(OBJ_DIR)/%.o,$(filter-out %/main.cc,$(SOURCES)))
 
 SERVER_UNIT_TEST_OBJS := $(SERVER_NOMAIN_OBJS) $(OBJ_DIR)/unittest/main.o
 
@@ -367,11 +367,6 @@ $(BUILD_DIR)/$(SERVER_UNIT_TEST_NAME): $(SERVER_UNIT_TEST_OBJS) $(GTEST_LIBS_DEP
 $(BUILD_DIR)/$(GDB_FUNCTIONS_NAME): | $(BUILD_DIR)/.
 	$P CP $@
 	cp $(SCRIPTS_DIR)/$(GDB_FUNCTIONS_NAME) $@
-
-$(OBJ_DIR)/web_assets/web_assets.o: $(BUILD_ROOT_DIR)/bundle_assets/web_assets.cc $(MAKEFILE_DEPENDENCY)
-	mkdir -p $(dir $@)
-	$P CC
-	$(RT_CXX) $(RT_CXXFLAGS) -c -o $@ $<
 
 $(OBJ_DIR)/%.pb.o: $(PROTO_DIR)/%.pb.cc $(MAKEFILE_DEPENDENCY) $(QL2_PROTO_HEADERS)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Removes the notion of precompiled web assets.  (They're always precompiled now.)

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Ports dac34e7a1dfc7f1d27076a338d94c119a527ba92 to v2.4.x branch.