### PR TITLE
Add libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ First install some dependencies.  For example, on Ubuntu or Debian:
 
     sudo apt-get install build-essential protobuf-compiler python \
         libprotobuf-dev libcurl4-openssl-dev libboost-all-dev \
-        libncurses5-dev libjemalloc-dev wget m4 g++
+        libncurses5-dev libjemalloc-dev wget m4 g++ libssl-dev
 
 Generally, you will need
 
@@ -70,6 +70,7 @@ Generally, you will need
 * Python 2
 * libcurl
 * libcrypto (OpenSSL)
+* libssl-dev
 
 Then, to build:
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
The `libssl-dev` package is not listed for install but needed for the builds. 
