### PR TITLE
Add RDB_NO_BACKTRACE flag for musl, alpine users

### DIFF
--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -332,7 +332,10 @@ void initialize_dbghelp() {
 #endif
 
 std::string backtrace_t::print_frames(bool use_addr2line) const {
-#ifdef _WIN32
+#if defined(RDB_NO_BACKTRACE)
+    (void)use_addr2line;
+    return "backtrace not supported by this binary\n";
+#elif defined(_WIN32)
     initialize_dbghelp();
 
     std::string output;

--- a/src/rethinkdb_backtrace.cc
+++ b/src/rethinkdb_backtrace.cc
@@ -1,6 +1,14 @@
 #include "rethinkdb_backtrace.hpp"
 
-#ifdef __MACH__
+#if defined(RDB_NO_BACKTRACE)
+
+int rethinkdb_backtrace(void **buffer, int size) {
+    (void)buffer;
+    (void)size;
+    return 0;
+}
+
+#elif defined(__MACH__)
 
 #include <execinfo.h>
 #include <pthread.h>


### PR DESCRIPTION
Add CXXFLAGS=-DRDB_NO_BACKTRACE to your ./configure line, or your
environment when running make.

I have not (yet?) tested this on Alpine or with Musl libc.  (In the prior month or two, I got reliance on backtrace() being the one error on Alpine.)  This will make it possible or at least easier for musl users to use RethinkDB.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
