### PR TITLE
Point to vendored submodule without stdatomic.h usage

### DIFF
--- a/src/build.mk
+++ b/src/build.mk
@@ -425,7 +425,7 @@ build-clean:
 check-syntax:
 	$(RT_CXX) $(RT_CXXFLAGS) -c -o /dev/null $(patsubst %,$(CWD)/%,$(CHK_SOURCES))
 
-VENDORED_COMMIT := 890e9a1a91f89f9046282c5848891682366b8e0c
+VENDORED_COMMIT := d5cb3f41338f683c1ef42ac3586b4eed9f72e753
 VENDORED_REMOTE_REPO := https://github.com/rethinkdb/rethinkdb-vendored.git
 
 # Right now, rethinkdb-vendored's history is light, so we don't bother


### PR DESCRIPTION
Unconfigures Worker and Atomic features from QuickJS, so that stdatomic.h is not #included.

With this change, we successfully build on CentOS 7.  (We run into a package generation problem, but compilation works.)

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
