### PR TITLE
Patch v8 build arguments for gcc6+ support (v2.4)

### DIFF
--- a/mk/support/pkg/patch/v8_4-gcc6+.patch
+++ b/mk/support/pkg/patch/v8_4-gcc6+.patch
@@ -1,0 +1,10 @@
+--- a/build/toolchain.gypi
++++ b/build/toolchain.gypi
+@@ -1082,6 +1082,7 @@
+             'cflags': [
+               '-fdata-sections',
+               '-ffunction-sections',
++              '-fno-delete-null-pointer-checks',
+               '<(wno_array_bounds)',
+             ],
+             'conditions': [


### PR DESCRIPTION
Like https://github.com/rethinkdb/rethinkdb/pull/6963 but for v2.4 branch