### PR TITLE
Avoid use of 32-bit int str_to_log_index

### DIFF
--- a/src/clustering/administration/persist/raft_storage_interface.cc
+++ b/src/clustering/administration/persist/raft_storage_interface.cc
@@ -12,7 +12,7 @@ raft_log_index_t str_to_log_index(const std::string &str) {
     guarantee(str.size() == 16);
     raft_log_index_t index = 0;
     for (size_t i = 0; i < 16; ++i) {
-        int val;
+        raft_log_index_t val;
         if (str[i] >= '0' && str[i] <= '9') {
             val = str[i] - '0';
         } else if (str[i] >= 'a' && str[i] <= 'f') {


### PR DESCRIPTION
As far as I can tell, raft log indexes could never actually make it past 32 bits.  Good thing they move relatively slowly.

This fixes #7036.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
