### PR TITLE
refactor: avoid backtrace for user error

### DIFF
--- a/src/paths.cc
+++ b/src/paths.cc
@@ -37,7 +37,7 @@ int remove_directory_helper(const char *path) {
     } else {
         res = DeleteFile(path);
     }
-    if(res != 0) {
+    if (res != 0) {
         fail_due_to_user_error("failed to remove: '%s': %s", path, winerr_string(GetLastError()).c_str());
     }
     return 0;
@@ -48,7 +48,7 @@ int remove_directory_helper(const char *path) {
 int remove_directory_helper(const char *path, UNUSED const struct stat *, UNUSED int, UNUSED struct FTW *) {
     logNTC("In recursion: removing file '%s'\n", path);
     int res = ::remove(path);
-    if(res != 0) {
+    if (res != 0) {
         fail_due_to_user_error("Fatal error: failed to delete '%s'.", path);
     }
     return 0;

--- a/src/paths.cc
+++ b/src/paths.cc
@@ -17,6 +17,7 @@
 
 #include "arch/io/disk.hpp"
 #include "clustering/administration/main/directory_lock.hpp"
+#include "errors.hpp"
 #include "logger.hpp"
 
 #ifdef _MSC_VER
@@ -36,7 +37,9 @@ int remove_directory_helper(const char *path) {
     } else {
         res = DeleteFile(path);
     }
-    guarantee_winerr(res, "failed to remove: '%s': %s", path, winerr_string(GetLastError()).c_str());
+    if(res != 0) {
+        fail_due_to_user_error("failed to remove: '%s': %s", path, winerr_string(GetLastError()).c_str());
+    }
     return 0;
 }
 
@@ -45,7 +48,9 @@ int remove_directory_helper(const char *path) {
 int remove_directory_helper(const char *path, UNUSED const struct stat *, UNUSED int, UNUSED struct FTW *) {
     logNTC("In recursion: removing file '%s'\n", path);
     int res = ::remove(path);
-    guarantee_err(res == 0, "Fatal error: failed to delete '%s'.", path);
+    if(res != 0) {
+        fail_due_to_user_error("Fatal error: failed to delete '%s'.", path);
+    }
     return 0;
 }
 
@@ -220,4 +225,3 @@ std::string blocking_read_file(const char *path) {
     guarantee(success);
     return ret;
 }
-

--- a/src/random.cc
+++ b/src/random.cc
@@ -1,9 +1,10 @@
 // Copyright 2010-2016 RethinkDB, all rights reserved.
 #include "random.hpp"
 
+#include <memory>
+
 #include "containers/scoped.hpp"
 #include "thread_local.hpp"
-#include <memory>
 
 rng_t::rng_t()
     : m_mt19937(std::random_device{}()) {


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

This PR resolves https://github.com/rethinkdb/rethinkdb/issues/4647 by using `fail_due_to_user_error` over `guarantee_err` and `guarantee_winerr` for `remove_directory_helper`.