### PR TITLE
Apply fixed version of "try to fix memory leak" to v2.4.x

### DIFF
--- a/src/random.cc
+++ b/src/random.cc
@@ -3,6 +3,7 @@
 
 #include "containers/scoped.hpp"
 #include "thread_local.hpp"
+#include <memory>
 
 rng_t::rng_t()
     : m_mt19937(std::random_device{}()) {
@@ -41,16 +42,19 @@ double rng_t::randdouble() {
     return std::uniform_real_distribution<double>(0, 1)(m_mt19937);
 }
 
-TLS_with_init(rng_t*, rng, nullptr)
+// TLS_with_init(rng_t*, rng, nullptr)
 
 rng_t *get_TLS_rng() {
     // This lazy construction is to ensure that we construct the thread local
     // rng_t on the correct thread, instead of creating it on startup.
 
-    if (TLS_get_rng() == nullptr) {
-        TLS_set_rng(new rng_t());
-    }
-    return TLS_get_rng();
+    // if (TLS_get_rng() == nullptr) {
+    //     TLS_set_rng(new rng_t());
+    // }
+    // return TLS_get_rng();
+    
+    static thread_local std::unique_ptr<rng_t> tls_rng(new rng_t());
+    return tls_rng.get();
 }
 
 int randint(int n) {

--- a/src/random.cc
+++ b/src/random.cc
@@ -42,19 +42,16 @@ double rng_t::randdouble() {
     return std::uniform_real_distribution<double>(0, 1)(m_mt19937);
 }
 
-// TLS_with_init(rng_t*, rng, nullptr)
+TLS_with_get_ref(std::unique_ptr<rng_t>, rng)
 
 rng_t *get_TLS_rng() {
     // This lazy construction is to ensure that we construct the thread local
     // rng_t on the correct thread, instead of creating it on startup.
 
-    // if (TLS_get_rng() == nullptr) {
-    //     TLS_set_rng(new rng_t());
-    // }
-    // return TLS_get_rng();
-    
-    static thread_local std::unique_ptr<rng_t> tls_rng(new rng_t());
-    return tls_rng.get();
+    if (TLS_get_ref_rng() == nullptr) {
+        TLS_set_rng(std::unique_ptr<rng_t>(new rng_t()));
+    }
+    return TLS_get_ref_rng().get();
 }
 
 int randint(int n) {


### PR DESCRIPTION
#6957 would need to be applied to v2.4.x.

Also, it makes the mistake of avoiding the NOINLINE macros.  We have thread locals using the peculiar TLS_... macros because our coroutines can switch POSIX threads and basic thread_local usage could cause the compiler to optimize access to the variables such that a second access is assumed to be on the same thread as the first access.  An explanation exists in thread_local.hpp.

So now thread_local.hpp is updated to have TLS_with_get_ref, to support noncopyable thread locals and returning them by reference.

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
