### PR TITLE
Patch v8 build arguments for gcc6+ support

### DIFF
--- a/mk/support/pkg/patch/v8_4-gcc6+.patch
+++ b/mk/support/pkg/patch/v8_4-gcc6+.patch
@@ -1,0 +1,10 @@
+--- a/build/toolchain.gypi
++++ b/build/toolchain.gypi
+@@ -1082,6 +1082,7 @@
+             'cflags': [
+               '-fdata-sections',
+               '-ffunction-sections',
++              '-fno-delete-null-pointer-checks',
+               '<(wno_array_bounds)',
+             ],
+             'conditions': [


### PR DESCRIPTION
Pass `-fno-delete-null-pointer-checks` to prevent segmentation fault with `mksnapshot`.

**Reason for the change**
It fixes issues: https://github.com/rethinkdb/rethinkdb/issues/5757, https://github.com/rethinkdb/rethinkdb_rebirth/issues/59, https://github.com/rethinkdb/rethinkdb/issues/6731  

**Description**
Since gcc6, it was no longer possible to build rethinkdb and especially this old v8 version. By preventing this compiler optimization, it builds (tested with gcc10.2 and it runs smoothly).

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Some interesting references:  
- https://bugs.archlinux.org/task/49395
- https://github.com/qt/qtwebengine-chromium/commit/d03c8ccab741952fee6bd54fb56a878c7cc4ca97
- https://github.com/arangodb/arangodb/issues/1817
