### PR TITLE
MAX_THREADS bumped to 260, part 1 of 2

### DIFF
--- a/src/config/args.hpp
+++ b/src/config/args.hpp
@@ -97,7 +97,7 @@
 
 // Maximum number of threads we support
 // TODO: make this dynamic where possible
-#define MAX_THREADS                               128
+#define MAX_THREADS                               260
 
 // How many times the page replacement algorithm tries to find an eligible page before giving up.
 // Note that (MAX_UNSAVED_DATA_LIMIT_FRACTION ** PAGE_REPL_NUM_TRIES) is the probability that the


### PR DESCRIPTION
"If anybody wants to make a pull request updating MAX_THREADS to 260 (from 128) in RethinkDB's v2.4.x and next branches, it would be much appreciated.  Due to some temporary contract issues I can 99% do that now, but just to keep copyright squeaky clean, somebody else should." - srh