### PR TITLE
Srh/24x/includes

### DIFF
--- a/src/btree/backfill.cc
+++ b/src/btree/backfill.cc
@@ -13,22 +13,6 @@
 values from the leaf nodes. */
 static const int MAX_CONCURRENT_VALUE_LOADS = 16;
 
-RDB_IMPL_SERIALIZABLE_1_FOR_CLUSTER(backfill_pre_item_t, range);
-RDB_IMPL_SERIALIZABLE_3_FOR_CLUSTER(backfill_item_t::pair_t, key, recency, value);
-RDB_IMPL_SERIALIZABLE_3_FOR_CLUSTER(backfill_item_t,
-    range, pairs, min_deletion_timestamp);
-
-void backfill_item_t::mask_in_place(const key_range_t &m) {
-    range = range.intersection(m);
-    std::vector<pair_t> new_pairs;
-    for (auto &&pair : pairs) {
-        if (m.contains_key(pair.key)) {
-            new_pairs.push_back(std::move(pair));
-        }
-    }
-    pairs = std::move(new_pairs);
-}
-
 /* `convert_to_right_bound()` is suitable for converting `btree_key_t *`s in the format
 of `right_incl` or `left_excl_or_null` into a `key_range_t::right_bound_t`. */
 key_range_t::right_bound_t convert_to_right_bound(const btree_key_t *rightmost_before) {

--- a/src/btree/backfill.hpp
+++ b/src/btree/backfill.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "btree/backfill_types.hpp"
 #include "btree/keys.hpp"
 #include "btree/types.hpp"
 #include "buffer_cache/types.hpp"
@@ -19,92 +20,6 @@ class buf_parent_t;
 class superblock_t;
 class value_sizer_t;
 
-/* `backfill_pre_item_t` describes a range of keys which have changed on the backfill
-destination since the source and destination diverged. The backfill destination sends
-pre items to the backfill source so that the source knows to re-transmit the values of
-those keys. */
-class backfill_pre_item_t {
-public:
-    key_range_t get_range() const {
-        return range;
-    }
-    size_t get_mem_size() const {
-        return sizeof(backfill_pre_item_t);
-    }
-    void mask_in_place(const key_range_t &m) {
-        range = range.intersection(m);
-    }
-    key_range_t range;
-};
-RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_pre_item_t);
-
-/* A `backfill_item_t` is a complete description of some sub-range of the B-tree,
-containing all the information necessary to bring the corresponding sub-range of any
-other B-tree into a state equivalent to that of the B-tree that the `backfill_item_t`
-came from. */
-class backfill_item_t {
-public:
-    class pair_t {
-    public:
-        store_key_t key;
-        repli_timestamp_t recency;
-        optional<std::vector<char> > value;   /* empty indicates deletion */
-        size_t get_mem_size() const {
-            size_t s = sizeof(pair_t);
-            if (static_cast<bool>(value)) {
-                s += value->size();
-            }
-            return s;
-        }
-        /* The size of a `pair_t` assuming its value is set to the given size */
-        static size_t get_mem_size_with_value(size_t value_size) {
-            return sizeof(pair_t) + value_size;
-        }
-    };
-
-    key_range_t get_range() const {
-        return range;
-    }
-
-    /* `get_mem_size()` estimates the size the `backfill_item_t` occupies in RAM or when
-    serialized over the network. Backfill batch sizes are defined in terms of the total
-    mem sizes of all the backfill items in the batch. */
-    size_t get_mem_size() const {
-        size_t s = sizeof(backfill_item_t);
-        for (const auto &pair : pairs) {
-            s += pair.get_mem_size();
-        }
-        return s;
-    }
-
-    void mask_in_place(const key_range_t &m);
-
-    /* A single-key backfill item consists of a `key_range_t` covering exactly one key,
-    and a single `pair_t` for that same key. The backfill receiver logic has a separate
-    code path for single-key items in order to improve performance. */
-    bool is_single_key() {
-        key_range_t::right_bound_t x(range.left);
-        x.increment();
-        return pairs.size() == 1 && x == range.right;
-    }
-
-    /* The `range` member describes what range of keys this item applies to. `pairs`
-    contains an entry for every key present in the range on the backfill source. In
-    addition, for every key that has been deleted from the range with timestamp greater
-    than or equal to `min_deletion_timestamp`, `pairs` will contain an deletion entry.
-    Every pair carries a timestamp, which is greater than or equal to the timestamp of
-    the actual query that last touched the key. */
-    key_range_t range;
-    std::vector<pair_t> pairs;
-    repli_timestamp_t min_deletion_timestamp;
-
-    /* TODO: For single-key items, this is not very memory-efficient, because we store
-    the key in three places: in `pairs[0].key`, in `range.left`, and in `range.right.key`
-    minus one. Consider wrapping `range` in a `scoped_ptr_t`, which is left empty for a
-    single-key item. This will also reduce data copying when moving an item. */
-};
-RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_item_t::pair_t);
-RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_item_t);
 
 /* `btree_send_backfill_pre()` finds all of the keys or ranges of keys that have changed
 since `reference_timestamp` and describes them as a sequence of `backfill_pre_item_t`s,

--- a/src/btree/backfill_types.cc
+++ b/src/btree/backfill_types.cc
@@ -1,0 +1,21 @@
+#include "btree/backfill_types.hpp"
+
+#include "containers/archive/optional.hpp"
+#include "containers/archive/stl_types.hpp"
+
+
+RDB_IMPL_SERIALIZABLE_1_FOR_CLUSTER(backfill_pre_item_t, range);
+RDB_IMPL_SERIALIZABLE_3_FOR_CLUSTER(backfill_item_t::pair_t, key, recency, value);
+RDB_IMPL_SERIALIZABLE_3_FOR_CLUSTER(backfill_item_t,
+    range, pairs, min_deletion_timestamp);
+
+void backfill_item_t::mask_in_place(const key_range_t &m) {
+    range = range.intersection(m);
+    std::vector<pair_t> new_pairs;
+    for (auto &&pair : pairs) {
+        if (m.contains_key(pair.key)) {
+            new_pairs.push_back(std::move(pair));
+        }
+    }
+    pairs = std::move(new_pairs);
+}

--- a/src/btree/backfill_types.hpp
+++ b/src/btree/backfill_types.hpp
@@ -1,0 +1,98 @@
+#ifndef BTREE_BACKFILL_TYPES_HPP_
+#define BTREE_BACKFILL_TYPES_HPP_
+
+#include <vector>
+
+#include "btree/keys.hpp"
+#include "containers/optional.hpp"
+#include "repli_timestamp.hpp"
+#include "rpc/serialize_macros.hpp"
+
+/* `backfill_pre_item_t` describes a range of keys which have changed on the backfill
+destination since the source and destination diverged. The backfill destination sends
+pre items to the backfill source so that the source knows to re-transmit the values of
+those keys. */
+class backfill_pre_item_t {
+public:
+    key_range_t get_range() const {
+        return range;
+    }
+    size_t get_mem_size() const {
+        return sizeof(backfill_pre_item_t);
+    }
+    void mask_in_place(const key_range_t &m) {
+        range = range.intersection(m);
+    }
+    key_range_t range;
+};
+RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_pre_item_t);
+
+/* A `backfill_item_t` is a complete description of some sub-range of the B-tree,
+containing all the information necessary to bring the corresponding sub-range of any
+other B-tree into a state equivalent to that of the B-tree that the `backfill_item_t`
+came from. */
+class backfill_item_t {
+public:
+    class pair_t {
+    public:
+        store_key_t key;
+        repli_timestamp_t recency;
+        optional<std::vector<char> > value;   /* empty indicates deletion */
+        size_t get_mem_size() const {
+            size_t s = sizeof(pair_t);
+            if (static_cast<bool>(value)) {
+                s += value->size();
+            }
+            return s;
+        }
+        /* The size of a `pair_t` assuming its value is set to the given size */
+        static size_t get_mem_size_with_value(size_t value_size) {
+            return sizeof(pair_t) + value_size;
+        }
+    };
+
+    key_range_t get_range() const {
+        return range;
+    }
+
+    /* `get_mem_size()` estimates the size the `backfill_item_t` occupies in RAM or when
+    serialized over the network. Backfill batch sizes are defined in terms of the total
+    mem sizes of all the backfill items in the batch. */
+    size_t get_mem_size() const {
+        size_t s = sizeof(backfill_item_t);
+        for (const auto &pair : pairs) {
+            s += pair.get_mem_size();
+        }
+        return s;
+    }
+
+    void mask_in_place(const key_range_t &m);
+
+    /* A single-key backfill item consists of a `key_range_t` covering exactly one key,
+    and a single `pair_t` for that same key. The backfill receiver logic has a separate
+    code path for single-key items in order to improve performance. */
+    bool is_single_key() {
+        key_range_t::right_bound_t x(range.left);
+        x.increment();
+        return pairs.size() == 1 && x == range.right;
+    }
+
+    /* The `range` member describes what range of keys this item applies to. `pairs`
+    contains an entry for every key present in the range on the backfill source. In
+    addition, for every key that has been deleted from the range with timestamp greater
+    than or equal to `min_deletion_timestamp`, `pairs` will contain an deletion entry.
+    Every pair carries a timestamp, which is greater than or equal to the timestamp of
+    the actual query that last touched the key. */
+    key_range_t range;
+    std::vector<pair_t> pairs;
+    repli_timestamp_t min_deletion_timestamp;
+
+    /* TODO: For single-key items, this is not very memory-efficient, because we store
+    the key in three places: in `pairs[0].key`, in `range.left`, and in `range.right.key`
+    minus one. Consider wrapping `range` in a `scoped_ptr_t`, which is left empty for a
+    single-key item. This will also reduce data copying when moving an item. */
+};
+RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_item_t::pair_t);
+RDB_DECLARE_SERIALIZABLE_FOR_CLUSTER(backfill_item_t);
+
+#endif  // BTREE_BACKFILL_TYPES_HPP_

