### PR TITLE
2020-07-30/v2.4.x/aarch64 Patch to enable building on aarch64 platforms

### DIFF
--- a/mk/support/pkg/v8.sh
+++ b/mk/support/pkg/v8.sh
@@ -136,7 +136,7 @@ pkg_install () {
         i?86)    arch=ia32 ;;
         x86_64)  arch=x64 ;;
         arm64)   arch=arm64; arch_gypflags=$arm_gypflags ;;
-        aarch64) arch=aarch64; arch_gypflags=$arm_gypflags ;;
+        aarch64) arch=arm64; arch_gypflags=$arm_gypflags ;;
         arm*)    arch=arm; arch_gypflags=$arm_gypflags ;;
         s390x)   arch=s390x ;;
 	ppc64le*|powerpc*) arch=ppc64 ;;

--- a/src/arch/runtime/context_switching.cc
+++ b/src/arch/runtime/context_switching.cc
@@ -260,7 +260,7 @@ artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_
 #elif defined(__arm__)
     // This slot is used to store r12.
     const size_t min_frame = 1;
-#elif defined(__arm64__)
+#elif defined(__arm64__) || defined(__aarch64__)
     // The ARM64 ABI requires the stack pointer to always be 16-byte-aligned at
     // all registers.
     const size_t min_frame = 1;
@@ -457,7 +457,7 @@ void context_switch(artificial_stack_context_ref_t *current_context_out, artific
 }
 
 asm(
-#if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined (__s390x__) || defined (__powerpc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined (__s390x__) || defined (__powerpc64__)
 // We keep architecture-specific code interleaved in order to enforce commonality.
 #if defined(__x86_64__)
 #if defined(__LP64__) || defined(__LLP64__)


### PR DESCRIPTION
**Reason for the change**
RethinkDB fails to build on aarch64 platforms. AWS ARM instances are using ARMv8 processors and cannot currently build rethinkdb from source.

**Description**
aarch64 is backwards-compatible with arm64. This patch aliases aarch64 with arm64 for the architecture branching statements in context_switching and on the v8 make scripts. 

I'm not sure if this is the *best* approach, but I am now able to build RethinkDB from source on AMD ARM instances without issue.

**Code examples**
None

**Checklist**
- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
None