### PR TITLE
Apply patch for rethinkdb/rethinkdb#5801

### DIFF
--- a/drivers/python/rethinkdb/ast.py
+++ b/drivers/python/rethinkdb/ast.py
@@ -754,11 +754,9 @@ class ReQLDecoder(py_json.JSONDecoder):
                                    'have expected field "epoch_time".')
                                   % py_json.dumps(obj))
 
-        if 'timezone' in obj:
-            return datetime.datetime.fromtimestamp(obj['epoch_time'],
-                                                   RqlTzinfo(obj['timezone']))
-        else:
-            return datetime.datetime.utcfromtimestamp(obj['epoch_time'])
+        tzinfo = RqlTzinfo(obj["timezone"]) if "timezone" in obj else None
+        tz_epoch = datetime.datetime(1970, 1, 1, tzinfo=tzinfo)
+        return tz_epoch + datetime.timedelta(0, 0, 0, obj["epoch_time"])
 
     def convert_grouped_data(self, obj):
         if 'data' not in obj:


### PR DESCRIPTION
```
>>> reload(rethinkdb.ast)
<module 'rethinkdb.ast' from 'rethinkdb/ast.py'>
>>> from rethinkdb.ast import ReQLDecoder
>>> ReQLDecoder().convert_time({"epoch_time": 500})
datetime.datetime(1970, 1, 1, 0, 0, 0, 500000)
>>> ReQLDecoder().convert_time({"epoch_time": 500, "timezone": "00:00"})
datetime.datetime(1970, 1, 1, 0, 0, 0, 500000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x10eb26590>)
>>> ReQLDecoder().convert_time({"epoch_time": 500, "timezone": "-05:00"})
datetime.datetime(1970, 1, 1, 0, 0, 0, 500000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x10eb26750>)
>>> ^D
```

- [X] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Fixes #5801 by applying a slightly modified form of the original patch. Tested on Python 2.X to ensure backwards compatibility.