--- a/src/btree/depth_first_traversal.cc
+++ b/src/btree/depth_first_traversal.cc
@@ -2,6 +2,7 @@
 #include "btree/depth_first_traversal.hpp"
 
 #include "btree/internal_node.hpp"
+#include "btree/leaf_node.hpp"
 #include "btree/operations.hpp"
 #include "concurrency/interruptor.hpp"
 #include "rdb_protocol/profile.hpp"

--- a/src/btree/leaf_node.cc
+++ b/src/btree/leaf_node.cc
@@ -1504,8 +1504,7 @@ void insert(
         const btree_key_t *key,
         const void *value,
         repli_timestamp_t tstamp,
-        repli_timestamp_t maximum_existing_tstamp,
-        UNUSED key_modification_proof_t km_proof) {
+        repli_timestamp_t maximum_existing_tstamp) {
     rassert(!is_full(sizer, node, key, value));
 
     /* Make space for the entry itself */
@@ -1533,8 +1532,7 @@ void remove(
         leaf_node_t *node,
         const btree_key_t *key,
         repli_timestamp_t tstamp,
-        repli_timestamp_t maximum_existing_tstamp,
-        UNUSED key_modification_proof_t km_proof) {
+        repli_timestamp_t maximum_existing_tstamp) {
     /* If the deletion entry would fall after `tstamp_cutpoint`, then it
     shouldn't be written at all. If that's the case, then
     `prepare_space_for_new_entry()` will return false because we pass false for
@@ -1557,7 +1555,7 @@ void remove(
 }
 
 // Erases the entry for the given key, leaving behind no trace.
-void erase_presence(value_sizer_t *sizer, leaf_node_t *node, const btree_key_t *key, UNUSED key_modification_proof_t km_proof) {
+void erase_presence(value_sizer_t *sizer, leaf_node_t *node, const btree_key_t *key) {
     int index;
     bool found = find_key(node, key, &index);
     if (found) {

--- a/src/btree/leaf_node.hpp
+++ b/src/btree/leaf_node.hpp
@@ -15,23 +15,6 @@ class value_sizer_t;
 struct btree_key_t;
 class repli_timestamp_t;
 
-// TODO: Could key_modification_proof_t not go in this file?
-
-// Originally we thought that leaf node modification functions would
-// take a key-modification callback, thus forcing every key/value
-// modification to consider the callback.  The problem is that the
-// user is supposed to call is_full before calling insert, and is_full
-// depends on the value size and can cause a split to happen.  But
-// what if the key modification then wants to change the value size?
-// Then we would need to redo the logic considering whether we want to
-// split the leaf node.  Instead the caller just provides evidence
-// that they considered doing the appropriate value modifications, by
-// constructing one of these dummy values.
-class key_modification_proof_t {
-public:
-    static key_modification_proof_t real_proof() { return key_modification_proof_t(); }
-};
-
 namespace leaf {
 class iterator;
 class reverse_iterator;
@@ -152,8 +135,7 @@ void insert(
         const void *value,
         repli_timestamp_t tstamp,
         /* the recency of the buf_t that `node` comes from */
-        repli_timestamp_t maximum_existing_tstamp,
-        UNUSED key_modification_proof_t km_proof);
+        repli_timestamp_t maximum_existing_tstamp);
 
 /* `remove()` removes any preexisting value or tombstone, then creates a tombstone unless
 `tstamp` is before `tstamp_cutpoint`. */
@@ -163,12 +145,11 @@ void remove(
         const btree_key_t *key,
         repli_timestamp_t tstamp,
         /* the recency of the buf_t that `node` comes from */
-        repli_timestamp_t maximum_existing_tstamp,
-        key_modification_proof_t km_proof);
+        repli_timestamp_t maximum_existing_tstamp);
 
 /* `erase_presence()` removes any preexisting value or tombstone, but does not create a
 new tombstone. */
-void erase_presence(value_sizer_t *sizer, leaf_node_t *node, const btree_key_t *key, key_modification_proof_t km_proof);
+void erase_presence(value_sizer_t *sizer, leaf_node_t *node, const btree_key_t *key);
 
 /* Returns the smallest timestamp such that if a deletion had occurred with that
 timestamp, the node would still have a record of it. */

--- a/src/btree/operations.cc
+++ b/src/btree/operations.cc
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "btree/internal_node.hpp"
+#include "btree/leaf_node.hpp"
 #include "buffer_cache/alt.hpp"
 #include "buffer_cache/blob.hpp"
 #include "containers/archive/vector_stream.hpp"
@@ -557,11 +558,7 @@ void apply_keyvalue_change(
         keyvalue_location_t *kv_loc,
         const btree_key_t *key, repli_timestamp_t tstamp,
         const value_deleter_t *balancing_detacher,
-        key_modification_callback_t *km_callback,
         delete_mode_t delete_mode) {
-    key_modification_proof_t km_proof
-        = km_callback->value_modification(kv_loc, key);
-
     /* how much this keyvalue change affects the total population of the btree
      * (should be -1, 0 or 1) */
     int population_change;
@@ -605,8 +602,7 @@ void apply_keyvalue_change(
                          key,
                          kv_loc->value.get(),
                          tstamp,
-                         previous_leaf_recency,
-                         km_proof);
+                         previous_leaf_recency);
         }
     } else {
         // Delete the value if it's there.
@@ -631,14 +627,12 @@ void apply_keyvalue_change(
                              leaf_node,
                              key,
                              tstamp,
-                             previous_leaf_recency,
-                             km_proof);
+                             previous_leaf_recency);
                     } break;
                     case delete_mode_t::ERASE: {
                         leaf::erase_presence(sizer,
                             leaf_node,
-                            key,
-                            km_proof);
+                            key);
                     } break;
                     default: unreachable();
                 }

--- a/src/btree/operations.hpp
+++ b/src/btree/operations.hpp
@@ -6,7 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "btree/leaf_node.hpp"
 #include "btree/node.hpp"
 #include "buffer_cache/alt.hpp"
 #include "concurrency/fifo_enforcer.hpp"
@@ -139,36 +138,6 @@ private:
     DISABLE_COPYING(keyvalue_location_t);
 };
 
