### PR TITLE
Fix build on Ubuntu 20.04 with clang++-9

### DIFF
--- a/src/clustering/immediate_consistency/history.hpp
+++ b/src/clustering/immediate_consistency/history.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <set>
+#include <stdexcept>
 
 #include "concurrency/signal.hpp"
 #include "containers/uuid.hpp"

--- a/src/crypto/random.hpp
+++ b/src/crypto/random.hpp
@@ -8,7 +8,7 @@ namespace crypto {
 
 namespace detail {
 
-void random_bytes(unsigned char *, size_t);
+void random_bytes(unsigned char *, std::size_t);
 
 }  // namespace detail
 


### PR DESCRIPTION
**Reason for the change**
I got some compilation fails recently on Ubuntu 20.04 with clang++-9, this is a fix.

**Description**
Add a missing header and namespace.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
