### PR TITLE
Silence more GCC warnings

### DIFF
--- a/src/btree/internal_node.cc
+++ b/src/btree/internal_node.cc
@@ -5,6 +5,20 @@
 
 #include "btree/node.hpp"
 
+// We comment out this warning, and static_assert that pair_offsets is
+// at an aligned offset.
+//
+// Considering we're doing arbitrary math into the node, we still
+// might have problems with unaligned pointers on some platforms.  Of
+// course, that would show itself instantly in testing.
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
+
+static_assert(offsetof(internal_node_t, pair_offsets) % 2 == 0,
+              "pair_offsets must be at uint16_t alignment");
+
 //In this tree, less than or equal takes the left-hand branch and greater than takes the right hand branch
 
 namespace internal_node {
@@ -464,3 +478,6 @@ bool is_equal(const btree_key_t *key1, const btree_key_t *key2) {
 
 }  // namespace internal_node
 
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic pop
+#endif

--- a/src/btree/leaf_node.cc
+++ b/src/btree/leaf_node.cc
@@ -10,6 +10,20 @@
 #include "repli_timestamp.hpp"
 #include "utils.hpp"
 
+// We comment out this warning, and static_assert that pair_offsets is
+// at an aligned offset.
+//
+// Considering we're doing arbitrary math into the node, we still
+// might have problems with unaligned pointers on some platforms.  Of
+// course, that would show itself instantly in testing.
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
+
+static_assert(offsetof(leaf_node_t, pair_offsets) % 2 == 0,
+              "pair_offsets must be at uint16_t alignment");
+
 namespace leaf {
 
 
@@ -1820,3 +1834,7 @@ leaf::reverse_iterator exclusive_upper_bound(const btree_key_t *key, const leaf_
 }
 
 }  // namespace leaf
+
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic pop
+#endif

--- a/src/extproc/js_job.cc
+++ b/src/extproc/js_job.cc
@@ -375,8 +375,6 @@ ql::datum_t js_make_datum(quickjs_context *qjs_ctx,
                 // Quickjs JS_ToUint32 actually converts non-integral floats to integers.
                 // As well as negative values.
                 err_out->assign("Array length is not convertable to a small integer");
-            } else if (length32 < 0) {
-                err_out->assign("Array length is negative");
             } else {
                 rcheck_array_size_value_datum(length32, limits);
                 std::vector<ql::datum_t> datum_array;

--- a/src/unittest/internal_node_test.cc
+++ b/src/unittest/internal_node_test.cc
@@ -7,6 +7,15 @@
 #include "btree/internal_node.hpp"
 #include "btree/node.hpp"
 
+// Silence warnings just as in internal_node.cc
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
+
+static_assert(offsetof(internal_node_t, pair_offsets) % 2 == 0,
+              "pair_offsets must be at uint16_t alignment");
+
 namespace unittest {
 
 void verify(block_size_t block_size, const internal_node_t *buf) {
@@ -64,3 +73,6 @@ TEST(InternalNodeTest, Offsets) {
 
 }  // namespace unittest
 
+#if defined(__GNUC__) && (100 * __GNUC__ + __GNUC_MINOR__ >= 901)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
This seems to be the last of the new GCC warnings seen in Debian Bullseye.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