-
-// KSI: This type is stupid because the only subclass is
-// null_key_modification_callback_t?
-class key_modification_callback_t {
-public:
-    // Perhaps this modifies the kv_loc in place, swapping in its own
-    // scoped_malloc_t.  It's the caller's responsibility to have
-    // destroyed any blobs that the value might reference, before
-    // calling this here, so that this callback can reacquire them.
-    virtual key_modification_proof_t value_modification(keyvalue_location_t *kv_loc, const btree_key_t *key) = 0;
-
-    key_modification_callback_t() { }
-protected:
-    virtual ~key_modification_callback_t() { }
-private:
-    DISABLE_COPYING(key_modification_callback_t);
-};
-
-
-
-
-class null_key_modification_callback_t : public key_modification_callback_t {
-    key_modification_proof_t
-    value_modification(UNUSED keyvalue_location_t *kv_loc,
-                       UNUSED const btree_key_t *key) {
-        // do nothing
-        return key_modification_proof_t::real_proof();
-    }
-};
-
 buf_lock_t get_root(value_sizer_t *sizer, superblock_t *sb);
 
 void check_and_handle_split(value_sizer_t *sizer,
@@ -235,7 +204,6 @@ void apply_keyvalue_change(
         const btree_key_t *key,
         repli_timestamp_t tstamp,
         const value_deleter_t *balancing_detacher,
-        key_modification_callback_t *km_callback,
         delete_mode_t delete_mode);
 
 #endif  // BTREE_OPERATIONS_HPP_

--- a/src/btree/operations.hpp
+++ b/src/btree/operations.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "btree/node.hpp"
+#include "btree/stats.hpp"
 #include "buffer_cache/alt.hpp"
 #include "concurrency/fifo_enforcer.hpp"
 #include "concurrency/new_semaphore.hpp"
@@ -23,6 +24,8 @@ namespace profile {
 class trace_t;
 }
 
+class buf_parent_t;
+class cache_t;
 class value_deleter_t;
 
 enum cache_snapshotted_t { CACHE_SNAPSHOTTED_NO, CACHE_SNAPSHOTTED_YES };
@@ -53,47 +56,6 @@ public:
 
 private:
     DISABLE_COPYING(superblock_t);
-};
-
-class btree_stats_t {
-public:
-    explicit btree_stats_t(perfmon_collection_t *parent,
-                           const std::string &identifier)
-        : btree_collection(),
-          pm_keys_read(secs_to_ticks(1)),
-          pm_keys_set(secs_to_ticks(1)),
-          pm_keys_membership(&btree_collection,
-              &pm_keys_read, "keys_read",
-              &pm_total_keys_read, "total_keys_read",
-              &pm_keys_set, "keys_set",
-              &pm_total_keys_set, "total_keys_set") {
-        if (parent != nullptr) {
-            rename(parent, identifier);
-        }
-    }
-
-    void hide() {
-        btree_collection_membership.reset();
-    }
-
-    void rename(perfmon_collection_t *parent,
-                const std::string &identifier) {
-        btree_collection_membership.reset();
-        btree_collection_membership.init(new perfmon_membership_t(
-            parent,
-            &btree_collection,
-            "btree-" + identifier));
-    }
-
-    perfmon_collection_t btree_collection;
-    scoped_ptr_t<perfmon_membership_t> btree_collection_membership;
-    perfmon_rate_monitor_t
-        pm_keys_read,
-        pm_keys_set;
-    perfmon_counter_t
-        pm_total_keys_read,
-        pm_total_keys_set;
-    perfmon_multi_membership_t pm_keys_membership;
 };
 
 class keyvalue_location_t {

--- a/src/btree/stats.hpp
+++ b/src/btree/stats.hpp
@@ -1,0 +1,48 @@
+#ifndef BTREE_STATS_HPP_
+#define BTREE_STATS_HPP_
+
+#include "perfmon/perfmon.hpp"
+
+class btree_stats_t {
+public:
+    explicit btree_stats_t(perfmon_collection_t *parent,
+                           const std::string &identifier)
+        : btree_collection(),
+          pm_keys_read(secs_to_ticks(1)),
+          pm_keys_set(secs_to_ticks(1)),
+          pm_keys_membership(&btree_collection,
+              &pm_keys_read, "keys_read",
+              &pm_total_keys_read, "total_keys_read",
+              &pm_keys_set, "keys_set",
+              &pm_total_keys_set, "total_keys_set") {
+        if (parent != nullptr) {
+            rename(parent, identifier);
+        }
+    }
+
+    void hide() {
+        btree_collection_membership.reset();
+    }
+
+    void rename(perfmon_collection_t *parent,
+                const std::string &identifier) {
+        btree_collection_membership.reset();
+        btree_collection_membership.init(new perfmon_membership_t(
+            parent,
+            &btree_collection,
+            "btree-" + identifier));
+    }
+
+    perfmon_collection_t btree_collection;
+    scoped_ptr_t<perfmon_membership_t> btree_collection_membership;
+    perfmon_rate_monitor_t
+        pm_keys_read,
+        pm_keys_set;
+    perfmon_counter_t
+        pm_total_keys_read,
+        pm_total_keys_set;
+    perfmon_multi_membership_t pm_keys_membership;
+};
+
+
+#endif  // BTREE_STATS_HPP_

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -32,16 +32,17 @@
 #include "perfmon/perfmon.hpp"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 #include "rdb_protocol/rdb_backtrace.hpp"
 #include "rdb_protocol/base64.hpp"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/env.hpp"
-#include "rpc/semilattice/view.hpp"
-#include "time.hpp"
-
 #include "rdb_protocol/ql2proto.hpp"
 #include "rdb_protocol/query_server.hpp"
 #include "rdb_protocol/query_cache.hpp"
 #include "rdb_protocol/response.hpp"
+#include "rpc/semilattice/view.hpp"
+#include "time.hpp"
 
 http_conn_cache_t::http_conn_t::http_conn_t(rdb_context_t *rdb_ctx,
                                             ip_and_port_t client_addr_port) :

--- a/src/clustering/administration/issues/non_transitive.hpp
+++ b/src/clustering/administration/issues/non_transitive.hpp
@@ -3,6 +3,7 @@
 #define CLUSTERING_ADMINISTRATION_ISSUES_NON_TRANSITIVE_HPP_
 
 #include "clustering/administration/issues/issue.hpp"
+#include "rpc/connectivity/server_id.hpp"
 
 class non_transitive_issue_t : public issue_t {
 public:

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/persist/file.hpp"
 
 #include "btree/depth_first_traversal.hpp"
+#include "btree/operations.hpp"
 #include "btree/types.hpp"
 #include "buffer_cache/blob.hpp"
 #include "buffer_cache/cache_balancer.hpp"

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -290,9 +290,8 @@ void metadata_file_t::write_txn_t::write_bin(
                     blob::btree_maxreflen);
         write_onto_blob(buf_parent_t(&kvloc.buf), &blob, *msg);
     }
-    null_key_modification_callback_t null_cb;
     apply_keyvalue_change(&sizer, &kvloc, key.btree_key(), repli_timestamp_t::invalid,
-        &detacher, &null_cb, delete_mode_t::ERASE);
+        &detacher, delete_mode_t::ERASE);
 }
 
 metadata_file_t::metadata_file_t(

--- a/src/clustering/administration/persist/file.hpp
+++ b/src/clustering/administration/persist/file.hpp
@@ -22,138 +22,35 @@ public:
     }
 };
 
