### PR TITLE
Allow hyphens in table and database names

### DIFF
--- a/admin/static/coffee/modals.coffee
+++ b/admin/static/coffee/modals.coffee
@@ -41,7 +41,7 @@ class AddDatabaseModal extends ui_modals.AbstractModal
             error = true
             @$('.alert_modal').html @templates.error
                 database_is_empty: true
-        else if /^[a-zA-Z0-9_]+$/.test(@formdata.name) is false
+        else if /^[a-zA-Z0-9_-]+$/.test(@formdata.name) is false
             # Only alphanumeric char + underscore are allowed
             error = true
             @$('.alert_modal').html @templates.error
@@ -172,7 +172,7 @@ class AddTableModal extends ui_modals.AbstractModal
         if @formdata.name is '' # Need a name
             input_error = true
             template_error.table_name_empty = true
-        else if /^[a-zA-Z0-9_]+$/.test(@formdata.name) is false
+        else if /^[a-zA-Z0-9_-]+$/.test(@formdata.name) is false
             input_error = true
             template_error.special_char_detected = true
             template_error.type = 'table'

--- a/admin/static/coffee/ui_components/modals.coffee
+++ b/admin/static/coffee/ui_components/modals.coffee
@@ -204,7 +204,7 @@ class RenameItemModal extends AbstractModal
             no_error = false
             $('.alert_modal').html @error_template
                 empty_name: true
-        else if /^[a-zA-Z0-9_]+$/.test(@formdata.new_name) is false
+        else if /^[a-zA-Z0-9_-]+$/.test(@formdata.new_name) is false
             no_error = false
             $('.alert_modal').html @error_template
                 special_char_detected: true

--- a/admin/static/handlebars/error_input.hbs
+++ b/admin/static/handlebars/error_input.hbs
@@ -39,7 +39,7 @@
         <p>The chosen server's name is already being used. please choose another one.</p>
     {{/if}}
     {{#if special_char_detected}}
-    <p>You can only use alphanumeric characters and underscores for a {{type}}'s name.</p>
+    <p>You can only use alphanumeric characters, hyphens and underscores for a {{type}}'s name.</p>
     {{/if}}
     {{#if fail_create_secondary_index}}
     <p>The secondary index could not be created. Message returned by the driver:<br/>


### PR DESCRIPTION
**Reason for the change**
When creating a new table or database with a hyphen in the name using the admin UI, the following error message is shown:

> You can only use alphanumeric characters and underscores for a table's name.

**Description**
Allow hyphens in table and database names.

**Code examples**
N/A

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
resolves https://github.com/rethinkdb/rethinkdb/issues/6828
