### PR TITLE
Remove quickjs-version.h build step integrated for quickjspp

### DIFF
--- a/src/build.mk
+++ b/src/build.mk
@@ -403,7 +403,6 @@ $(QUICKJS_INCLUDE): | $(QUICKJS_SOURCE)
 	mkdir -p $(QUICKJS_INCLUDE_DIR)
 	$P CP
 	cp $(QUICKJS_SOURCE)/quickjs.h $(QUICKJS_INCLUDE_DIR)/quickjs.h
-	cp $(QUICKJS_SOURCE)/quickjs-version.h $(QUICKJS_INCLUDE_DIR)/quickjs-version.h
 
 FORCE_ALL_DEPS := $(patsubst %,force-dep/%,$(NAMES))
 force-dep/%: $(SOURCE_DIR)/%.cc $(QL2_PROTO_HEADERS) $(ALL_INCLUDE_DEPS)


### PR DESCRIPTION
(because we un-integrated that).

Fixes the build

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
