### PR TITLE
Update QuickJS vendored repo build system logic and point to non-LTO/non-warning vendored commit

### DIFF
--- a/src/build.mk
+++ b/src/build.mk
@@ -425,7 +425,7 @@ build-clean:
 check-syntax:
 	$(RT_CXX) $(RT_CXXFLAGS) -c -o /dev/null $(patsubst %,$(CWD)/%,$(CHK_SOURCES))
 
-VENDORED_COMMIT := e3bdd7d0419220c787132e4e9b56c84ed6d733cd
+VENDORED_COMMIT := e4fba2d11b3997c07650df150d6ff7e4d109a8ee
 VENDORED_REMOTE_REPO := https://github.com/rethinkdb/rethinkdb-vendored.git
 
 # Right now, rethinkdb-vendored's history is light, so we don't bother

--- a/src/build.mk
+++ b/src/build.mk
@@ -392,7 +392,7 @@ $(BUILD_ROOT_DIR)/vendored: | vendored
 	mkdir -p $(BUILD_ROOT_DIR)/vendored
 
 $(QUICKJS_SOURCE): | $(BUILD_ROOT_DIR)/vendored
-	rm -r $(QUICKJS_SOURCE) || true
+	[ -d $(QUICKJS_SOURCE) ] && rm -r $(QUICKJS_SOURCE)
 	cp -R vendored/quickjs $(QUICKJS_SOURCE)
 
 $(QUICKJS_A): | $(QUICKJS_SOURCE)
@@ -429,9 +429,10 @@ VENDORED_COMMIT := e3bdd7d0419220c787132e4e9b56c84ed6d733cd
 VENDORED_REMOTE_REPO := https://github.com/rethinkdb/rethinkdb-vendored.git
 
 # Right now, rethinkdb-vendored's history is light, so we don't bother
-# with --depth and other clone params.
-vendored:
-	$P GIT clone vendored
-	git clone --quiet $(VENDORED_REMOTE_REPO) vendored || true
+# with --depth and other clone params.  The dependency is on this
+# makefile because it carries the commit hash.
+vendored: src/build.mk
+	$P GIT checkout vendored
+	[ ! -d vendored ] && git clone --quiet $(VENDORED_REMOTE_REPO) vendored || true
 	git -C vendored checkout --quiet $(VENDORED_COMMIT) || \
 	  ( git -C vendored fetch --quiet && git -C vendored checkout --quiet $(VENDORED_COMMIT) )


### PR DESCRIPTION
Apparently with QuickJS's build system, with LTO, you get a warning that `@` is unused because the makefile expands `@F` outside of a rule.  See https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html .

That's broken, and to avoid that, I'm silencing the warning an disabling LTO.