### PR TITLE
Fix MacOS ARM build

### DIFF
--- a/mk/support/pkg/openssl.sh
+++ b/mk/support/pkg/openssl.sh
@@ -35,8 +35,7 @@ pkg_install () {
 
     pkg_configure
 
-    # Compiling without -j1 causes a lot of "undefined reference" errors
-    pkg_make -j1
+    pkg_make
 
     pkg_make install
 }

--- a/mk/support/pkg/openssl.sh
+++ b/mk/support/pkg/openssl.sh
@@ -14,11 +14,17 @@ pkg_configure () {
     # use shared instead of no-shared because curl's configure script
     # fails on some platforms if it can't find -lssl
     if [[ "$OS" = "Darwin" ]]; then
-        in_dir "$build_dir" ./Configure darwin64-x86_64-cc -shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
-    elif [[ "$arch" = arm ]]; then
-        in_dir "$build_dir" ./Configure linux-armv4 -shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        if [[ "$arch" = arm ]]; then
+            in_dir "$build_dir" ./Configure darwin64-arm64-cc -shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        else
+            in_dir "$build_dir" ./Configure darwin64-x86_64-cc -shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        fi
     else
-        in_dir "$build_dir" ./config shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        if [[ "$arch" = arm ]]; then
+            in_dir "$build_dir" ./Configure linux-armv4 -shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        else
+            in_dir "$build_dir" ./config shared --prefix="$(niceabspath "$install_dir")" $CFLAGS
+        fi
     fi
 }
 


### PR DESCRIPTION
Gets us building on MacOS on ARM.

Generally, `./configure --fetch all PYTHON=/usr/bin/python3` or `./configure --allow-fetch PYTHON=/usr/bin/python3` followed by `make -j8` or `make -j8 DEBUG=1` successfully build.

I verified that the admin UI started up and you could run queries, including r.http.

We encounter #7041 though.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

