### PR TITLE
Inclusion removal related to rdb_protocol and metadata

### DIFF
--- a/src/clustering/administration/auth/base_artificial_table_backend.hpp
+++ b/src/clustering/administration/auth/base_artificial_table_backend.hpp
@@ -6,10 +6,12 @@
 #include <string>
 #include <vector>
 
-#include "clustering/administration/metadata.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
 #include "containers/lifetime.hpp"
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
+#include "rpc/semilattice/view.hpp"
+
+class cluster_semilattice_metadata_t;
 
 namespace auth {
 

--- a/src/clustering/administration/auth/permissions_artificial_table_backend.hpp
+++ b/src/clustering/administration/auth/permissions_artificial_table_backend.hpp
@@ -3,6 +3,7 @@
 #define CLUSTERING_ADMINISTRATION_AUTH_PERMISSIONS_ARTIFICIAL_TABLE_BACKEND_HPP
 
 #include "clustering/administration/auth/base_artificial_table_backend.hpp"
+#include "rdb_protocol/context.hpp"
 
 class name_resolver_t;
 

--- a/src/clustering/administration/auth/users_artificial_table_backend.cc
+++ b/src/clustering/administration/auth/users_artificial_table_backend.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/auth/users_artificial_table_backend.hpp"
 
+#include "clustering/administration/auth/user.hpp"
+#include "clustering/administration/metadata.hpp"
+
 namespace auth {
 
 users_artificial_table_backend_t::users_artificial_table_backend_t(

--- a/src/clustering/administration/cluster_config.cc
+++ b/src/clustering/administration/cluster_config.cc
@@ -3,6 +3,7 @@
 
 #include "clustering/administration/admin_op_exc.hpp"
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 
 cluster_config_artificial_table_backend_t::cluster_config_artificial_table_backend_t(
         rdb_context_t *rdb_context,

--- a/src/clustering/administration/cluster_config.hpp
+++ b/src/clustering/administration/cluster_config.hpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "clustering/administration/metadata.hpp"
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
 #include "rpc/semilattice/view.hpp"
 

--- a/src/clustering/administration/datum_adapter.cc
+++ b/src/clustering/administration/datum_adapter.cc
@@ -1,8 +1,10 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "clustering/administration/datum_adapter.hpp"
 
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "clustering/administration/tables/database_metadata.hpp"
+#include "clustering/administration/tables/table_metadata.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
 #include "rdb_protocol/pseudo_time.hpp"
 

--- a/src/clustering/administration/issues/issues_backend.cc
+++ b/src/clustering/administration/issues/issues_backend.cc
@@ -3,6 +3,7 @@
 
 #include "clustering/administration/admin_op_exc.hpp"
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/main/watchable_fields.hpp"
 #include "concurrency/cross_thread_signal.hpp"
 

--- a/src/clustering/administration/issues/issues_backend.hpp
+++ b/src/clustering/administration/issues/issues_backend.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
-#include "clustering/administration/metadata.hpp"
 #include "concurrency/watchable.hpp"
 #include "clustering/administration/issues/local.hpp"
 #include "clustering/administration/issues/name_collision.hpp"

--- a/src/clustering/administration/issues/log_write.hpp
+++ b/src/clustering/administration/issues/log_write.hpp
@@ -7,7 +7,6 @@
 #include "clustering/administration/issues/issue.hpp"
 #include "containers/incremental_lenses.hpp"
 #include "rpc/mailbox/typed.hpp"
-#include "rdb_protocol/store.hpp"
 
 class local_issue_server_t;
 

--- a/src/clustering/administration/issues/memory.hpp
+++ b/src/clustering/administration/issues/memory.hpp
@@ -7,7 +7,6 @@
 #include "clustering/administration/issues/issue.hpp"
 #include "containers/incremental_lenses.hpp"
 #include "rpc/mailbox/typed.hpp"
-#include "rdb_protocol/store.hpp"
 
 class local_issue_server_t;
 

--- a/src/clustering/administration/issues/name_collision.cc
+++ b/src/clustering/administration/issues/name_collision.cc
@@ -2,7 +2,10 @@
 #include "clustering/administration/issues/name_collision.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
+#include "clustering/administration/tables/database_metadata.hpp"
+#include "clustering/administration/tables/table_metadata.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
 #include "rdb_protocol/configured_limits.hpp"
 

--- a/src/clustering/administration/issues/name_collision.hpp
+++ b/src/clustering/administration/issues/name_collision.hpp
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "clustering/administration/issues/issue.hpp"
-#include "clustering/administration/metadata.hpp"
 #include "rpc/connectivity/server_id.hpp"
 #include "rpc/semilattice/view.hpp"
 

--- a/src/clustering/administration/issues/outdated_index.hpp
+++ b/src/clustering/administration/issues/outdated_index.hpp
@@ -11,7 +11,6 @@
 #include "concurrency/one_per_thread.hpp"
 #include "concurrency/pump_coro.hpp"
 #include "containers/scoped.hpp"
-#include "rdb_protocol/store.hpp"
 
 class outdated_index_issue_t : public issue_t {
 public:

--- a/src/clustering/administration/issues/table.cc
+++ b/src/clustering/administration/issues/table.cc
@@ -3,7 +3,7 @@
 #include <map>
 
 #include "clustering/administration/datum_adapter.hpp"
-#include "clustering/administration/tables/table_metadata.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/tables/table_status.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
 

--- a/src/clustering/administration/jobs/backend.cc
+++ b/src/clustering/administration/jobs/backend.cc
@@ -8,6 +8,7 @@
 #include "clustering/administration/jobs/manager.hpp"
 #include "clustering/administration/jobs/report.hpp"
 #include "clustering/administration/main/watchable_fields.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "concurrency/cross_thread_signal.hpp"
 
 jobs_artificial_table_backend_t::jobs_artificial_table_backend_t(

--- a/src/clustering/administration/jobs/backend.hpp
+++ b/src/clustering/administration/jobs/backend.hpp
@@ -7,11 +7,16 @@
 #include <vector>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
+#include "rdb_protocol/context.hpp"
 #include "clustering/administration/auth/user_context.hpp"
-#include "clustering/administration/metadata.hpp"
 #include "concurrency/watchable.hpp"
 
+class cluster_directory_metadata_t;
+class cluster_semilattice_metadata_t;
 class server_config_client_t;
+class table_meta_client_t;
+template <class T> class semilattice_readwrite_view_t;
+template <class key_type, class inner_type> class change_tracking_map_t;
 
 class jobs_artificial_table_backend_t :
     public timer_cfeed_artificial_table_backend_t

--- a/src/clustering/administration/jobs/report.hpp
+++ b/src/clustering/administration/jobs/report.hpp
@@ -12,6 +12,7 @@
 #include "containers/archive/stl_types.hpp"
 #include "containers/uuid.hpp"
 #include "rdb_protocol/datum.hpp"
+#include "rpc/mailbox/typed.hpp"
 #include "rpc/serialize_macros.hpp"
 #include "time.hpp"
 

--- a/src/clustering/administration/logs/log_writer.cc
+++ b/src/clustering/administration/logs/log_writer.cc
@@ -17,6 +17,7 @@
 #include "arch/io/disk.hpp"
 #include "concurrency/promise.hpp"
 #include "containers/scoped.hpp"
+#include "paths.hpp"
 #include "thread_local.hpp"
 
 

--- a/src/clustering/administration/logs/logs_backend.cc
+++ b/src/clustering/administration/logs/logs_backend.cc
@@ -2,6 +2,9 @@
 #include "clustering/administration/logs/logs_backend.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/logs/log_writer.hpp"
+#include "clustering/administration/logs/log_transfer.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "rdb_protocol/pseudo_time.hpp"
 

--- a/src/clustering/administration/logs/logs_backend.hpp
+++ b/src/clustering/administration/logs/logs_backend.hpp
@@ -8,8 +8,11 @@
 #include <vector>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
-#include "clustering/administration/metadata.hpp"
+#include "rdb_protocol/context.hpp"
 
+class cluster_directory_metadata_t;
+class log_message_t;
+class log_server_business_card_t;
 class server_config_client_t;
 
 /* This backend assumes that the entries in the log file have timestamps that are unique

--- a/src/clustering/administration/servers/auto_reconnect.cc
+++ b/src/clustering/administration/servers/auto_reconnect.cc
@@ -5,6 +5,7 @@
 #include "clustering/administration/servers/config_client.hpp"
 #include "concurrency/exponential_backoff.hpp"
 #include "concurrency/wait_any.hpp"
+#include "logger.hpp"
 
 auto_reconnector_t::auto_reconnector_t(
         connectivity_cluster_t *connectivity_cluster_,

--- a/src/clustering/administration/servers/config_client.cc
+++ b/src/clustering/administration/servers/config_client.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "clustering/administration/servers/config_client.hpp"
 
+#include "clustering/administration/admin_op_exc.hpp"
+#include "clustering/administration/metadata.hpp"
+
 server_config_client_t::server_config_client_t(
         mailbox_manager_t *_mailbox_manager,
         watchable_map_t<peer_id_t, cluster_directory_metadata_t> *_directory_view,

--- a/src/clustering/administration/servers/config_client.hpp
+++ b/src/clustering/administration/servers/config_client.hpp
@@ -6,11 +6,14 @@
 #include <set>
 #include <string>
 
-#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"
 #include "containers/incremental_lenses.hpp"
 #include "rpc/mailbox/mailbox.hpp"
 #include "rpc/semilattice/view.hpp"
+
+class cluster_directory_metadata_t;
+class empty_value_t;
+struct admin_err_t;
 
 struct server_connectivity_t {
     std::map<server_id_t, std::set<server_id_t> > connected_to;

--- a/src/clustering/administration/servers/server_common.cc
+++ b/src/clustering/administration/servers/server_common.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/servers/server_common.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "concurrency/cross_thread_signal.hpp"
 

--- a/src/clustering/administration/servers/server_config.cc
+++ b/src/clustering/administration/servers/server_config.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/servers/server_config.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "concurrency/cross_thread_signal.hpp"
 

--- a/src/clustering/administration/servers/server_status.cc
+++ b/src/clustering/administration/servers/server_status.cc
@@ -3,6 +3,7 @@
 
 #include "clustering/administration/admin_op_exc.hpp"
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/main/watchable_fields.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 

--- a/src/clustering/administration/servers/server_status.hpp
+++ b/src/clustering/administration/servers/server_status.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/server_common.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"
 #include "rdb_protocol/artificial_table/backend.hpp"

--- a/src/clustering/administration/stats/debug_stats_backend.cc
+++ b/src/clustering/administration/stats/debug_stats_backend.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/stats/debug_stats_backend.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "clustering/administration/main/watchable_fields.hpp"
 

--- a/src/clustering/administration/stats/debug_stats_backend.hpp
+++ b/src/clustering/administration/stats/debug_stats_backend.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/server_common.hpp"
 #include "clustering/administration/servers/server_metadata.hpp"
 #include "clustering/administration/stats/stat_manager.hpp"

--- a/src/clustering/administration/stats/stats_backend.hpp
+++ b/src/clustering/administration/stats/stats_backend.hpp
@@ -7,9 +7,12 @@
 #include <vector>
 
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
-#include "clustering/administration/metadata.hpp"
+#include "rdb_protocol/context.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "concurrency/watchable.hpp"
+
+class cluster_semilattice_metadata_t;
+class table_meta_client_t;
 
 class stats_artificial_table_backend_t :
     public timer_cfeed_artificial_table_backend_t

--- a/src/clustering/administration/tables/calculate_status.cc
+++ b/src/clustering/administration/tables/calculate_status.cc
@@ -77,7 +77,7 @@ void get_table_status(
         table_status_t *status_out)
         THROWS_ONLY(interrupted_exc_t, no_such_table_exc_t) {
     status_out->total_loss = false;
-    status_out->config = config;
+    *status_out->config = config;
 
     /* Get the Raft leader for this table. */
     table_meta_client->get_raft_leader(table_id, interruptor, &status_out->raft_leader);

--- a/src/clustering/administration/tables/calculate_status.hpp
+++ b/src/clustering/administration/tables/calculate_status.hpp
@@ -2,7 +2,9 @@
 #ifndef CLUSTERING_ADMINISTRATION_TABLES_CALCULATE_STATUS_HPP_
 #define CLUSTERING_ADMINISTRATION_TABLES_CALCULATE_STATUS_HPP_
 
+#include "clustering/administration/servers/server_metadata.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
+#include "rpc/connectivity/server_id.hpp"
 #include "protocol_api.hpp"
 
 class namespace_repo_t;
@@ -54,7 +56,7 @@ public:
     appear in `server_shards` that aren't in `config`. Every server in any of the three
     appears in `server_names`. */
 
-    table_config_and_shards_t config;
+    scoped_ptr_t<table_config_and_shards_t> config = make_scoped<table_config_and_shards_t>();
     std::map<server_id_t, range_map_t<key_range_t::right_bound_t,
         table_shard_status_t> > server_shards;
     optional<server_id_t> raft_leader;

--- a/src/clustering/administration/tables/debug_table_status.cc
+++ b/src/clustering/administration/tables/debug_table_status.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/tables/debug_table_status.hpp"
 
 #include "clustering/administration/datum_adapter.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "clustering/administration/tables/table_config.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"

--- a/src/clustering/administration/tables/table_common.hpp
+++ b/src/clustering/administration/tables/table_common.hpp
@@ -7,10 +7,12 @@
 #include <vector>
 
 #include "clustering/administration/admin_op_exc.hpp"
-#include "clustering/administration/metadata.hpp"
 #include "containers/lifetime.hpp"
 #include "rdb_protocol/artificial_table/caching_cfeed_backend.hpp"
+#include "rdb_protocol/context.hpp"
 #include "rpc/semilattice/view.hpp"
+
+class cluster_semilattice_metadata_t;
 
 /* This is a base class for the `rethinkdb.table_config` and `rethinkdb.table_status`
 pseudo-tables. Subclasses should implement `format_row()` and `write_row()`. */

--- a/src/clustering/administration/tables/table_config.hpp
+++ b/src/clustering/administration/tables/table_config.hpp
@@ -13,6 +13,7 @@
 #include "rpc/semilattice/view.hpp"
 
 class real_reql_cluster_interface_t;
+class table_config_t;
 
 /* This is publicly exposed so that it can be used to create the return value of
 `table.reconfigure()`. */

--- a/src/clustering/administration/tables/table_status.cc
+++ b/src/clustering/administration/tables/table_status.cc
@@ -5,6 +5,7 @@
 
 #include "clustering/administration/datum_adapter.hpp"
 #include "clustering/administration/servers/config_client.hpp"
+#include "clustering/administration/metadata.hpp"
 #include "clustering/table_contract/executor/exec_primary.hpp"
 #include "clustering/table_manager/table_meta_client.hpp"
 
@@ -118,8 +119,8 @@ ql::datum_t convert_table_status_to_datum(
         builder.overwrite("shards", ql::datum_t::null());
     } else {
         ql::datum_array_builder_t shards_builder(ql::configured_limits_t::unlimited);
-        for (size_t i = 0; i < status.config.config.shards.size(); ++i) {
-            key_range_t range = status.config.shard_scheme.get_shard_range(i);
+        for (size_t i = 0; i < status.config->config.shards.size(); ++i) {
+            key_range_t range = status.config->shard_scheme.get_shard_range(i);
             std::map<server_id_t, table_shard_status_t> states;
             for (const auto &pair : status.server_shards) {
                 pair.second.visit(
@@ -132,7 +133,7 @@ ql::datum_t convert_table_status_to_datum(
                     });
             }
             shards_builder.add(convert_shard_status_to_datum(
-                status.config.config.shards[i], states, status.disconnected,
+                status.config->config.shards[i], states, status.disconnected,
                 identifier_format, status.server_names));
         }
         builder.overwrite("shards", std::move(shards_builder).to_datum());
@@ -172,7 +173,7 @@ void table_status_artificial_table_backend_t::format_row(
     ql::datum_object_builder_t builder(status_datum);
     builder.overwrite("id", convert_uuid_to_datum(table_id));
     builder.overwrite("db", db_name_or_uuid);
-    builder.overwrite("name", convert_name_to_datum(status.config.config.basic.name));
+    builder.overwrite("name", convert_name_to_datum(status.config->config.basic.name));
     *row_out = std::move(builder).to_datum();
 }
 

--- a/src/clustering/generic/raft_core.tcc
+++ b/src/clustering/generic/raft_core.tcc
@@ -9,6 +9,7 @@
 #include "concurrency/exponential_backoff.hpp"
 #include "containers/map_sentries.hpp"
 #include "logger.hpp"
+#include "random.hpp"
 
 /* After finding myself repeatedly adding debug logging to Raft and then tearing it out
 when I didn't need it anymore, I automated the process. Define `ENABLE_RAFT_DEBUG` to

--- a/src/clustering/id_types.hpp
+++ b/src/clustering/id_types.hpp
@@ -1,0 +1,8 @@
+#ifndef CLUSTERING_ID_TYPES_HPP_
+#define CLUSTERING_ID_TYPES_HPP_
+
+#include "containers/uuid.hpp"
+
+typedef uuid_u contract_id_t;
+
+#endif  // CLUSTERING_ID_TYPES_HPP_

--- a/src/clustering/immediate_consistency/backfill_item_seq.hpp
+++ b/src/clustering/immediate_consistency/backfill_item_seq.hpp
@@ -1,7 +1,10 @@
 #ifndef CLUSTERING_IMMEDIATE_CONSISTENCY_BACKFILL_ITEM_SEQ_HPP_
 #define CLUSTERING_IMMEDIATE_CONSISTENCY_BACKFILL_ITEM_SEQ_HPP_
 
-#include "rdb_protocol/protocol.hpp"
+#include <list>
+
+#include "btree/keys.hpp"
+#include "region/region.hpp"
 
 /* A `backfill_item_seq_t` contains all of the `backfill_{pre_}item_t`s in some range of
 the key-space. The items are stored in lexicographical order.

--- a/src/clustering/immediate_consistency/backfill_metadata.hpp
+++ b/src/clustering/immediate_consistency/backfill_metadata.hpp
@@ -6,8 +6,8 @@
 #include "clustering/generic/registration_metadata.hpp"
 #include "clustering/immediate_consistency/backfill_item_seq.hpp"
 #include "clustering/immediate_consistency/history.hpp"
+#include "concurrency/fifo_enforcer.hpp"
 #include "rdb_protocol/distribution_progress.hpp"
-#include "rdb_protocol/protocol.hpp"
 #include "rpc/mailbox/typed.hpp"
 
 /* `backfill_config_t` contains parameters for tuning the backfill's performance and

--- a/src/clustering/immediate_consistency/replica.cc
+++ b/src/clustering/immediate_consistency/replica.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/replica.hpp"
 
+#include "rdb_protocol/protocol.hpp"
 #include "store_view.hpp"
 
 replica_t::replica_t(

--- a/src/clustering/query_routing/table_query_client.cc
+++ b/src/clustering/query_routing/table_query_client.cc
@@ -6,6 +6,7 @@
 #include "clustering/query_routing/primary_query_client.hpp"
 #include "clustering/table_contract/cpu_sharding.hpp"
 #include "clustering/table_manager/multi_table_manager.hpp"
+#include "clustering/table_manager/table_meta_client.hpp"
 #include "concurrency/cross_thread_signal.hpp"
 #include "concurrency/fifo_enforcer.hpp"
 #include "concurrency/watchable.hpp"

--- a/src/clustering/table_contract/contract_metadata.hpp
+++ b/src/clustering/table_contract/contract_metadata.hpp
@@ -8,6 +8,7 @@
 
 #include "clustering/administration/tables/table_metadata.hpp"
 #include "clustering/generic/raft_core.hpp"
+#include "clustering/id_types.hpp"
 #include "clustering/immediate_consistency/history.hpp"
 #include "containers/optional.hpp"
 #include "region/region_map.hpp"
@@ -103,7 +104,8 @@ acking.
 In order to facilitiate CPU sharding, each contract's region must apply to exactly one
 CPU shard. */
 
-typedef uuid_u contract_id_t;
+// Defined in id_types.hpp.
+// typedef uuid_u contract_id_t;
 
 /* The `contract_executor_t` looks at what each `contract_t` says about its server ID,
 and reacts according to the following rules:

--- a/src/clustering/table_contract/coordinator/coordinator.hpp
+++ b/src/clustering/table_contract/coordinator/coordinator.hpp
@@ -3,8 +3,13 @@
 #define CLUSTERING_TABLE_CONTRACT_COORDINATOR_COORDINATOR_HPP_
 
 #include "clustering/generic/raft_core.hpp"
-#include "clustering/table_contract/contract_metadata.hpp"
+#include "clustering/id_types.hpp"
 #include "concurrency/pump_coro.hpp"
+
+class contract_ack_t;
+class server_id_t;
+class table_config_and_shards_t;
+class table_raft_state_t;
 
 /* There is one `contract_coordinator_t` per table, located on whichever server is
 currently the Raft leader. It's the only thing which ever initiates Raft transactions.

--- a/src/clustering/table_contract/executor/exec.hpp
+++ b/src/clustering/table_contract/executor/exec.hpp
@@ -2,16 +2,18 @@
 #ifndef CLUSTERING_TABLE_CONTRACT_EXECUTOR_EXEC_HPP_
 #define CLUSTERING_TABLE_CONTRACT_EXECUTOR_EXEC_HPP_
 
+#include "clustering/id_types.hpp"
 #include "clustering/immediate_consistency/backfill_metadata.hpp"
 #include "clustering/immediate_consistency/remote_replicator_metadata.hpp"
-#include "clustering/table_contract/contract_metadata.hpp"
-#include "clustering/query_routing/metadata.hpp"
 #include "paths.hpp"
 #include "store_view.hpp"
 
 class backfill_progress_tracker_t;
 class backfill_throttler_t;
+class contract_ack_t;
 class io_backender_t;
+class table_raft_state_t;
+class table_query_bcard_t;
 
 /* `contract_execution_bcard_t`s are passed around between the `contract_executor_t`s for
 the same table on different servers. They allow servers to request backfills from one

--- a/src/clustering/table_contract/executor/executor.hpp
+++ b/src/clustering/table_contract/executor/executor.hpp
@@ -4,13 +4,14 @@
 
 #include "clustering/generic/raft_core.hpp"
 #include "clustering/immediate_consistency/history.hpp"
-#include "clustering/table_contract/contract_metadata.hpp"
 #include "clustering/table_contract/cpu_sharding.hpp"
 #include "clustering/table_contract/executor/exec.hpp"
 #include "concurrency/pump_coro.hpp"
 #include "store_subview.hpp"
 
 class backfill_progress_tracker_t;
+class contract_t;
+class table_shard_status_t;
 
 /* The `contract_executor_t` is responsible for executing the instructions contained in
 the `contract_t`s in the `table_raft_state_t`. Each server has one `contract_executor_t`

--- a/src/clustering/table_manager/multi_table_manager.cc
+++ b/src/clustering/table_manager/multi_table_manager.cc
@@ -2,6 +2,7 @@
 #include "clustering/table_manager/multi_table_manager.hpp"
 
 #include "clustering/generic/raft_core.tcc"
+#include "clustering/query_routing/metadata.hpp"
 #include "clustering/table_manager/table_manager.hpp"
 #include "logger.hpp"
 

--- a/src/clustering/table_manager/server_name_cache_updater.cc
+++ b/src/clustering/table_manager/server_name_cache_updater.cc
@@ -3,6 +3,7 @@
 #include "clustering/table_manager/server_name_cache_updater.hpp"
 
 #include "clustering/generic/raft_core.tcc"
+#include "clustering/table_contract/contract_metadata.hpp"
 
 server_name_cache_updater_t::server_name_cache_updater_t(
         raft_member_t<table_raft_state_t> *_raft,

--- a/src/clustering/table_manager/server_name_cache_updater.hpp
+++ b/src/clustering/table_manager/server_name_cache_updater.hpp
@@ -5,6 +5,9 @@
 #include "clustering/administration/servers/config_client.hpp"
 #include "concurrency/pump_coro.hpp"
 
+template <class state_t> class raft_member_t;
+class table_raft_state_t;
+
 class server_name_cache_updater_t {
 public:
     server_name_cache_updater_t(

--- a/src/clustering/table_manager/table_meta_client.cc
+++ b/src/clustering/table_manager/table_meta_client.cc
@@ -24,6 +24,8 @@ table_meta_client_t::table_meta_client_t(
     table_basic_configs(multi_table_manager->get_table_basic_configs())
     { }
 
+table_meta_client_t::~table_meta_client_t() {}
+
 void table_meta_client_t::find(
         const database_id_t &database,
         const name_string_t &name,

--- a/src/clustering/table_manager/table_meta_client.hpp
+++ b/src/clustering/table_manager/table_meta_client.hpp
@@ -2,12 +2,33 @@
 #ifndef CLUSTERING_TABLE_MANAGER_TABLE_META_CLIENT_HPP_
 #define CLUSTERING_TABLE_MANAGER_TABLE_META_CLIENT_HPP_
 
-#include "clustering/table_manager/table_metadata.hpp"
+#include "btree/keys.hpp"
 #include "concurrency/cross_thread_watchable.hpp"
 #include "concurrency/watchable_map.hpp"
+#include "containers/uuid.hpp"
 
+enum class all_replicas_ready_mode_t;
+enum class emergency_repair_mode_t;
+class mailbox_manager_t;
 class multi_table_manager_t;
+class multi_table_manager_bcard_t;
+class multi_table_manager_timestamp_t;
+class multi_table_manager_timestamp_epoch_t;
+class name_string_t;
+class peer_id_t;
+template <class edge_t, class value_t> class range_map_t;
 class server_config_client_t;
+class server_id_t;
+class sindex_config_t;
+class sindex_status_t;
+class table_basic_config_t;
+class table_config_and_shards_t;
+class table_config_and_shards_change_t;
+class table_raft_state_t;
+class table_manager_bcard_t;
+class table_shard_status_t;
+class table_status_request_t;
+class table_status_response_t;
 
 /* These four exception classes are all thrown by `table_meta_client_t` to describe
 different error conditions. There are several reasons why this is better than having
@@ -79,6 +100,7 @@ public:
         watchable_map_t<std::pair<peer_id_t, namespace_id_t>, table_manager_bcard_t>
             *_table_manager_directory,
         server_config_client_t *_server_config_client);
+    ~table_meta_client_t();
 
     /* All of these functions can be called from any thread. */
 
@@ -216,7 +238,7 @@ private:
     void create_or_emergency_repair(
         const namespace_id_t &table_id,
         const table_raft_state_t &raft_state,
-        const multi_table_manager_timestamp_t::epoch_t &epoch,
+        const multi_table_manager_timestamp_epoch_t &epoch,
         signal_t *interruptor)
         THROWS_ONLY(interrupted_exc_t, failed_table_op_exc_t,
             maybe_failed_table_op_exc_t);

--- a/src/rdb_protocol/artificial_table/backend.hpp
+++ b/src/rdb_protocol/artificial_table/backend.hpp
@@ -5,8 +5,23 @@
 #include <string>
 #include <vector>
 
+#include "concurrency/cross_thread_mutex.hpp"
+#include "containers/name_string.hpp"
+#include "containers/uuid.hpp"
 #include "rdb_protocol/datum.hpp"
-#include "rdb_protocol/datum_stream.hpp"
+
+namespace auth {
+class user_context_t;
+}
+
+namespace ql {
+class datum_stream_t;
+class datumspec_t;
+namespace changefeed { class streamspec_t; }
+}
+
+struct admin_err_t;
+enum class sorting_t;
 
 /* `artificial_table_backend_t` is the interface that `artificial_table_t` uses to access
 the actual data or configuration. There is one subclass for each table like

--- a/src/rdb_protocol/artificial_table/cfeed_backend.cc
+++ b/src/rdb_protocol/artificial_table/cfeed_backend.cc
@@ -3,6 +3,7 @@
 
 #include "clustering/administration/admin_op_exc.hpp"
 #include "concurrency/cross_thread_signal.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/env.hpp"
 
 /* We destroy the machinery if there have been no changefeeds for this many seconds */

--- a/src/rdb_protocol/artificial_table/cfeed_backend.hpp
+++ b/src/rdb_protocol/artificial_table/cfeed_backend.hpp
@@ -3,6 +3,7 @@
 #define RDB_PROTOCOL_ARTIFICIAL_TABLE_CFEED_BACKEND_HPP_
 
 #include "arch/timing.hpp"
+#include "clustering/administration/auth/user_context.hpp"
 #include "concurrency/new_mutex.hpp"
 #include "containers/scoped.hpp"
 #include "rdb_protocol/artificial_table/backend.hpp"

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -11,6 +11,7 @@
 #include "containers/archive/boost_types.hpp"
 #include "rdb_protocol/artificial_table/backend.hpp"
 #include "rdb_protocol/btree.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/geo/exceptions.hpp"
 #include "rdb_protocol/geo/intersection.hpp"

--- a/src/rdb_protocol/datum_stream.hpp
+++ b/src/rdb_protocol/datum_stream.hpp
@@ -26,8 +26,6 @@ class func_t;
 class response_t;
 class val_t;
 
-enum class return_empty_normal_batches_t { NO, YES };
-
 enum class feed_type_t { not_feed, point, stream, orderby_limit, unioned };
 
 // Handle unions of changefeeds; if there's no plausible unioned type then we

--- a/src/rdb_protocol/env.hpp
+++ b/src/rdb_protocol/env.hpp
@@ -15,7 +15,6 @@
 #include "extproc/js_runner.hpp"
 #include "rdb_protocol/configured_limits.hpp"
 #include "rdb_protocol/context.hpp"
-#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/optargs.hpp"
 #include "rdb_protocol/protocol.hpp"
@@ -32,6 +31,8 @@ class RE2;
 namespace ql {
 class datum_t;
 class term_t;
+
+enum class return_empty_normal_batches_t { NO, YES };
 
 scoped_ptr_t<profile::trace_t> maybe_make_profile_trace(profile_bool_t profile);
 

--- a/src/rdb_protocol/query_cache.cc
+++ b/src/rdb_protocol/query_cache.cc
@@ -2,6 +2,7 @@
 #include "rdb_protocol/query_cache.hpp"
 
 #include "rdb_protocol/env.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/pseudo_time.hpp"
 #include "rdb_protocol/response.hpp"
 #include "rdb_protocol/term_walker.hpp"

--- a/src/rdb_protocol/query_cache.hpp
+++ b/src/rdb_protocol/query_cache.hpp
@@ -20,7 +20,6 @@
 #include "containers/counted.hpp"
 #include "containers/intrusive_list.hpp"
 #include "containers/object_buffer.hpp"
-#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/rdb_backtrace.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/env.hpp"
@@ -31,6 +30,8 @@
 #include "rdb_protocol/wire_func.hpp"
 
 namespace ql {
+class datum_stream_t;
+class response_t;
 
 class query_cache_t : public home_thread_mixin_t {
     class entry_t;

--- a/src/rdb_protocol/shards.cc
+++ b/src/rdb_protocol/shards.cc
@@ -7,6 +7,7 @@
 #include <boost/variant.hpp>
 
 #include "debug.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/profile.hpp"
 #include "rdb_protocol/protocol.hpp"

--- a/src/rdb_protocol/terms/arr.cc
+++ b/src/rdb_protocol/terms/arr.cc
@@ -3,6 +3,7 @@
 
 #include "math.hpp"
 #include "parsing/utf8.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/op.hpp"

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -8,6 +8,7 @@
 #include "clustering/administration/auth/permissions.hpp"
 #include "clustering/administration/auth/username.hpp"
 #include "containers/name_string.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/datum_string.hpp"
 #include "rdb_protocol/op.hpp"
 #include "rdb_protocol/pseudo_geometry.hpp"

--- a/src/rdb_protocol/terms/geo.cc
+++ b/src/rdb_protocol/terms/geo.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/geo/distances.hpp"
 #include "rdb_protocol/geo/ellipsoid.hpp"
 #include "rdb_protocol/geo/exceptions.hpp"

--- a/src/rdb_protocol/terms/http.cc
+++ b/src/rdb_protocol/terms/http.cc
@@ -7,6 +7,7 @@
 #include "clustering/administration/metadata.hpp"
 #include "extproc/http_runner.hpp"
 #include "math.hpp"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/op.hpp"

--- a/src/rdb_protocol/terms/obj_or_seq.cc
+++ b/src/rdb_protocol/terms/obj_or_seq.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <functional>
 
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/op.hpp"

--- a/src/rdb_protocol/terms/type_manip.cc
+++ b/src/rdb_protocol/terms/type_manip.cc
@@ -8,6 +8,7 @@
 #include "clustering/administration/admin_op_exc.hpp"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/math_utils.hpp"

--- a/src/rdb_protocol/terms/writes.cc
+++ b/src/rdb_protocol/terms/writes.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/func.hpp"
 #include "rdb_protocol/minidriver.hpp"

--- a/src/rdb_protocol/val.cc
+++ b/src/rdb_protocol/val.cc
@@ -13,6 +13,10 @@
 
 namespace ql {
 
+selection_t::selection_t(counted_t<table_t> _table, counted_t<datum_stream_t> _seq)
+        : table(std::move(_table)), seq(std::move(_seq)) { }
+selection_t::~selection_t() {}
+
 class get_selection_t : public single_selection_t {
 public:
     get_selection_t(env_t *_env,

--- a/src/rdb_protocol/val.hpp
+++ b/src/rdb_protocol/val.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "containers/counted.hpp"
-#include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/datum_string.hpp"
 #include "rdb_protocol/geo/distances.hpp"
 #include "rdb_protocol/geo/lon_lat_types.hpp"
@@ -174,8 +173,8 @@ protected:
 
 class selection_t : public single_threaded_countable_t<selection_t> {
 public:
-    selection_t(counted_t<table_t> _table, counted_t<datum_stream_t> _seq)
-        : table(std::move(_table)), seq(std::move(_seq)) { }
+    selection_t(counted_t<table_t> _table, counted_t<datum_stream_t> _seq);
+    ~selection_t();
     counted_t<table_t> table;
     counted_t<datum_stream_t> seq;
 };

--- a/src/store_view.hpp
+++ b/src/store_view.hpp
@@ -1,6 +1,7 @@
 #ifndef STORE_VIEW_HPP_
 #define STORE_VIEW_HPP_
 
+#include "btree/types.hpp"
 #include "protocol_api.hpp"
 #include "region/region_map.hpp"
 


### PR DESCRIPTION
Separates out some rdb_protocol stuff from being a direct include dependency of clustering code, a bit.

- Removes clustering inclusions of metadata.hpp,
  contract_metadata.hpp, table_metadata.hpp.

- Removes some protocol.hpp inclusions

- Vastly reduces inclusion of store.hpp, datum_stream.hpp

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
