### PR TITLE
Fix warnings about missing assignment definitions in clang 10.0.0

### DIFF
--- a/src/btree/keys.hpp
+++ b/src/btree/keys.hpp
@@ -66,6 +66,11 @@ public:
         assign(_key.size(), _key.contents());
     }
 
+    store_key_t &operator=(const store_key_t &_key) {
+        assign(_key.size(), _key.contents());
+        return *this;
+    }
+
     explicit store_key_t(const btree_key_t *key) {
         assign(key->size, key->contents);
     }

--- a/src/clustering/table_contract/coordinator/calculate_contracts.cc
+++ b/src/clustering/table_contract/coordinator/calculate_contracts.cc
@@ -549,7 +549,7 @@ void calculate_all_contracts(
     /* We want to break the key-space into sub-regions small enough that the contract,
     table config, and ack versions are all constant across the sub-region. First we
     iterate over all contracts: */
-    for (const std::pair<contract_id_t, std::pair<region_t, contract_t> > &cpair :
+    for (const std::pair<const contract_id_t, std::pair<region_t, contract_t> > &cpair :
             old_state.contracts) {
         /* Next iterate over all shards of the table config and find the ones that
         overlap the contract in question: */

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -326,10 +326,10 @@ struct GenericStringRef {
 
 private:
     //! Disallow copy-assignment
-    GenericStringRef operator=(const GenericStringRef&);
+    GenericStringRef &operator=(const GenericStringRef&) = delete;
     //! Disallow construction from non-const array
     template<SizeType N>
-    GenericStringRef(CharType (&str)[N]) /* = delete */;
+    GenericStringRef(CharType (&str)[N]) = delete;
 };
 
 //! Mark a character pointer as constant string

--- a/src/rapidjson/internal/biginteger.h
+++ b/src/rapidjson/internal/biginteger.h
@@ -38,6 +38,12 @@ public:
         std::memcpy(digits_, rhs.digits_, count_ * sizeof(Type));
     }
 
+    BigInteger &operator=(const BigInteger& rhs) {
+        count_ = rhs.count_;
+        std::memcpy(digits_, rhs.digits_, count_ * sizeof(Type));
+	return *this;
+    }
+  
     explicit BigInteger(uint64_t u) : count_(1) {
         digits_[0] = u;
     }

--- a/src/rdb_protocol/geo/s2/base/docid.h
+++ b/src/rdb_protocol/geo/s2/base/docid.h
@@ -112,10 +112,8 @@ class DocId {
   explicit DocId(value_type _docid)     { docid_ = _docid; }
   value_type docid() const              { return docid_; }   // ONLY use here
   value_type* docidptr()                { return &docid_; }  // ie in this file
-  DocId& operator=(const DocId& x) {
-    docid_ = x.docid_;
-    return *this;
-  }
+  DocId& operator=(const DocId&) = default;
+  DocId(const DocId&) = default;
   // These two are required for delta encoding
   value_type operator+(const DocId& x) const { return docid_ + x.docid_; }
   value_type operator-(const DocId& x) const { return docid_ - x.docid_; }
@@ -218,10 +216,8 @@ class DocId32Bit {
   }
   value_type docid() const              { return docid_; }   // ONLY use here
   value_type* docidptr()                { return &docid_; }  // ie in this file
-  DocId32Bit& operator=(const DocId32Bit& x) {
-    docid_ = x.docid_;
-    return *this;
-  }
+  DocId32Bit(const DocId32Bit&) = default;
+  DocId32Bit& operator=(const DocId32Bit&) = default;
   // These two are required for delta encoding
   value_type operator+(const DocId32Bit& x) const { return docid_ + x.docid_; }
   value_type operator-(const DocId32Bit& x) const { return docid_ - x.docid_; }

--- a/src/rdb_protocol/serialize_datum.cc
+++ b/src/rdb_protocol/serialize_datum.cc
@@ -116,7 +116,7 @@ void serialize_offset_table(write_message_t *wm,
                             datum_t::type_t datum_type,
                             const std::vector<size_tree_node_t> &elem_sizes,
                             datum_offset_size_t offset_size) {
-    rassert(datum_type == datum_t::R_OBJECT || datum_t::R_ARRAY);
+    rassert(datum_type == datum_t::R_OBJECT || datum_type == datum_t::R_ARRAY);
     const size_t num_elements =
         datum_type == datum_t::R_OBJECT
         ? elem_sizes.size() / 2

--- a/src/rpc/mailbox/raw_mailbox.cc
+++ b/src/rpc/mailbox/raw_mailbox.cc
@@ -8,9 +8,6 @@
 raw_mailbox_t::address_t::address_t() :
     peer(peer_id_t()), thread(-1), mailbox_id(0) { }
 
-raw_mailbox_t::address_t::address_t(const address_t &a) :
-    peer(a.peer), thread(a.thread), mailbox_id(a.mailbox_id) { }
-
 bool raw_mailbox_t::address_t::is_nil() const {
     return peer.is_nil();
 }

--- a/src/rpc/mailbox/raw_mailbox.hpp
+++ b/src/rpc/mailbox/raw_mailbox.hpp
@@ -51,7 +51,8 @@ public:
         /* Constructs a nil address */
         address_t();
 
-        address_t(const address_t&);
+        address_t(const address_t&) = default;
+        address_t &operator=(const address_t&) = default;
 
         /* Tests if the address is nil */
         bool is_nil() const;


### PR DESCRIPTION
The warnings caught legitimate code smells.  Performance of
store_key_t should improve.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