+namespace metadata {
+class read_txn_t;
+class write_txn_t;
+
+template<class T>
+class key_t {
+public:
+    explicit key_t(const std::string &s) : key(s) { }
+    key_t suffix(const std::string &s) const {
+        key_t copy = *this;
+        guarantee(key.size() + s.size() <= MAX_KEY_SIZE);
+        copy.key.set_size(key.size() + s.size());
+        memcpy(copy.key.contents() + key.size(), s.c_str(), s.size());
+        return copy;
+    }
+private:
+    friend class metadata_file_t;
+    friend class read_txn_t;
+    friend class write_txn_t;
+    store_key_t key;
+};
+}
+
 class metadata_file_t {
 public:
-    template<class T>
-    class key_t {
-    public:
-        explicit key_t(const std::string &s) : key(s) { }
-        key_t suffix(const std::string &s) const {
-            key_t copy = *this;
-            guarantee(key.size() + s.size() <= MAX_KEY_SIZE);
-            copy.key.set_size(key.size() + s.size());
-            memcpy(copy.key.contents() + key.size(), s.c_str(), s.size());
-            return copy;
-        }
-    private:
-        friend class metadata_file_t;
-        store_key_t key;
-    };
-
-    class read_txn_t {
-    public:
-        read_txn_t(metadata_file_t *file, signal_t *interruptor);
-
-        template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
-        T read(const key_t<T> &key, signal_t *interruptor) {
-            T value;
-            bool found = read_maybe<T, W>(key, &value, interruptor);
-            guarantee(found, "failed to find expected metadata key");
-            return value;
-        }
-
-        template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
-        bool read_maybe(
-                const key_t<T> &key,
-                T *value_out,
-                signal_t *interruptor) {
-            bool found = false;
-            read_bin(
-                key.key,
-                [&](read_stream_t *bin_value) {
-                    archive_result_t res = deserialize<W>(bin_value, value_out);
-                    guarantee_deserialization(res, "metadata_file_t::read_txn_t::read");
-                    found = true;
-                },
-                interruptor);
-            return found;
-        }
-
-        template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
-        void read_many(
-                const key_t<T> &key_prefix,
-                const std::function<void(
-                    const std::string &key_suffix, const T &value)> &cb,
-                signal_t *interruptor) {
-            read_many_bin(
-                key_prefix.key,
-                [&](const std::string &key_suffix, read_stream_t *bin_value) {
-                    T value;
-                    archive_result_t res = deserialize<W>(bin_value, &value);
-                    guarantee_deserialization(res,
-                        "metadata_file_t::read_txn_t::read_many");
-                    cb(key_suffix, value);
-                },
-                interruptor);
-        }
-
-    protected:
-        txn_t *get_txn() {
-            return &txn;
-        }
-
-    private:
-        friend class metadata_file_t;
-
-        /* This constructor is used by `write_txn_t` */
-        read_txn_t(metadata_file_t *file, write_access_t, signal_t *interruptor);
-
-        void blob_to_stream(
-            buf_parent_t parent,
-            const void *ref,
-            const std::function<void(read_stream_t *)> &callback);
-
-        void read_bin(
-            const store_key_t &key,
-            const std::function<void(read_stream_t *)> &callback,
-            signal_t *interruptor);
-
-        void read_many_bin(
-            const store_key_t &key_prefix,
-            const std::function<void(
-                const std::string &key_suffix, read_stream_t *)> &cb,
-            signal_t *interruptor);
-
-        metadata_file_t *file;
-        txn_t txn;
-        rwlock_acq_t rwlock_acq;
-    };
-
-    class write_txn_t : public read_txn_t {
-    public:
-        write_txn_t(metadata_file_t *file, signal_t *interruptor);
-
-        template<class T>
-        void write(
-                const key_t<T> &key,
-                const T &value,
-                signal_t *interruptor) {
-            write_message_t wm;
-            serialize<cluster_version_t::LATEST_DISK>(&wm, value);
-            write_bin(key.key, &wm, interruptor);
-        }
-
-        template<class T>
-        void erase(const key_t<T> &key, signal_t *interruptor) {
-            write_bin(key.key, nullptr, interruptor);
-        }
-
-        // Must be called before the `write_txn_t` is destructed.
-        // This acts as a safety check to make sure a transaction
-        // is not interrupted in the middle, which could leave the
-        // metadata in an inconsistent state.
-        void commit() {
-            get_txn()->commit();
-        }
-
-    private:
-        friend class metadata_file_t;
-
-        void write_bin(
-            const store_key_t &key,
-            const write_message_t *msg,
-            signal_t *interruptor);
-    };
+    template <class T>
+    using key_t = metadata::key_t<T>;
+    using read_txn_t = metadata::read_txn_t;
+    using write_txn_t = metadata::write_txn_t;
 
     // Used to open an existing metadata file
     metadata_file_t(
@@ -172,6 +69,9 @@ public:
     ~metadata_file_t();
 
 private:
+    friend class metadata::read_txn_t;
+    friend class metadata::write_txn_t;
+
     void init_serializer(
         filepath_file_opener_t *file_opener,
         perfmon_collection_t *perfmon_parent);
@@ -185,6 +85,120 @@ private:
     btree_stats_t btree_stats;
     rwlock_t rwlock;
 };
+
+
+namespace metadata {
+class read_txn_t {
+public:
+    read_txn_t(metadata_file_t *file, signal_t *interruptor);
+
+    template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
+    T read(const key_t<T> &key, signal_t *interruptor) {
+        T value;
+        bool found = read_maybe<T, W>(key, &value, interruptor);
+        guarantee(found, "failed to find expected metadata key");
+        return value;
+    }
+
+    template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
+    bool read_maybe(
+            const key_t<T> &key,
+            T *value_out,
+            signal_t *interruptor) {
+        bool found = false;
+        read_bin(
+            key.key,
+            [&](read_stream_t *bin_value) {
+                archive_result_t res = deserialize<W>(bin_value, value_out);
+                guarantee_deserialization(res, "metadata_file_t::read_txn_t::read");
+                found = true;
+            },
+            interruptor);
+        return found;
+    }
+
+    template<class T, cluster_version_t W = cluster_version_t::LATEST_DISK>
+    void read_many(
+            const key_t<T> &key_prefix,
+            const std::function<void(
+                const std::string &key_suffix, const T &value)> &cb,
+            signal_t *interruptor) {
+        read_many_bin(
+            key_prefix.key,
+            [&](const std::string &key_suffix, read_stream_t *bin_value) {
+                T value;
+                archive_result_t res = deserialize<W>(bin_value, &value);
+                guarantee_deserialization(res,
+                    "metadata_file_t::read_txn_t::read_many");
+                cb(key_suffix, value);
+            },
+            interruptor);
+    }
+
+    friend class ::metadata_file_t;
+    friend class write_txn_t;
+
+private:
+    /* This constructor is used by `write_txn_t` */
+    read_txn_t(metadata_file_t *file, write_access_t, signal_t *interruptor);
+
+    void blob_to_stream(
+        buf_parent_t parent,
+        const void *ref,
+        const std::function<void(read_stream_t *)> &callback);
+
+    void read_bin(
+        const store_key_t &key,
+        const std::function<void(read_stream_t *)> &callback,
+        signal_t *interruptor);
+
+    void read_many_bin(
+        const store_key_t &key_prefix,
+        const std::function<void(
+            const std::string &key_suffix, read_stream_t *)> &cb,
+        signal_t *interruptor);
+
+    metadata_file_t *file;
+    txn_t txn;
+    rwlock_acq_t rwlock_acq;
+};
+
+class write_txn_t : public read_txn_t {
+public:
+    write_txn_t(metadata_file_t *file, signal_t *interruptor);
+
+    template<class T>
+    void write(
+            const key_t<T> &key,
+            const T &value,
+            signal_t *interruptor) {
+        write_message_t wm;
+        serialize<cluster_version_t::LATEST_DISK>(&wm, value);
+        write_bin(key.key, &wm, interruptor);
+    }
+
+    template<class T>
+    void erase(const key_t<T> &key, signal_t *interruptor) {
+        write_bin(key.key, nullptr, interruptor);
+    }
+
+    // Must be called before the `write_txn_t` is destructed.
+    // This acts as a safety check to make sure a transaction
+    // is not interrupted in the middle, which could leave the
+    // metadata in an inconsistent state.
+    void commit() {
+        txn.commit();
+    }
+
+private:
+    friend class ::metadata_file_t;
+
+    void write_bin(
+        const store_key_t &key,
+        const write_message_t *msg,
+        signal_t *interruptor);
+};
+}  // namespace metadata
 
 #endif /* CLUSTERING_ADMINISTRATION_PERSIST_FILE_HPP_ */
 

--- a/src/clustering/administration/persist/file.hpp
+++ b/src/clustering/administration/persist/file.hpp
@@ -2,7 +2,8 @@
 #ifndef CLUSTERING_ADMINISTRATION_PERSIST_FILE_HPP_
 #define CLUSTERING_ADMINISTRATION_PERSIST_FILE_HPP_
 
-#include "btree/operations.hpp"
+#include "btree/keys.hpp"
+#include "btree/stats.hpp"
 #include "buffer_cache/alt.hpp"
 #include "buffer_cache/types.hpp"
 #include "concurrency/rwlock.hpp"

--- a/src/clustering/administration/tables/table_metadata.cc
+++ b/src/clustering/administration/tables/table_metadata.cc
@@ -8,6 +8,119 @@
 #include "containers/archive/versioned.hpp"
 #include "rdb_protocol/protocol.hpp"
 
+std::set<server_id_t> table_config_t::shard_t::voting_replicas() const {
+    std::set<server_id_t> s;
+    std::set_difference(
+        all_replicas.begin(), all_replicas.end(),
+        nonvoting_replicas.begin(), nonvoting_replicas.end(),
+        std::inserter(s, s.end()));
+    return s;
+}
+
+
+key_range_t table_shard_scheme_t::get_shard_range(size_t i) const {
+    guarantee(i < num_shards());
+    store_key_t left = (i == 0) ? store_key_t::min() : split_points[i-1];
+    if (i != num_shards() - 1) {
+        return key_range_t(
+            key_range_t::closed, left,
+            key_range_t::open, split_points[i]);
+    } else {
+        return key_range_t(
+            key_range_t::closed, left,
+            key_range_t::none, store_key_t());
+    }
+}
+
+size_t table_shard_scheme_t::find_shard_for_key(const store_key_t &key) const {
+    size_t ix = 0;
+    while (ix < split_points.size() && key >= split_points[ix]) {
+        ++ix;
+    }
+    return ix;
+}
+
+class table_config_and_shards_change_t::apply_change_visitor_t
+    : public boost::static_visitor<bool> {
+public:
+    explicit apply_change_visitor_t(
+            table_config_and_shards_t *_table_config_and_shards)
+        : table_config_and_shards(_table_config_and_shards) { }
+
+    result_type operator()(
+            const set_table_config_and_shards_t &set_table_config_and_shards) const {
+        *table_config_and_shards =
+            set_table_config_and_shards.new_config_and_shards;
+        return true;
+    }
+
+    result_type operator()(const write_hook_create_t &write_hook_create) const {
+        table_config_and_shards->config.write_hook.set(write_hook_create.config);
+        return true;
+    }
+
+    result_type operator()(UNUSED const write_hook_drop_t &write_hook_drop) const {
+        table_config_and_shards->config.write_hook = r_nullopt;
+        return true;
+    }
+
+    result_type operator()(const sindex_create_t &sindex_create) const {
+        auto pair = table_config_and_shards->config.sindexes.insert(
+            std::make_pair(sindex_create.name, sindex_create.config));
+        return pair.second;
+    }
+
+    result_type operator()(const sindex_drop_t &sindex_drop) const {
+        auto size = table_config_and_shards->config.sindexes.erase(sindex_drop.name);
+        return size == 1;
+    }
+
+    result_type operator()(const sindex_rename_t &sindex_rename) const {
+        if (table_config_and_shards->config.sindexes.count(
+                sindex_rename.name) == 0) {
+            /* The index `sindex_rename.name` does not exist. */
+            return false;
+        }
+        if (sindex_rename.name != sindex_rename.new_name) {
+            if (table_config_and_shards->config.sindexes.count(
+                        sindex_rename.new_name) == 1 &&
+                    sindex_rename.overwrite == false) {
+                /* The index `sindex_rename.new_name` already exits and should not be
+                overwritten. */
+                return false;
+            } else {
+                table_config_and_shards->config.sindexes[sindex_rename.new_name] =
+                    table_config_and_shards->config.sindexes.at(sindex_rename.name);
+                table_config_and_shards->config.sindexes.erase(sindex_rename.name);
+            }
+        }
+        return true;
+    }
+
+private:
+    table_config_and_shards_t *table_config_and_shards;
+};
+
+/* Note, it's important that `apply_change` does not change
+`table_config_and_shards` if it returns false. */
+bool table_config_and_shards_change_t::apply_change(table_config_and_shards_t *table_config_and_shards) const {
+    return boost::apply_visitor(
+        apply_change_visitor_t(table_config_and_shards), change);
+}
+
+bool  table_config_and_shards_change_t::name_and_database_equal(const table_basic_config_t &table_basic_config) const {
+    const set_table_config_and_shards_t *set_table_config_and_shards =
+        boost::get<set_table_config_and_shards_t>(&change);
+    if (set_table_config_and_shards == nullptr) {
+        return true;
+    } else {
+        return set_table_config_and_shards->new_config_and_shards.config.basic.name == table_basic_config.name &&
+            set_table_config_and_shards->new_config_and_shards.config.basic.database == table_basic_config.database;
+    }
+}
+
+
+
 RDB_IMPL_SERIALIZABLE_3_SINCE_v2_1(table_basic_config_t,
     name, database, primary_key);
 RDB_IMPL_EQUALITY_COMPARABLE_3(table_basic_config_t,

--- a/src/clustering/administration/tables/table_metadata.hpp
+++ b/src/clustering/administration/tables/table_metadata.hpp
@@ -10,15 +10,11 @@
 
 #include "buffer_cache/types.hpp"   // for `write_durability_t`
 #include "clustering/administration/servers/server_metadata.hpp"
-#include "clustering/administration/tables/database_metadata.hpp"
 #include "clustering/generic/nonoverlapping_regions.hpp"
 #include "containers/name_string.hpp"
 #include "containers/uuid.hpp"
 #include "rdb_protocol/protocol.hpp"
-#include "rpc/semilattice/joins/deletable.hpp"
 #include "rpc/semilattice/joins/macros.hpp"
-#include "rpc/semilattice/joins/map.hpp"
-#include "rpc/semilattice/joins/versioned.hpp"
 #include "rpc/serialize_macros.hpp"
 
 /* This is the metadata for a single table. */
@@ -53,14 +49,7 @@ class table_config_t {
 public:
     class shard_t {
     public:
-        std::set<server_id_t> voting_replicas() const {
-            std::set<server_id_t> s;
-            std::set_difference(
-                all_replicas.begin(), all_replicas.end(),
-                nonvoting_replicas.begin(), nonvoting_replicas.end(),
-                std::inserter(s, s.end()));
-            return s;
-        }
+        std::set<server_id_t> voting_replicas() const;
 
         /* `nonvoting_replicas` must be a subset of `all_replicas`. `primary_replica`
         must be in `all_replicas` and not in `nonvoting_replicas`. */
@@ -93,27 +82,8 @@ public:
         return split_points.size() + 1;
     }
 
-    key_range_t get_shard_range(size_t i) const {
-        guarantee(i < num_shards());
-        store_key_t left = (i == 0) ? store_key_t::min() : split_points[i-1];
-        if (i != num_shards() - 1) {
-            return key_range_t(
-                key_range_t::closed, left,
-                key_range_t::open, split_points[i]);
-        } else {
-            return key_range_t(
-                key_range_t::closed, left,
-                key_range_t::none, store_key_t());
-        }
-    }
-
-    size_t find_shard_for_key(const store_key_t &key) const {
-        size_t ix = 0;
-        while (ix < split_points.size() && key >= split_points[ix]) {
-            ++ix;
-        }
-        return ix;
-    }
+    key_range_t get_shard_range(size_t i) const;
+    size_t find_shard_for_key(const store_key_t &key) const;
 };
 
 RDB_DECLARE_SERIALIZABLE(table_shard_scheme_t);
@@ -187,21 +157,9 @@ public:
 
     /* Note, it's important that `apply_change` does not change
     `table_config_and_shards` if it returns false. */
-    bool apply_change(table_config_and_shards_t *table_config_and_shards) const {
-        return boost::apply_visitor(
-            apply_change_visitor_t(table_config_and_shards), change);
-    }
+    bool apply_change(table_config_and_shards_t *table_config_and_shards) const;
 
-    bool name_and_database_equal(const table_basic_config_t &table_basic_config) const {
-        const set_table_config_and_shards_t *set_table_config_and_shards =
-            boost::get<set_table_config_and_shards_t>(&change);
-        if (set_table_config_and_shards == nullptr) {
-            return true;
-        } else {
-            return set_table_config_and_shards->new_config_and_shards.config.basic.name == table_basic_config.name &&
-                set_table_config_and_shards->new_config_and_shards.config.basic.database == table_basic_config.database;
-        }
-    }
+    bool name_and_database_equal(const table_basic_config_t &table_basic_config) const;
 
     RDB_MAKE_ME_SERIALIZABLE_1(table_config_and_shards_change_t, change);
 
@@ -214,66 +172,7 @@ private:
         write_hook_create_t,
         write_hook_drop_t> change;
 
-    class apply_change_visitor_t
-        : public boost::static_visitor<bool> {
-    public:
-        explicit apply_change_visitor_t(
-                table_config_and_shards_t *_table_config_and_shards)
-            : table_config_and_shards(_table_config_and_shards) { }
-
-        result_type operator()(
-                const set_table_config_and_shards_t &set_table_config_and_shards) const {
-            *table_config_and_shards =
-                set_table_config_and_shards.new_config_and_shards;
-            return true;
-        }
-
-        result_type operator()(const write_hook_create_t &write_hook_create) const {
-            table_config_and_shards->config.write_hook.set(write_hook_create.config);
-            return true;
-        }
-
-        result_type operator()(UNUSED const write_hook_drop_t &write_hook_drop) const {
-            table_config_and_shards->config.write_hook = r_nullopt;
-            return true;
-        }
-
-        result_type operator()(const sindex_create_t &sindex_create) const {
-            auto pair = table_config_and_shards->config.sindexes.insert(
-                std::make_pair(sindex_create.name, sindex_create.config));
-            return pair.second;
-        }
-
-        result_type operator()(const sindex_drop_t &sindex_drop) const {
-            auto size = table_config_and_shards->config.sindexes.erase(sindex_drop.name);
-            return size == 1;
-        }
-
-        result_type operator()(const sindex_rename_t &sindex_rename) const {
-            if (table_config_and_shards->config.sindexes.count(
-                    sindex_rename.name) == 0) {
-                /* The index `sindex_rename.name` does not exist. */
-                return false;
-            }
-            if (sindex_rename.name != sindex_rename.new_name) {
-                if (table_config_and_shards->config.sindexes.count(
-                            sindex_rename.new_name) == 1 &&
-                        sindex_rename.overwrite == false) {
-                    /* The index `sindex_rename.new_name` already exits and should not be
-                    overwritten. */
-                    return false;
-                } else {
-                    table_config_and_shards->config.sindexes[sindex_rename.new_name] =
-                        table_config_and_shards->config.sindexes.at(sindex_rename.name);
-                    table_config_and_shards->config.sindexes.erase(sindex_rename.name);
-                }
-            }
-            return true;
-        }
-
-    private:
-        table_config_and_shards_t *table_config_and_shards;
-    };
+    class apply_change_visitor_t;
 };
 
 RDB_DECLARE_SERIALIZABLE(table_config_and_shards_change_t::set_table_config_and_shards_t);

--- a/src/clustering/immediate_consistency/backfill_metadata.hpp
+++ b/src/clustering/immediate_consistency/backfill_metadata.hpp
@@ -2,7 +2,7 @@
 #ifndef CLUSTERING_IMMEDIATE_CONSISTENCY_BACKFILL_METADATA_HPP_
 #define CLUSTERING_IMMEDIATE_CONSISTENCY_BACKFILL_METADATA_HPP_
 
-#include "btree/backfill.hpp"
+#include "btree/backfill_types.hpp"
 #include "clustering/generic/registration_metadata.hpp"
 #include "clustering/immediate_consistency/backfill_item_seq.hpp"
 #include "clustering/immediate_consistency/history.hpp"

--- a/src/clustering/immediate_consistency/history.hpp
+++ b/src/clustering/immediate_consistency/history.hpp
@@ -5,7 +5,6 @@
 #include <map>
 #include <set>
 
-#include "concurrency/interruptor.hpp"
 #include "concurrency/signal.hpp"
 #include "containers/uuid.hpp"
 #include "region/region_map.hpp"

--- a/src/clustering/table_manager/multi_table_manager.cc
+++ b/src/clustering/table_manager/multi_table_manager.cc
@@ -37,7 +37,7 @@ multi_table_manager_t::multi_table_manager_t(
         [&](const namespace_id_t &table_id,
                 const table_active_persistent_state_t &state,
                 raft_storage_interface_t<table_raft_state_t> *raft_storage,
-                metadata_file_t::read_txn_t *metadata_read_txn) {
+                metadata::read_txn_t *metadata_read_txn) {
             guarantee(tables.count(table_id) == 0);
             table_t *table;
             tables[table_id].init(table = new table_t);
@@ -55,7 +55,7 @@ multi_table_manager_t::multi_table_manager_t(
         },
         [&](const namespace_id_t &table_id,
                 const table_inactive_persistent_state_t &state,
-                metadata_file_t::read_txn_t *) {
+                metadata::read_txn_t *) {
             guarantee(tables.count(table_id) == 0);
             table_t *table;
             tables[table_id].init(table = new table_t);

--- a/src/clustering/table_manager/table_metadata.hpp
+++ b/src/clustering/table_manager/table_metadata.hpp
@@ -2,7 +2,6 @@
 #ifndef CLUSTERING_TABLE_MANAGER_TABLE_METADATA_HPP_
 #define CLUSTERING_TABLE_MANAGER_TABLE_METADATA_HPP_
 
-#include "clustering/administration/persist/file.hpp"
 #include "clustering/generic/minidir.hpp"
 #include "clustering/generic/raft_core.hpp"
 #include "clustering/generic/raft_network.hpp"
@@ -11,6 +10,11 @@
 #include "clustering/table_contract/executor/exec.hpp"
 #include "containers/optional.hpp"
 #include "rpc/mailbox/typed.hpp"
+
+namespace metadata {
+class read_txn_t;
+class write_txn_t;
+}
 
 /* Every message to the `action_mailbox` has an `multi_table_manager_timestamp_t`
 attached. This is used to filter out outdated instructions. */
@@ -313,11 +317,11 @@ public:
             const namespace_id_t &table_id,
             const table_active_persistent_state_t &state,
             raft_storage_interface_t<table_raft_state_t> *raft_storage,
-            metadata_file_t::read_txn_t *metadata_read_txn)> &active_cb,
+            metadata::read_txn_t *metadata_read_txn)> &active_cb,
         const std::function<void(
             const namespace_id_t &table_id,
             const table_inactive_persistent_state_t &state,
-            metadata_file_t::read_txn_t *metadata_read_txn)> &inactive_cb,
+            metadata::read_txn_t *metadata_read_txn)> &inactive_cb,
         signal_t *interruptor) = 0;
 
     /* `write_metadata_active()` sets the stored metadata for the table to be the given
@@ -342,7 +346,7 @@ public:
 
     virtual void load_multistore(
         const namespace_id_t &table_id,
-        metadata_file_t::read_txn_t *metadata_read_txn,
+        metadata::read_txn_t *metadata_read_txn,
         scoped_ptr_t<multistore_ptr_t> *multistore_ptr_out,
         signal_t *interruptor,
         perfmon_collection_t *perfmon_collection_serializers) = 0;

--- a/src/concurrency/queue/disk_backed_queue_wrapper.hpp
+++ b/src/concurrency/queue/disk_backed_queue_wrapper.hpp
@@ -7,6 +7,7 @@
 
 #include "assignment_sentry.hpp"
 #include "concurrency/auto_drainer.hpp"
+#include "concurrency/interruptor.hpp"
 #include "concurrency/queue/passive_producer.hpp"
 #include "concurrency/wait_any.hpp"
 #include "containers/archive/archive.hpp"

--- a/src/extproc/http_job.cc
+++ b/src/extproc/http_job.cc
@@ -17,6 +17,7 @@
 #include "http/http_parser.hpp"
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/env.hpp"
 
 #define RETHINKDB_USER_AGENT (SOFTWARE_NAME_STRING "/" RETHINKDB_VERSION)

--- a/src/protocol_api.hpp
+++ b/src/protocol_api.hpp
@@ -9,8 +9,6 @@
 #include <vector>
 
 #include "buffer_cache/types.hpp"
-#include "clustering/administration/auth/user_context.hpp"
-#include "clustering/administration/auth/permission_error.hpp"
 #include "concurrency/fifo_checker.hpp"
 #include "concurrency/fifo_enforcer.hpp"
 #include "concurrency/interruptor.hpp"
@@ -27,6 +25,8 @@
 #include "version.hpp"
 
 namespace auth {
+class permission_error_t;
+class user_context_t;
 class username_t;
 }  // namespace auth
 

--- a/src/rdb_protocol/btree.cc
+++ b/src/rdb_protocol/btree.cc
@@ -130,9 +130,8 @@ void kv_location_delete(keyvalue_location_t *kv_location,
 
     kv_location->value.reset();
     rdb_value_sizer_t sizer(block_size);
-    null_key_modification_callback_t null_cb;
     apply_keyvalue_change(&sizer, kv_location, key.btree_key(), timestamp,
-            deletion_context->balancing_detacher(), &null_cb, delete_mode);
+            deletion_context->balancing_detacher(), delete_mode);
 }
 
 MUST_USE ql::serialization_result_t
@@ -174,11 +173,10 @@ kv_location_set(keyvalue_location_t *kv_location,
 
     // Actually update the leaf, if needed.
     kv_location->value = std::move(new_value);
-    null_key_modification_callback_t null_cb;
     rdb_value_sizer_t sizer(block_size);
     apply_keyvalue_change(&sizer, kv_location, key.btree_key(),
                           timestamp,
-                          deletion_context->balancing_detacher(), &null_cb,
+                          deletion_context->balancing_detacher(),
                           delete_mode_t::REGULAR_QUERY);
     return ql::serialization_result_t::SUCCESS;
 }
@@ -201,10 +199,9 @@ kv_location_set(keyvalue_location_t *kv_location,
     // Update the leaf, if needed.
     kv_location->value = std::move(new_value);
 
-    null_key_modification_callback_t null_cb;
     rdb_value_sizer_t sizer(kv_location->buf.cache()->max_block_size());
     apply_keyvalue_change(&sizer, kv_location, key.btree_key(), timestamp,
-                          deletion_context->balancing_detacher(), &null_cb,
+                          deletion_context->balancing_detacher(),
                           delete_mode_t::REGULAR_QUERY);
     return ql::serialization_result_t::SUCCESS;
 }

--- a/src/rdb_protocol/btree_store.cc
+++ b/src/rdb_protocol/btree_store.cc
@@ -5,6 +5,7 @@
 
 #include "arch/runtime/coroutines.hpp"
 #include "btree/depth_first_traversal.hpp"
+#include "btree/leaf_node.hpp"
 #include "btree/node.hpp"
 #include "btree/operations.hpp"
 #include "btree/reql_specific.hpp"
@@ -800,8 +801,7 @@ void store_t::clear_sindex_data(
                                  leaf_node,
                                  keys[i].btree_key(),
                                  repli_timestamp_t::distant_past,
-                                 kv_location.buf.get_recency(),
-                                 key_modification_proof_t::real_proof());
+                                 kv_location.buf.get_recency());
                 }
                 check_and_handle_underfull(sizer, &kv_location.buf,
                         &kv_location.last_buf, kv_location.superblock,

--- a/src/rdb_protocol/changefeed.hpp
+++ b/src/rdb_protocol/changefeed.hpp
@@ -14,7 +14,6 @@
 #include <boost/variant.hpp>
 
 #include "btree/keys.hpp"
-#include "clustering/administration/auth/user_context.hpp"
 #include "concurrency/new_mutex.hpp"
 #include "concurrency/promise.hpp"
 #include "concurrency/rwlock.hpp"
@@ -176,7 +175,8 @@ struct keyspec_t {
 };
 region_t keyspec_to_region(const keyspec_t &keyspec);
 
-struct streamspec_t {
+class streamspec_t {
+public:
     counted_t<datum_stream_t> maybe_src; // Non-null iff `include_initial`.
     std::string table_name;
     bool include_offsets;

--- a/src/rdb_protocol/configured_limits.hpp
+++ b/src/rdb_protocol/configured_limits.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+
 #include "rpc/serialize_macros.hpp"
 
 class rdb_context_t;

--- a/src/rdb_protocol/context.hpp
+++ b/src/rdb_protocol/context.hpp
@@ -10,6 +10,8 @@
 
 #include "concurrency/one_per_thread.hpp"
 #include "concurrency/promise.hpp"
+#include "concurrency/watchable.hpp"
+#include "containers/clone_ptr.hpp"
 #include "containers/counted.hpp"
 #include "containers/name_string.hpp"
 #include "containers/optional.hpp"
@@ -17,7 +19,6 @@
 #include "containers/uuid.hpp"
 #include "perfmon/perfmon.hpp"
 #include "protocol_api.hpp"
-#include "rdb_protocol/changefeed.hpp"
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/geo/distances.hpp"
 #include "rdb_protocol/geo/lon_lat_types.hpp"
@@ -30,6 +31,17 @@ class user_context_t;
 class permissions_t;
 
 }  // namespace auth
+
+namespace ql {
+class configured_limits_t;
+class datumspec_t;
+class env_t;
+class query_cache_t;
+
+namespace changefeed {
+class streamspec_t;
+}
+}
 
 struct admin_err_t;
 
@@ -116,9 +128,6 @@ public:
 RDB_DECLARE_SERIALIZABLE(sindex_status_t);
 
 namespace ql {
-class configured_limits_t;
-class env_t;
-class query_cache_t;
 class db_t : public single_threaded_countable_t<db_t> {
 public:
     db_t(uuid_u _id, const name_string_t &_name) : id(_id), name(_name) { }

--- a/src/rdb_protocol/datum.cc
+++ b/src/rdb_protocol/datum.cc
@@ -18,6 +18,7 @@
 #include "cjson/json.hpp"
 #include "containers/archive/stl_types.hpp"
 #include "containers/scoped.hpp"
+#include "math.hpp"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/stringbuffer.h"

--- a/src/rdb_protocol/datum.hpp
+++ b/src/rdb_protocol/datum.hpp
@@ -16,9 +16,6 @@
 #include "containers/counted.hpp"
 #include "containers/optional.hpp"
 #include "rdb_protocol/datum_string.hpp"
-#include "rapidjson/document.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
 #include "rdb_protocol/configured_limits.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/serialize_datum.hpp"
@@ -306,7 +303,6 @@ public:
     // json_writer_t can be rapidjson::Writer<rapidjson::StringBuffer>
     // or rapidjson::PrettyWriter<rapidjson::StringBuffer>
     template <class json_writer_t> void write_json(json_writer_t *writer) const;
-    rapidjson::Value as_json(rapidjson::Value::AllocatorType *allocator) const;
 
     // DEPRECATED: Used for backwards compatibility with reql_versions before 2.1
     cJSON *as_json_raw() const;
@@ -462,10 +458,7 @@ public:
 };
 
 datum_t to_datum(const Datum *d, const configured_limits_t &, reql_version_t);
-datum_t to_datum(
-    const rapidjson::Value &json,
-    const configured_limits_t &,
-    reql_version_t);
+
 
 // DEPRECATED: Used in the r.json term for pre 2.1 backwards compatibility
 datum_t to_datum(cJSON *json, const configured_limits_t &, reql_version_t);

--- a/src/rdb_protocol/datum.hpp
+++ b/src/rdb_protocol/datum.hpp
@@ -352,6 +352,10 @@ public:
     // the datum is currently backed by one, or NULL otherwise.
     const shared_buf_ref_t<char> *get_buf_ref() const;
 
+    // Same as get_pair() / get(), but don't perform boundary or type checks.
+    std::pair<datum_string_t, datum_t> unchecked_get_pair(size_t index) const;
+    datum_t unchecked_get(size_t) const;
+
 private:
     // We have a special version of `call_with_enough_stack` for datums that only uses
     // `call_with_enough_stack` if there a chance of additional recursion (based on
@@ -370,14 +374,6 @@ private:
 
     static std::vector<std::pair<datum_string_t, datum_t> > to_sorted_vec(
             std::map<datum_string_t, datum_t> &&map);
-
-    template <class json_writer_t>
-    void write_json_unchecked_stack(json_writer_t *writer) const;
-
-    // Same as get_pair() / get(), but don't perform boundary or type checks.
-    // For internal use to improve performance.
-    std::pair<datum_string_t, datum_t> unchecked_get_pair(size_t index) const;
-    datum_t unchecked_get(size_t) const;
 
     datum_t default_merge_unchecked_stack(const datum_t &rhs) const;
     datum_t custom_merge_unchecked_stack(const datum_t &rhs,

--- a/src/rdb_protocol/datum_json.hpp
+++ b/src/rdb_protocol/datum_json.hpp
@@ -1,0 +1,15 @@
+#ifndef RDB_PROTOCOL_DATUM_JSON_HPP_
+#define RDB_PROTOCOL_DATUM_JSON_HPP_
+
+#include "rapidjson/document.h"
+#include "rdb_protocol/configured_limits.hpp"
+#include "rdb_protocol/datum.hpp"
+
+namespace ql {
+datum_t to_datum(
+    const rapidjson::Value &json,
+    const configured_limits_t &,
+    reql_version_t);
+}
+
+#endif  // RDB_PROTOCOL_DATUM_JSON_HPP_

--- a/src/rdb_protocol/datum_stream.cc
+++ b/src/rdb_protocol/datum_stream.cc
@@ -3,6 +3,7 @@
 
 #include <map>
 
+#include "math.hpp"
 #include "rdb_protocol/batching.hpp"
 #include "rdb_protocol/datum_stream/array.hpp"
 #include "rdb_protocol/datum_stream/eq_join.hpp"
@@ -35,8 +36,6 @@
 #include "rdb_protocol/term.hpp"
 #include "rdb_protocol/val.hpp"
 #include "utils.hpp"
-
-#include "debug.hpp"
 
 namespace ql {
 

--- a/src/rdb_protocol/datumspec.hpp
+++ b/src/rdb_protocol/datumspec.hpp
@@ -74,7 +74,7 @@ private:
     std::function<T(const std::map<datum_t, uint64_t> &)> f2;
 };
 
-struct datumspec_t {
+class datumspec_t {
 public:
     template<class T>
     explicit datumspec_t(T t) : spec(std::move(t)) { }

--- a/src/rdb_protocol/erase_range.cc
+++ b/src/rdb_protocol/erase_range.cc
@@ -2,6 +2,7 @@
 #include "rdb_protocol/erase_range.hpp"
 
 #include "buffer_cache/alt.hpp"
+#include "btree/depth_first_traversal.hpp"
 #include "btree/leaf_node.hpp"
 #include "btree/node.hpp"
 #include "btree/operations.hpp"

--- a/src/rdb_protocol/erase_range.cc
+++ b/src/rdb_protocol/erase_range.cc
@@ -141,11 +141,9 @@ continue_bool_t rdb_erase_small_range(
                 buf_parent_t(&kv_location.buf), kv_location.value.get());
             // Erase the entry from the leaf node
             kv_location.value.reset();
-            null_key_modification_callback_t null_cb;
             apply_keyvalue_change(&sizer, &kv_location, key.btree_key(),
                                   repli_timestamp_t::invalid /* ignored for erase */,
                                   deletion_context->in_tree_deleter(),
