### PR TITLE
Upgrade nodejs6 (v2.4)

### DIFF
--- a/mk/support/pkg/node.sh
+++ b/mk/support/pkg/node.sh
@@ -1,4 +1,4 @@
-version=6.11.0
+version=6.17.1
 
 src_url=http://nodejs.org/dist/v$version/node-v$version.tar.gz
-src_url_sha1=df31d0e4e2104b3a62342533af5fb879f321416b
+src_url_sha1=7497b72ad8e216b95e3dea864adeb6e5e4100509


### PR DESCRIPTION
**Reason for the change**
Fix build of external nodejs6 (tested on Ubuntu 20.04)
See https://github.com/rethinkdb/rethinkdb/pull/6963#issuecomment-842140932

**Description**
Fix this:  
![image](https://user-images.githubusercontent.com/397862/118464315-01530380-b701-11eb-890e-a6725aafc688.png)

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)