### PR TITLE
build-rpm.sh script updates, CentOS 7 support

### DIFF
--- a/mk/support/pkg/patch/quickjs_1-no-atomics.patch
+++ b/mk/support/pkg/patch/quickjs_1-no-atomics.patch
@@ -1,0 +1,13 @@
+diff -ruN original ./quickjs.c
+--- original	2022-03-28 07:32:36.359699208 -0700
++++ ./quickjs.c	2022-03-28 07:32:49.608141930 -0700
+@@ -70,7 +70,7 @@
+ /* define to include Atomics.* operations which depend on the OS
+    threads */
+ #if !defined(EMSCRIPTEN)
+-#define CONFIG_ATOMICS
++/* #define CONFIG_ATOMICS */
+ #endif
+ 
+ #if !defined(EMSCRIPTEN)
+ 

--- a/mk/support/pkg/patch/quickjs_2-no-workers.patch
+++ b/mk/support/pkg/patch/quickjs_2-no-workers.patch
@@ -1,0 +1,13 @@
+diff -ruN original ./quickjs-libc.c 
+--- original	2022-03-28 07:43:53.441856605 -0700
++++ ./quickjs-libc.c	2022-03-28 07:44:00.298255090 -0700
+@@ -59,7 +59,7 @@
+ 
+ #if !defined(_WIN32)
+ /* enable the os.Worker API. IT relies on POSIX threads */
+-#define USE_WORKER
++/* #define USE_WORKER */
+ #endif
+ 
+ #ifdef USE_WORKER
+ 

--- a/mk/support/pkg/quickjs.sh
+++ b/mk/support/pkg/quickjs.sh
@@ -21,3 +21,18 @@ pkg_install-include () {
     mkdir -p "$install_dir/include/quickjs"
     cp "$src_dir"/quickjs.h "$install_dir/include/quickjs"
 }
+
+pkg_install () {
+    if ! fetched; then
+        error "cannot install package, it has not been fetched"
+    fi
+    pkg_copy_src_to_build
+    pkg_configure ${configure_flags:-}
+    # The pkg.sh pkg_install would work on newer systems (invoking
+    # "pkg_make install").  But instead, we (a) avoid building quickjs
+    # executables, and (b) we avoid linking problems that occur on
+    # older platforms with those executables.
+    pkg_make libquickjs.a
+    mkdir -p "$install_dir/lib/quickjs"
+    install -m644 "$build_dir/libquickjs.a" "$install_dir/lib/quickjs/libquickjs.a"
+}

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -55,7 +55,7 @@ EOF
     ... --architecture "$ARCH"
     ... --maintainer 'RethinkDB <devops@rethinkdb.com>'
     ... --description "$DESCRIPTION"
-    ... --url 'http://www.rethinkdb.com/'
+    ... --url 'https://www.rethinkdb.com/'
     ... --before-install "$BEFORE_INSTALL"
     ... -s dir -C $RPM_ROOT     # Directory containing the installed files
     ... usr etc var             # Directories to package in the package

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -25,7 +25,7 @@ getent passwd rethinkdb >/dev/null || \
     --comment "RethinkDB Daemon" rethinkdb
 EOF
 
-    test -n "${NOCONFIGURE:-}" || ./configure --static all --fetch all --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+    test -n "${NOCONFIGURE:-}" || ./configure --fetch jemalloc --fetch boost --fetch re2 --fetch quickjs --fetch protobuf --prefix=/usr --sysconfdir=/etc --localstatedir=/var
 
     `make command-line` install DESTDIR=$RPM_ROOT BUILD_PORTABLE=1 ALLOW_WARNINGS=1 SPLIT_SYMBOLS=1
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -32,6 +32,10 @@ EOF
     ... () { command="$command $(for x in "$@"; do printf "%q " "$x"; done)"; }
 
     GLIBC_VERSION=`rpm -qa --queryformat '%{VERSION}\n' glibc | head -n1`
+    LIBSTDCPP_VERSION=`rpm -qa --queryformat '%{VERSION}\n' libstdc++ | head -n1`
+    LIBCURL_VERSION=`rpm -qa --queryformat '%{VERSION}\n' libcurl | head -n1`
+    OPENSSL_VERSION=`rpm -qa --queryformat '%{VERSION}\n' openssl-libs | head -n1`
+    ZLIB_VERSION=`rpm -qa --queryformat '%{VERSION}\n' zlib | head -n1`
 
     command=fpm
     ... -t rpm                  # Build an RPM package
@@ -43,6 +47,10 @@ EOF
     ... --version "$VERSION"
     ... --iteration "`./scripts/gen-version.sh -r`"
     ... --depends "glibc >= $GLIBC_VERSION"
+    ... --depends "libstdc++ >= $LIBSTDCPP_VERSION"
+    ... --depends "libcurl >= $LIBCURL_VERSION"
+    ... --depends "openssl-libs >= $OPENSSL_VERSION"
+    ... --depends "zlib >= $ZLIB_VERSION"
     ... --conflicts 'rethinkdb'
     ... --architecture "$ARCH"
     ... --maintainer 'RethinkDB <devops@rethinkdb.com>'


### PR DESCRIPTION
Makes build-rpm.sh fetch explicitly which deps it wants to statically link.

Also, makes us only build libquickjs.a, not the entire quickjs "make install" (hence, "make all") target, and disables a couple of exotic QuickJS features: workers and atomics.  This gets building for CentOS 7 users working.  It also gets Ubuntu Trusty and Debian Jessie package building working.

JS workers and atomics were disabled with the intent to get the build to succeed, but it's also desirable on its own to have that disabled.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
