### PR TITLE
Revert QuickJSpp, avoid git -C

### DIFF
--- a/src/build.mk
+++ b/src/build.mk
@@ -426,7 +426,7 @@ build-clean:
 check-syntax:
 	$(RT_CXX) $(RT_CXXFLAGS) -c -o /dev/null $(patsubst %,$(CWD)/%,$(CHK_SOURCES))
 
-VENDORED_COMMIT := 28f35a28424e9eb53f98327bd9c32f16bdfd85bf
+VENDORED_COMMIT := 890e9a1a91f89f9046282c5848891682366b8e0c
 VENDORED_REMOTE_REPO := https://github.com/rethinkdb/rethinkdb-vendored.git
 
 # Right now, rethinkdb-vendored's history is light, so we don't bother

--- a/src/build.mk
+++ b/src/build.mk
@@ -435,5 +435,5 @@ VENDORED_REMOTE_REPO := https://github.com/rethinkdb/rethinkdb-vendored.git
 vendored: src/build.mk
 	$P GIT checkout vendored
 	[ ! -d vendored ] && git clone --quiet $(VENDORED_REMOTE_REPO) vendored || true
-	git -C vendored checkout --quiet $(VENDORED_COMMIT) || \
-	  ( git -C vendored fetch --quiet && git -C vendored checkout --quiet $(VENDORED_COMMIT) )
+	(cd vendored && git checkout --quiet $(VENDORED_COMMIT) && cd ..) || \
+	  ( cd vendored && git fetch --quiet && git checkout --quiet $(VENDORED_COMMIT) && cd .. )


### PR DESCRIPTION
Avoids the use of `git -C`, for compatibility with older git versions like the one available on CentOS 7.

Note that the CentOS 7 build is still failing because it doesn't have C11 support, which QuickJS is using (at least by default), expecting stdatomic.h to exist.

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
