### PR TITLE
Fix saslname_decode logic in =2C and =3D escaping, and some GCC warnings

### DIFF
--- a/src/cjson/cJSON.cc
+++ b/src/cjson/cJSON.cc
@@ -293,8 +293,11 @@ static const char *parse_string(cJSON *item,const char *str)
 
                     switch (len) {
                         case 4: *--ptr2 = ((uc | 0x80) & 0xBF); uc >>= 6;
+                            // fallthrough
                         case 3: *--ptr2 = ((uc | 0x80) & 0xBF); uc >>= 6;
+                            // fallthrough
                         case 2: *--ptr2 = ((uc | 0x80) & 0xBF); uc >>= 6;
+                            // fallthrough
                         case 1: *--ptr2 = (uc | firstByteMark[len]);
                     }
                     ptr2 += len;

--- a/src/clustering/administration/auth/scram_authenticator.cc
+++ b/src/clustering/administration/auth/scram_authenticator.cc
@@ -232,7 +232,8 @@ std::string scram_authenticator_t::next_message(std::string const &message)
                     throw authentication_error_t(18, "Invalid username encoding");
                 }
 
-                offset += 2;
+                offset += 3;
+                break;
             default:
                 username.push_back(saslname[offset]);
                 break;

--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -468,8 +468,8 @@ optional<int> parse_node_reconnect_timeout_secs_option(
                     "ERROR: cluster-reconnect-timeout should be a number, got '%s'",
                     timeout_opt.c_str()));
         }
-        if (node_reconnect_timeout_secs > std::numeric_limits<int>::max() ||
-            node_reconnect_timeout_secs * 1000 > std::numeric_limits<int>::max()) {
+        if (node_reconnect_timeout_secs > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
+            node_reconnect_timeout_secs * 1000 > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
             throw std::runtime_error(strprintf(
                 "ERROR: cluster-reconnect-timeout is too large. Must be at most %d",
                 std::numeric_limits<int>::max() / 1000));

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -343,7 +343,8 @@ metadata_file_t::metadata_file_t(
 
             // The metadata is now serialized using the latest serialization version
             metadata_version = cluster_version_t::LATEST_DISK;
-        } // fallthrough intentional
+        }
+        // fallthrough
         case cluster_version_t::v2_1: // fallthrough intentional
         case cluster_version_t::v2_2: {
             if (sb_lock.has()) {
@@ -358,7 +359,8 @@ metadata_file_t::metadata_file_t(
 
             // The metadata is now serialized using the latest serialization version
             metadata_version = cluster_version_t::LATEST_DISK;
-        } // fallthrough intentional
+        }
+        // fallthrough
         case cluster_version_t::v2_3: {
             if (sb_lock.has()) {
                 update_metadata_superblock_version(sb_data);

--- a/src/http/http_parser.cc
+++ b/src/http/http_parser.cc
@@ -2159,7 +2159,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_dead:
         return 1;
 
-      /* Skip delimeters */
+      /* Skip delimiters */
       case s_req_schema_slash:
       case s_req_schema_slash_slash:
       case s_req_server_start:
@@ -2174,7 +2174,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_req_server_with_at:
         found_at = 1;
 
-      /* FALLTROUGH */
+      /* FALLTHROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -1546,7 +1546,14 @@ private:
     void SetArrayRaw(GenericValue* values, SizeType count, Allocator& allocator) {
         flags_ = kArrayFlag;
         data_.a.elements = (GenericValue*)allocator.Malloc(count * sizeof(GenericValue));
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 800)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
         std::memcpy(data_.a.elements, values, count * sizeof(GenericValue));
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 800)
+#pragma GCC diagnostic pop
+#endif
         data_.a.size = data_.a.capacity = count;
     }
 
@@ -1554,7 +1561,14 @@ private:
     void SetObjectRaw(Member* members, SizeType count, Allocator& allocator) {
         flags_ = kObjectFlag;
         data_.o.members = (Member*)allocator.Malloc(count * sizeof(Member));
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 800)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
         std::memcpy(data_.o.members, members, count * sizeof(Member));
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 800)
+#pragma GCC diagnostic pop
+#endif
         data_.o.size = data_.o.capacity = count;
     }
 

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -3370,7 +3370,7 @@ subscription_t::get_els(batcher_t *batcher,
                 user_context.require_read_permission(
                     rdb_context, table_basic_config->database, feed->get_table_id());
             }
-        } catch (auth::permission_error_t const permission_error) {
+        } catch (const auth::permission_error_t &permission_error) {
             stop(
                 std::make_exception_ptr(
                     datum_exc_t(base_exc_t::PERMISSION_ERROR, permission_error.what())),

--- a/src/rdb_protocol/geo/s2/util/endian/endian.h
+++ b/src/rdb_protocol/geo/s2/util/endian/endian.h
@@ -127,7 +127,7 @@ class LittleEndian {
   static uint64 Load64VariableLength(const void * const p, int len) {
     DCHECK_GE(len, 1);
     DCHECK_LE(len, 8);
-    const char * const buf = static_cast<const char * const>(p);
+    const char * const buf = static_cast<const char *>(p);
     uint64 val = 0;
     --len;
     do {


### PR DESCRIPTION
The saslname_decode bug was found while addressing GCC warnings.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
