### PR TITLE
MAX_THREADS bumped to 260, part 2 of 2

### DIFF
--- a/src/config/args.hpp
+++ b/src/config/args.hpp
@@ -100,7 +100,7 @@
 
 // Maximum number of threads we support
 // TODO: make this dynamic where possible
-#define MAX_THREADS                               128
+#define MAX_THREADS                               260
 
 // Ticks (in milliseconds) the internal timed tasks are performed at
 #define TIMER_TICKS_IN_MS                         5


### PR DESCRIPTION
"If anybody wants to make a pull request updating MAX_THREADS to 260 (from 128) in RethinkDB's v2.4.x and next branches, it would be much appreciated.  Due to some temporary contract issues I can 99% do that now, but just to keep copyright squeaky clean, somebody else should." - srh