### PR TITLE
Allow dash in DB and table names when using '-e' option in rethinkdb-dump

### DIFF
--- a/drivers/python/rethinkdb/utils_common.py
+++ b/drivers/python/rethinkdb/utils_common.py
@@ -112,7 +112,7 @@ def check_minimum_version(options, minimum_version='1.6'):
 
 
 DbTable = collections.namedtuple('DbTable', ['db', 'table'])
-_tableNameRegex = re.compile(r'^(?P<db>\w+)(\.(?P<table>\w+))?$')
+_tableNameRegex = re.compile(r'^(?P<db>[\w-]+)(\.(?P<table>[\w-]+))?$')
 
 
 class CommonOptionsParser(optparse.OptionParser, object):


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Hello,

it seems from https://github.com/rethinkdb/rethinkdb/issues/5537 that '-' is allowed in DB and table names. However, the `-e` option when using `rethinkdb-dump` breaks when specifying a DB or table with '-' in its name due to this regex.

Opening this pull request to hopefully fix that.
