### PR TITLE
Actually fflush after calling fwrite in logging

### DIFF
--- a/src/clustering/administration/logs/log_writer.cc
+++ b/src/clustering/administration/logs/log_writer.cc
@@ -470,8 +470,15 @@ bool fallback_log_writer_t::write(const log_message_t &msg, std::string *error_o
         flockfile(write_stream);
 #endif
 
+        bool write_failure = false;
         size_t write_res = ::fwrite(console_formatted.data(), 1, console_formatted.length(), write_stream);
-        if (write_res != console_formatted.length()) {
+        if (write_res == console_formatted.length()) {
+            int fflush_res = ::fflush(write_stream);
+            write_failure = (fflush_res != 0);
+        } else {
+            write_failure = true;
+        }
+        if (write_failure) {
             error_out->assign("cannot write to stdout/stderr: " + errno_string(get_errno()));
             return false;
         }


### PR DESCRIPTION
This was introduced in 2.4.0 after a refactor switched away from the
write(2) syscall.  This forces flushing when stdout isn't on a TTY.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

Fixes #6819.