### PR TITLE
Fix more GCC warnings

### DIFF
--- a/src/arch/runtime/event_queue/poll.cc
+++ b/src/arch/runtime/event_queue/poll.cc
@@ -24,16 +24,13 @@
 #include "perfmon/perfmon.hpp"
 
 int user_to_poll(int mode) {
-
-#ifndef __linux
-    DEBUG_VAR
-#endif
     int allowed_mode_mask = poll_event_in | poll_event_out;
 
 #ifdef __linux
     allowed_mode_mask |= poll_event_rdhup;
 #endif
 
+    (void)allowed_mode_mask;
     rassert((mode & allowed_mode_mask) == mode);
 
     int out_mode = 0;
@@ -47,16 +44,13 @@ int user_to_poll(int mode) {
 }
 
 int poll_to_user(int mode) {
-
-#ifndef __linux
-DEBUG_VAR
-#endif
     int allowed_mode_mask = POLLIN | POLLOUT | POLLERR | POLLHUP;
 
 #ifdef __linux
     allowed_mode_mask |= POLLRDHUP;
 #endif
 
+    (void)allowed_mode_mask;
     rassert((mode & allowed_mode_mask) == mode);
 
     int out_mode = 0;

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -324,9 +324,14 @@ struct GenericStringRef {
     const Ch* const s; //!< plain CharType pointer
     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
 
+    GenericStringRef(GenericStringRef &&) = default;
+    GenericStringRef &operator=(GenericStringRef &&) = delete;
+
 private:
-    //! Disallow copy-assignment
+    //! Disallow copy-assignment and copy-construction
     GenericStringRef &operator=(const GenericStringRef&) = delete;
+    GenericStringRef(const GenericStringRef&) = delete;
+
     //! Disallow construction from non-const array
     template<SizeType N>
     GenericStringRef(CharType (&str)[N]) = delete;
@@ -541,7 +546,7 @@ public:
     GenericValue(const Ch* s, SizeType length) RAPIDJSON_NOEXCEPT : data_(), flags_() { SetStringRaw(StringRef(s, length)); }
 
     //! Constructor for constant string (i.e. do not make a copy of string)
-    explicit GenericValue(StringRefType s) RAPIDJSON_NOEXCEPT : data_(), flags_() { SetStringRaw(s); }
+    explicit GenericValue(StringRefType s) RAPIDJSON_NOEXCEPT : data_(), flags_() { SetStringRaw(std::move(s)); }
 
     //! Constructor for copy-string (i.e. do make a copy of string)
     GenericValue(const Ch* s, SizeType length, Allocator& allocator) : data_(), flags_() { SetStringRaw(StringRef(s, length), allocator); }

--- a/src/rdb_protocol/datum_stream.cc
+++ b/src/rdb_protocol/datum_stream.cc
@@ -396,7 +396,6 @@ raw_stream_t rget_response_reader_t::unshard(
     // exhausted in this step.
     std::vector<pseudoshard_t> pseudoshards;
     pseudoshards.reserve(active_ranges->ranges.size() * CPU_SHARDING_FACTOR);
-    size_t n_active = 0, n_fresh = 0;
     for (auto &&pair : active_ranges->ranges) {
         bool range_active = pair.second.state() == range_state_t::ACTIVE;
         for (auto &&hash_pair : pair.second.hash_ranges) {
@@ -404,12 +403,10 @@ raw_stream_t rget_response_reader_t::unshard(
             keyed_stream_t *fresh = nullptr;
             // Active shards need their bounds updated.
             if (range_active) {
-                n_active += 1;
                 store_key_t *new_bound = nullptr;
                 auto it = stream.substreams.find(
                     region_t(hash_pair.first.beg, hash_pair.first.end, pair.first));
                 if (it != stream.substreams.end()) {
-                    n_fresh += 1;
                     fresh = &it->second;
                     new_bound = &it->second.last_key;
                 }

--- a/src/rdb_protocol/geo/s2/util/math/vector3-inl.h
+++ b/src/rdb_protocol/geo/s2/util/math/vector3-inl.h
@@ -68,13 +68,6 @@ Vector3<VType>::Vector3(const Vector2<VType> &vb, VType _z) {
 }
 
 template <typename VType>
-Vector3<VType>::Vector3(const Self &vb) {
-  c_[0] = vb.c_[0];
-  c_[1] = vb.c_[1];
-  c_[2] = vb.c_[2];
-}
-
-template <typename VType>
 Vector3<VType>::Vector3(const Vector4<VType> &vb) {
   c_[0] = vb.x();
   c_[1] = vb.y();
@@ -135,14 +128,6 @@ void Vector3<VType>::Set(const VType _x, const VType _y, const VType _z) {
   c_[0] = _x;
   c_[1] = _y;
   c_[2] = _z;
-}
-
-template <typename VType>
-Vector3<VType>& Vector3<VType>::operator=(const Self& vb) {
-  c_[0] = vb.c_[0];
-  c_[1] = vb.c_[1];
-  c_[2] = vb.c_[2];
-  return (*this);
 }
 
 template <typename VType>

--- a/src/rdb_protocol/geo/s2/util/math/vector3.h
+++ b/src/rdb_protocol/geo/s2/util/math/vector3.h
@@ -50,7 +50,7 @@ class Vector3 {
   // and an additional z argument.
   explicit Vector3(const Vector2<VType> &vb, VType z);
   // Create a new copy of the vector vb
-  Vector3(const Self &vb);
+  Vector3(const Self &vb) = default;
   // Keep only the three first coordinates of the 4D vector vb
   explicit Vector3(const Vector4<VType> &vb);
   // Convert from another vector type
@@ -73,7 +73,7 @@ class Vector3 {
   static int Size() { return 3; }
   // Modify the coordinates of the current vector
   void Set(const VType x, const VType y, const VType z);
-  Self& operator=(const Self& vb);
+  Self& operator=(const Self& vb) = default;
   // Add two vectors, component by component
   Self& operator+=(const Self &vb);
   // Subtract two vectors, component by component

--- a/src/rdb_protocol/term_storage.hpp
+++ b/src/rdb_protocol/term_storage.hpp
@@ -48,6 +48,7 @@ class raw_term_t {
 public:
     explicit raw_term_t(const term_variant_t &source);
     raw_term_t(const raw_term_t &) = default;
+    raw_term_t &operator=(const raw_term_t &) = default;
 
     size_t num_args() const;
     size_t num_optargs() const;


### PR DESCRIPTION
Different opinions about unused variables, and a new warning about copy ctor/copy assignment consistency, the code being deprecated in the C++ standard.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