-                                  &null_cb,
                                   delete_mode_t::ERASE);
         } // kv_location is destroyed here. That's important because sometimes
           // pass_back_superblock_promise isn't pulsed before the kv_location

--- a/src/rdb_protocol/protocol.hpp
+++ b/src/rdb_protocol/protocol.hpp
@@ -23,6 +23,7 @@
 #include "rdb_protocol/configured_limits.hpp"
 #include "rdb_protocol/context.hpp"
 #include "rdb_protocol/datum.hpp"
+#include "rdb_protocol/datumspec.hpp"
 #include "rdb_protocol/erase_range.hpp"
 #include "rdb_protocol/geo/ellipsoid.hpp"
 #include "rdb_protocol/geo/lon_lat_types.hpp"

--- a/src/rdb_protocol/pseudo_binary.hpp
+++ b/src/rdb_protocol/pseudo_binary.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "rdb_protocol/datum_string.hpp"

--- a/src/rdb_protocol/shards.hpp
+++ b/src/rdb_protocol/shards.hpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include "arch/runtime/coroutines.hpp"
-#include "btree/concurrent_traversal.hpp"
 #include "btree/keys.hpp"
+#include "btree/types.hpp"
 #include "containers/archive/stl_types.hpp"
 #include "containers/archive/varint.hpp"
 #include "containers/uuid.hpp"

