### PR TITLE
Un-disable ExtProc.CrashedJob test

### DIFF
--- a/src/unittest/extproc_test.cc
+++ b/src/unittest/extproc_test.cc
@@ -293,7 +293,7 @@ private:
     }
 };
 
-SPAWNER_TEST(ExtProc, DISABLED_CrashedJob) {
+SPAWNER_TEST(ExtProc, CrashedJob) {
     extproc_pool_t pool(1);
 
     // Crash the worker, then make sure it recovers and we can still run more jobs


### PR DESCRIPTION
It's unclear why I disabled it in 2018.  It is the only disabled unit test, and it is passing.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
