### PR TITLE
Fix macOS build, including math.h

### DIFF
--- a/src/unittest/timer_test.cc
+++ b/src/unittest/timer_test.cc
@@ -1,4 +1,6 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
+#include <math.h>
+
 #include <algorithm>
 
 #include "arch/timing.hpp"


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Includes math.h in a unittest file to fix macOS build (after recent include simplification).  On Linux, I suppose some other system header brings it in.
