### PR TITLE
Get MacOS rethinkdb_backtrace, make crash_or_trap abort()

### DIFF
--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -108,9 +108,13 @@ void set_errno(int new_errno);
         ::abort();                                                  \
     } while (0)
 
+// We added abort() to this -- sorry if this hurts your debug tracing
+// -- raise(SIGTRAP) is not terminating the process on MacOS anymore,
+// probably because we are blocking it in thread_pool.cc.
 #define crash_or_trap(msg, ...) do {                                \
         report_fatal_error(__FILE__, __LINE__, msg, ##__VA_ARGS__); \
         BREAKPOINT;                                                 \
+        ::abort();                                                  \
     } while (0)
 
 void report_fatal_error(const char*, int, const char*, ...) ATTR_FORMAT(printf, 3, 4);

--- a/src/rethinkdb_backtrace.cc
+++ b/src/rethinkdb_backtrace.cc
@@ -11,17 +11,39 @@
 #include "arch/runtime/coroutines.hpp"
 #include "arch/runtime/context_switching.hpp"
 
+/* MacOS previously stored the stack address and stack size in the
+opaque pthread struct pointed at by th->__opaque.  With recent versions
+of its libraries, it changed the opaque struct to hold the stack
+address and stack bottom address (i.e. stackaddr - stackbottom ==
+stacksize).  MacOS's backtrace() implementation uses this information
+in computing the backtrace.  You can see that in the implementation of
+__thread_stack_pcs at
+https://opensource.apple.com/source/Libc/Libc-1439.40.11/gen/thread_stack_pcs.c.auto.html .
+
+We scan over the pthread struct's memory to find the location of the
+fields.  Then, before computing a backtrace, we overwrite these
+fields!  Previously, we scanned for stackaddr and stacksize.  Now, we
+scan for all three, and decide whether to overwrite stackbottom or
+stacksize based on which was found.  (As of 2022 we overwrite
+stackbottom.)
+
+This has been tested on ARM (on an M1) and on x86.
+*/
+
 struct pthread_t_field_locations_t {
-    size_t stackaddr_offset;
-    size_t stacksize_offset;
+    size_t stackaddr_offset = SIZE_MAX;
+    size_t stackbottom_offset = SIZE_MAX;
+    size_t stacksize_offset = SIZE_MAX;
 };
 
 bool get_pthread_t_stack_field_locations(pthread_t th, pthread_t_field_locations_t *locations_out) {
     void *const stackaddr = pthread_get_stackaddr_np(th);
     const size_t stacksize = pthread_get_stacksize_np(th);
+    void *const stackbottom = static_cast<char *>(stackaddr) - stacksize;
 
     pthread_t_field_locations_t locations;
     bool found_stackaddr = false;
+    bool found_stackbottom = false;
     bool found_stacksize = false;
 
     const size_t step = std::min(sizeof(size_t), sizeof(void *));
@@ -39,6 +61,19 @@ bool get_pthread_t_stack_field_locations(pthread_t th, pthread_t_field_locations
             *reinterpret_cast<void **>(p) = stackaddr;
         }
 
+        if (!found_stackbottom
+            && i <= __PTHREAD_SIZE__ - sizeof(void *)
+            && *reinterpret_cast<void **>(p) == stackbottom) {
+            void *const test_value = static_cast<char *>(stackbottom) + 8;
+            *reinterpret_cast<void **>(p) = test_value;
+            if (static_cast<char *>(pthread_get_stackaddr_np(th))
+                    - pthread_get_stacksize_np(th) == test_value) {
+                locations.stackbottom_offset = i;
+                found_stackbottom = true;
+            }
+            *reinterpret_cast<void **>(p) = stackbottom;
+        }
+
         if (!found_stacksize
             && i <= __PTHREAD_SIZE__ - sizeof(size_t)
             && *reinterpret_cast<size_t *>(p) == stacksize) {
@@ -52,7 +87,7 @@ bool get_pthread_t_stack_field_locations(pthread_t th, pthread_t_field_locations
         }
     }
 
-    if (found_stackaddr && found_stacksize) {
+    if ((found_stackaddr && found_stackbottom) || (found_stackaddr && found_stacksize)) {
         *locations_out = locations;
         return true;
     } else {
@@ -60,10 +95,16 @@ bool get_pthread_t_stack_field_locations(pthread_t th, pthread_t_field_locations
     }
 }
 
-void substitute_pthread_t_stack_fields(pthread_t th, pthread_t_field_locations_t locations,
-                                       void *addr, size_t size) {
-    *reinterpret_cast<void **>(th->__opaque + locations.stackaddr_offset) = addr;
-    *reinterpret_cast<size_t *>(th->__opaque + locations.stacksize_offset) = size;
+void substitute_pthread_t_stack_fields(
+        pthread_t th, const pthread_t_field_locations_t &locations,
+        void *stackaddr, void *stackbottom, size_t size) {
+    *reinterpret_cast<void **>(th->__opaque + locations.stackaddr_offset) = stackaddr;
+    if (locations.stackbottom_offset != SIZE_MAX) {
+        *reinterpret_cast<void **>(th->__opaque + locations.stackbottom_offset) = stackbottom;
+    }
+    if (locations.stacksize_offset != SIZE_MAX) {
+        *reinterpret_cast<size_t *>(th->__opaque + locations.stacksize_offset) = size;
+    }
 }
 
 int rethinkdb_backtrace(void **buffer, int size) {
@@ -83,12 +124,13 @@ int rethinkdb_backtrace(void **buffer, int size) {
 
         coro_stack_t *const stack = coro->get_stack();
         void *const coro_addr = stack->get_stack_base();
+        void *const coro_bottom = stack->get_stack_bound();
         const size_t coro_size = static_cast<char *>(coro_addr)
-            - static_cast<char *>(stack->get_stack_bound());
+            - static_cast<char *>(coro_bottom);
 
-        substitute_pthread_t_stack_fields(self, field_locations, coro_addr, coro_size);
+        substitute_pthread_t_stack_fields(self, field_locations, coro_addr, coro_bottom, coro_size);
         const int res = backtrace(buffer, size);
-        substitute_pthread_t_stack_fields(self, field_locations, stackaddr, stacksize);
+        substitute_pthread_t_stack_fields(self, field_locations, stackaddr, static_cast<char *>(stackaddr) - stacksize, stacksize);
         return res;
     }
 }


### PR DESCRIPTION
One thing to note: it's not _always_ working.  E.g. it doesn't work if we have a SIGSEGV but it does if we have guarantee(false).  It probably has something to do with signal handling.

We also encountered the confusing situation in `crash_or_trap` where `raise(SIGTRAP)` didn't abort the process.  Maybe it is now swallowed up by MacOS.  So now the crash_or_trap macro is the same as crash -- it calls abort() after the BREAKPOINT line.

If you're running a debugger on some system and want to do something crazy like step forward, well, then, you can adjust the macro accordingly.

I assume the reason for this MacOS change is somehow related to how we block signals on non-main threads in thread_pool.cc.  Maybe we just ignore SIGTRAP now on MacOS.  It didn't trap when running in lldb either.

(I tested a simple executable that calls `raise(SIGTRAP)` in a separate thread and that did interrupt the whole process.  I am not going to investigate further.)

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