--- a/src/rdb_protocol/store.hpp
+++ b/src/rdb_protocol/store.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "btree/node.hpp"
-#include "btree/parallel_traversal.hpp"
 #include "btree/secondary_operations.hpp"
 #include "buffer_cache/types.hpp"
 #include "concurrency/auto_drainer.hpp"

--- a/src/rdb_protocol/term_storage.cc
+++ b/src/rdb_protocol/term_storage.cc
@@ -2,6 +2,8 @@
 #include "rdb_protocol/term_storage.hpp"
 
 #include "arch/runtime/coroutines.hpp"
+#include "rapidjson/writer.h"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/optargs.hpp"
 #include "rdb_protocol/term_walker.hpp"
 

--- a/src/rdb_protocol/term_storage.hpp
+++ b/src/rdb_protocol/term_storage.hpp
@@ -11,6 +11,7 @@
 
 #include "containers/counted.hpp"
 #include "containers/scoped.hpp"
+#include "rapidjson/document.h"
 #include "rapidjson/rapidjson.h"
 #include "rdb_protocol/rdb_backtrace.hpp"
 #include "rdb_protocol/datum.hpp"

--- a/src/rdb_protocol/terms/json.cc
+++ b/src/rdb_protocol/terms/json.cc
@@ -1,5 +1,6 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "cjson/json.hpp"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/op.hpp"
 #include "rdb_protocol/term.hpp"
 #include "rdb_protocol/terms/terms.hpp"

