### PR TITLE
Fix default port and host overrides

### DIFF
--- a/drivers/javascript/net.coffee
+++ b/drivers/javascript/net.coffee
@@ -94,12 +94,12 @@ aropt = util.aropt
 mkAtom = util.mkAtom
 mkErr = util.mkErr
 
-# These are the default hostname and port used by RethinkDB
-DEFAULT_HOST = 'localhost'
-DEFAULT_PORT = 28015
-
-module.exports.DEFAULT_HOST = DEFAULT_HOST
-module.exports.DEFAULT_PORT = DEFAULT_PORT
+# These are the default hostname and port used by RethinkDB.
+# Set the default hostname and port on the exported constants, to
+# keep backward compatibility when somebody would like to override
+# the default port or host name.
+module.exports.DEFAULT_HOST = 'localhost'
+module.exports.DEFAULT_PORT = 28015
 
 # These are strings returned by the server after a handshake
 # request. Since they must match exactly they're defined in
@@ -149,8 +149,8 @@ class Connection extends events.EventEmitter
             host = {host: host}
 
         # Here we set all of the connection parameters to their defaults.
-        @host = host.host || DEFAULT_HOST
-        @port = host.port || DEFAULT_PORT
+        @host = host.host || exports.DEFAULT_HOST
+        @port = host.port || exports.DEFAULT_PORT
 
         # One notable exception to defaulting is the db name. If the
         # user doesn't specify it, we leave it undefined. On the

--- a/drivers/javascript/package.json
+++ b/drivers/javascript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rethinkdb",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "main": "rethinkdb",
     "description": "This package provides the JavaScript driver library for the RethinkDB database server for use in your node application.",
     "keywords": ["database", "NoSQL", "reql", "query language"],


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
With the 2.4.0 version of the driver, it is not possible to override the default host and port. Because this is needed in some cases, we need to support this behavior.

Because of the promises, the output is the following: The error is related to port 1234, the two success log lines are related to the first and last connection test.

<img width="700" alt="Screenshot 2019-12-13 at 7 42 27" src="https://user-images.githubusercontent.com/19173947/70776476-70466300-1d7d-11ea-8bf8-94d6dfae3913.png">
