### PR TITLE
Backport 'Treat release_superblock properly in do_read' to 2.3.x

### DIFF
--- a/src/rdb_protocol/btree_store.cc
+++ b/src/rdb_protocol/btree_store.cc
@@ -974,6 +974,7 @@ MUST_USE bool store_t::acquire_sindex_superblock_for_read(
         const sindex_name_t &name,
         const std::string &table_name,
         real_superblock_t *superblock,
+        release_superblock_t release_superblock,
         scoped_ptr_t<sindex_superblock_t> *sindex_sb_out,
         std::vector<char> *opaque_definition_out,
         uuid_u *sindex_uuid_out)
@@ -985,7 +986,9 @@ MUST_USE bool store_t::acquire_sindex_superblock_for_read(
     /* Acquire the sindex block. */
     buf_lock_t sindex_block(superblock->expose_buf(), superblock->get_sindex_block_id(),
                             access_t::read);
-    superblock->release();
+    if (release_superblock == release_superblock_t::RELEASE) {
+        superblock->release();
+    }
 
     /* Figure out what the superblock for this index is. */
     secondary_index_t sindex;

--- a/src/rdb_protocol/store.cc
+++ b/src/rdb_protocol/store.cc
@@ -151,6 +151,7 @@ void store_t::help_construct_bring_sindexes_up_to_date() {
 scoped_ptr_t<sindex_superblock_t> acquire_sindex_for_read(
     store_t *store,
     real_superblock_t *superblock,
+    release_superblock_t release_superblock,
     const std::string &table_name,
     const std::string &sindex_id,
     sindex_disk_info_t *sindex_info_out,
@@ -167,6 +168,7 @@ scoped_ptr_t<sindex_superblock_t> acquire_sindex_for_read(
             sindex_name_t(sindex_id),
             table_name,
             superblock,
+            release_superblock,
             &sindex_sb,
             &sindex_mapping_data,
             &sindex_uuid);
@@ -228,6 +230,7 @@ void do_read(ql::env_t *env,
                 acquire_sindex_for_read(
                     store,
                     superblock,
+                    release_superblock,
                     rget.table_name,
                     rget.sindex->id,
                     &sindex_info,
@@ -495,6 +498,7 @@ struct rdb_read_visitor_t : public boost::static_visitor<void> {
                 acquire_sindex_for_read(
                     store,
                     superblock,
+                    release_superblock_t::RELEASE,
                     geo_read.table_name,
                     geo_read.sindex.id,
                 &sindex_info, &sindex_uuid);
@@ -554,6 +558,7 @@ struct rdb_read_visitor_t : public boost::static_visitor<void> {
                 acquire_sindex_for_read(
                     store,
                     superblock,
+                    release_superblock_t::RELEASE,
                     geo_read.table_name,
                     geo_read.sindex_id,
                 &sindex_info, &sindex_uuid);

--- a/src/rdb_protocol/store.hpp
+++ b/src/rdb_protocol/store.hpp
@@ -248,7 +248,8 @@ public:
     MUST_USE bool acquire_sindex_superblock_for_read(
             const sindex_name_t &name,
             const std::string &table_name,
-            real_superblock_t *superblock,  // releases this.
+            real_superblock_t *superblock,
+            release_superblock_t release_superblock,
             scoped_ptr_t<sindex_superblock_t> *sindex_sb_out,
             std::vector<char> *opaque_definition_out,
             uuid_u *sindex_uuid_out)

--- a/src/unittest/btree_sindex.cc
+++ b/src/unittest/btree_sindex.cc
@@ -256,6 +256,7 @@ TPTEST(BTreeSindex, BtreeStoreAPI) {
                         name,
                         "",
                         main_sb.get(),
+                        release_superblock_t::RELEASE,
                         &sindex_super_block,
                         &opaque_definition,
                         &sindex_uuid);

--- a/src/unittest/rdb_btree.cc
+++ b/src/unittest/rdb_btree.cc
@@ -127,6 +127,7 @@ ql::grouped_t<ql::stream_t> read_row_via_sindex(
             sindex_name,
             "",
             super_block.get(),
+            release_superblock_t::RELEASE,
             &sindex_sb,
             &opaque_definition,
             &sindex_uuid);


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

The PR backports the fix described in https://github.com/rethinkdb/rethinkdb/pull/6710 to the 2.3.x branch, to attempt mitigation of https://github.com/rethinkdb/rethinkdb/issues/6863