--- a/src/unittest/btree_whole.cc
+++ b/src/unittest/btree_whole.cc
@@ -2,6 +2,7 @@
 
 #include "arch/io/disk.hpp"
 #include "arch/types.hpp"
+#include "btree/depth_first_traversal.hpp"
 #include "btree/reql_specific.hpp"
 #include "buffer_cache/cache_balancer.hpp"
 #include "rdb_protocol/btree.hpp"

--- a/src/unittest/btree_whole.cc
+++ b/src/unittest/btree_whole.cc
@@ -138,7 +138,6 @@ public:
             profile::trace_t trace;
             noop_value_deleter_t deleter;
             rdb_live_deletion_context_t deletion_context;
-            null_key_modification_callback_t null_cb;
 
             keyvalue_location_t kv_location;
             find_keyvalue_location_for_write(
@@ -162,7 +161,6 @@ public:
                 key.btree_key(),
                 timestamp,
                 &deleter,
-                &null_cb,
                 delete_mode_t::REGULAR_QUERY);
         });
 
@@ -180,7 +178,6 @@ public:
             profile::trace_t trace;
             noop_value_deleter_t deleter;
             rdb_live_deletion_context_t deletion_context;
-            null_key_modification_callback_t null_cb;
 
             keyvalue_location_t kv_location;
             find_keyvalue_location_for_write(
@@ -202,7 +199,6 @@ public:
                 key.btree_key(),
                 timestamp,
                 &deleter,
-                &null_cb,
                 delete_mode_t::REGULAR_QUERY);
         });
 

--- a/src/unittest/leaf_node_test.cc
+++ b/src/unittest/leaf_node_test.cc
@@ -47,8 +47,7 @@ public:
             key.btree_key(),
             v.data(),
             tstamp,
-            maximum_existing_tstamp_,
-            key_modification_proof_t::real_proof());
+            maximum_existing_tstamp_);
 
         maximum_existing_tstamp_ =
             superceding_recency(maximum_existing_tstamp_, tstamp);
@@ -77,8 +76,7 @@ public:
             node(),
             key.btree_key(),
             tstamp,
-            maximum_existing_tstamp_,
-            key_modification_proof_t::real_proof());
+            maximum_existing_tstamp_);
 
         maximum_existing_tstamp_ =
             superceding_recency(maximum_existing_tstamp_, tstamp);

--- a/src/unittest/rdb_btree.cc
+++ b/src/unittest/rdb_btree.cc
@@ -12,6 +12,7 @@
 #include "containers/uuid.hpp"
 #include "rapidjson/document.h"
 #include "rdb_protocol/btree.hpp"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/erase_range.hpp"
 #include "rdb_protocol/minidriver.hpp"

--- a/src/unittest/rdb_protocol.cc
+++ b/src/unittest/rdb_protocol.cc
@@ -12,6 +12,7 @@
 #include "extproc/extproc_pool.hpp"
 #include "extproc/extproc_spawner.hpp"
 #include "rdb_protocol/changefeed.hpp"
+#include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/datum_stream/vector.hpp"
 #include "rdb_protocol/minidriver.hpp"
 #include "rdb_protocol/protocol.hpp"


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Makes btree and buffer cache code not be included by clustering code.  This might improve compile time, but it would improve re-compile time when working on those parts of the codebase.

For example, buffer_cache/alt.hpp is only included by 52 .cc files now.
