### PR TITLE
Add polyglot and integration tests to CI/CD

### DIFF
--- a/.github/actions/driver-tests/action.yml
+++ b/.github/actions/driver-tests/action.yml
@@ -2,6 +2,9 @@ name: Driver tests
 description: Base action for running driver tests with the test runner
 
 inputs:
+  kind:
+    description: Unique name of the test suite.
+    required: true
   driver_name:
     description: Name of the driver.
     required: true
@@ -92,7 +95,7 @@ runs:
 
     - uses: ./.github/actions/tests
       with:
-        kind: ${{ inputs.driver_name }}
+        kind: ${{ inputs.kind }}
         command: ${{ inputs.test_command }}
         upload_artifacts: ${{ inputs.upload_artifacts }}
         upload_artifacts_dir: ${{ inputs.upload_artifacts_dir }}

--- a/.github/actions/driver-tests/action.yml
+++ b/.github/actions/driver-tests/action.yml
@@ -2,9 +2,6 @@ name: Driver tests
 description: Base action for running driver tests with the test runner
 
 inputs:
-  kind:
-    description: Unique name of the test suite.
-    required: true
   driver_name:
     description: Name of the driver.
     required: true
@@ -48,14 +45,6 @@ inputs:
     description: Test target name, like "polyglot".
     default: ""
     required: false
-  upload_artifacts:
-    description: Upload test artifacts.
-    default: "false"
-    required: false
-  upload_artifacts_dir:
-    description: Artifacts directory to upload.
-    default: "test/rql_test/build"
-    required: false
 
 # Composite step for using driver-related test, like polyglot.
 runs:
@@ -95,10 +84,7 @@ runs:
 
     - uses: ./.github/actions/tests
       with:
-        kind: ${{ inputs.kind }}
         command: ${{ inputs.test_command }}
-        upload_artifacts: ${{ inputs.upload_artifacts }}
-        upload_artifacts_dir: ${{ inputs.upload_artifacts_dir }}
       env:
         DEFAULT_PYTHON_DRIVER: /tmp/default-python-driver/rethinkdb
         DRIVER_NAME: ${{ inputs.driver_name }}

--- a/.github/actions/driver-tests/action.yml
+++ b/.github/actions/driver-tests/action.yml
@@ -1,0 +1,105 @@
+name: Driver tests
+description: Base action for running driver tests with the test runner
+
+inputs:
+  driver_name:
+    description: Name of the driver.
+    required: true
+  driver_dist_dir:
+    description: The directory which contains the driver's distribution code.
+    required: true
+  repo_url:
+    description: Public git repository URL.
+    required: false
+  commit_hash:
+    description: The commit hash to use at checkout.
+    required: false
+  # TODO: This commit is pointing after driver extraction, hence it should be the baseline.
+  #  When all tests are passing using this commit hash, update the hash to the latest and
+  #  fix the newly raised issues.
+  default_python_driver_commit_hash:
+    description: The commit hash to use at checkout for the default Python driver.
+    default: f0bf3b7e5279d23b72ffc8d8d3ae7e26dd5384e4
+    required: false
+  install_command:
+    description: The test runner command to execute.
+    required: false
+  interpreter:
+    description: Name of the interpreter version.
+    default: ""
+    required: false
+  env_activate:
+    description: Activate the environment for the interpreter if needed
+    default: echo "no activate command set"
+    required: true
+  test_command:
+    description: Test command to call
+    default: |
+      export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
+      export "${DRIVER_NAME^^}_DRIVER=${DRIVER_DIST_DIR}"
+      export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+      eval "${ENV_ACTIVATION_COMMAND}"
+      test/rql_test/test-runner --jobs "${MAX_JOBS}" --interpreter ${INTERPRETER} ${TEST_TARGET}
+    required: true
+  test_target:
+    description: Test target name, like "polyglot".
+    default: ""
+    required: false
+  upload_artifacts:
+    description: Upload test artifacts.
+    default: "false"
+    required: false
+  upload_artifacts_dir:
+    description: Artifacts directory to upload.
+    default: "test/rql_test/build"
+    required: false
+
+# Composite step for using driver-related test, like polyglot.
+runs:
+  using: composite
+  steps:
+    - name: download ${{ inputs.driver_name }} driver
+      if: ${{ inputs.driver_name != 'python' }}
+      shell: bash
+      run: |
+        git clone "${DRIVER_REPOSITORY_URL}" /tmp/driver
+        cd /tmp/driver
+        git checkout "${DRIVER_COMMIT_HASH}"
+        cd -
+      env:
+        DRIVER_REPOSITORY_URL: ${{ inputs.repo_url }}
+        DRIVER_COMMIT_HASH: ${{ inputs.commit_hash }}
+
+    - name: download and setup python driver
+      shell: bash
+      run: |
+        git clone https://github.com/rethinkdb/rethinkdb-python /tmp/python-driver
+        cd /tmp/python-driver
+        git checkout ${{ inputs.default_python_driver_commit_hash }}
+        sudo apt install -y rsync
+        pip install -r requirements.txt
+        make prepare
+        cd -
+
+    - name: setup ${{ inputs.driver_name }} driver
+      if: ${{ inputs.driver_name != 'python' }}
+      shell: bash
+      run: |
+        cd /tmp/driver
+        eval "${{ inputs.env_activate }}"
+        ${{ inputs.install_command }}
+        cd -
+
+    - uses: ./.github/actions/tests
+      with:
+        kind: ${{ inputs.driver_name }}
+        command: ${{ inputs.test_command }}
+        upload_artifacts: ${{ inputs.upload_artifacts }}
+        upload_artifacts_dir: ${{ inputs.upload_artifacts_dir }}
+      env:
+        DEFAULT_PYTHON_DRIVER: /tmp/default-python-driver/rethinkdb
+        DRIVER_NAME: ${{ inputs.driver_name }}
+        DRIVER_DIST_DIR: ${{ inputs.driver_dist_dir }}
+        INTERPRETER: ${{ inputs.interpreter }}
+        TEST_TARGET: ${{ inputs.test_target }}
+        ENV_ACTIVATION_COMMAND: ${{ inputs.env_activate }}

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -5,20 +5,9 @@ inputs:
   command:
     description: The test runner command to execute.
     required: true
-  kind:
-    description: The kind of tests.
-    required: true
   download_artifacts:
     description: Download and decompress build artifacts.
     default: "true"
-    required: false
-  upload_artifacts:
-    description: Upload test artifacts.
-    default: "true"
-    required: false
-  upload_artifacts_dir:
-    description: Artifacts directory to upload.
-    default: "test/results"
     required: false
 
 # Composite step for using the test runner with multiple parameters.
@@ -49,16 +38,3 @@ runs:
     - name: run tests
       shell: bash
       run: ${{ inputs.command }}
-
-    - name: compress test artifacts for upload
-      if: ${{ inputs.upload_artifacts == 'true' }}
-      shell: bash
-      run: tar -cvzf ${{ inputs.kind }}-tests.tar.gz ${{ inputs.upload_artifacts_dir }}
-
-    - name: upload ${{ inputs.kind }} test artifact
-      if: ${{ inputs.upload_artifacts == 'true' }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ inputs.kind }}-tests.tar.gz
-        path: ${{ inputs.kind }}-tests.tar.gz
-        if-no-files-found: error

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -1,0 +1,64 @@
+name: Test base
+description: Base action for running steps
+
+inputs:
+  command:
+    description: The test runner command to execute.
+    required: true
+  kind:
+    description: The kind of tests.
+    required: true
+  download_artifacts:
+    description: Download and decompress build artifacts.
+    default: "true"
+    required: false
+  upload_artifacts:
+    description: Upload test artifacts.
+    default: "true"
+    required: false
+  upload_artifacts_dir:
+    description: Artifacts directory to upload.
+    default: "test/results"
+    required: false
+
+# Composite step for using the test runner with multiple parameters.
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '2.7'
+
+    - name: install prerequisites
+      shell: bash
+      run: |
+        sudo apt update && sudo apt install -y curl make git ca-certificates gnupg2
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
+
+    - name: download build artifacts
+      uses: actions/download-artifact@v3
+      if: ${{ inputs.download_artifacts == 'true' }}
+      with:
+        name: build-artifacts
+
+    - name: decompress build dir
+      if: ${{ inputs.download_artifacts == 'true' }}
+      shell: bash
+      run: tar -xzf build.tar.gz
+
+    - name: run tests
+      shell: bash
+      run: ${{ inputs.command }}
+
+    - name: compress test artifacts for upload
+      if: ${{ inputs.upload_artifacts == 'true' }}
+      shell: bash
+      run: tar -cvzf ${{ inputs.kind }}-tests.tar.gz ${{ inputs.upload_artifacts_dir }}
+
+    - name: upload ${{ inputs.kind }} test artifact
+      if: ${{ inputs.upload_artifacts == 'true' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.kind }}-tests.tar.gz
+        path: ${{ inputs.kind }}-tests.tar.gz
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           test_command: |
             export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
-            test/run --timeout 300 --jobs "${MAX_JOBS}" -H long '!disabled'
+            test/run --timeout 900 --jobs "${MAX_JOBS}" -H long '!disabled'
           upload_artifacts: true
           upload_artifacts_dir: test/results
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: "Build"
 
+# NOTE: Although it is deprecated, we use Python 2, because all python scripts
+#  are targeting that in the repository. To drop Python 2, we would need to
+#  update every script, which is a big effort. Also, this locks us into a
+#  given Python driver version (rethinkdb-python < 2.5).
+
 on:
   push:
     branches: [ v2.4.x ]
@@ -9,22 +14,40 @@ on:
     - cron: '00 8 * * 1'
 
 jobs:
-  build:
 
+  # Preflight runs every test and assertion that has no dependency on the build
+  # directory.
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: cpplint
+        uses: ./.github/actions/tests
+        with:
+          kind: cpplint
+          command: ./scripts/check_style.sh
+          download_artifacts: false
+          upload_artifacts: false
 
+  # Build job runs after the preflight finished successfully. It configures the
+  # build system, then builds the DB.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    needs: preflight
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '2.x'
+          python-version: '2.7'
 
       - name: apt install
         run: |
           sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y tzdata \
               && sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
               && sudo dpkg-reconfigure --frontend noninteractive tzdata
-          sudo  apt update && sudo apt install -y \
+          sudo apt update && sudo apt install -y \
               libc6 libcurl4 \
               git build-essential protobuf-compiler \
               libprotobuf-dev libcurl4-openssl-dev \
@@ -34,23 +57,156 @@ jobs:
       - name: configure
         run: ./configure --fetch boost --fetch gtest --fetch re2 --fetch jemalloc --fetch quickjs
 
-      - name: check style
-        run: ./scripts/check_style.sh
-
       - name: make support
-        run: make support
+        run: make support -j $(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 
       - name: make DEBUG=1
-        run: make DEBUG=1
+        run: make DEBUG=1 -j $(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 
-      - name: prepare build dir for upload
+      - name: compress build artifacts for upload
         run: tar -cvzf build.tar.gz build
 
       - name: upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: build.tar.gz
-          path: build.tar.gz
+          name: build-artifacts
+          path: |
+            config.mk
+            build.tar.gz
+          if-no-files-found: error
 
-      - name: run unit tests
-        run: exec $(find build -name rethinkdb-unittest)
+  # Execute the test runner for unit tests.
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: unit tests
+        uses: ./.github/actions/tests
+        with:
+          kind: unit
+          command: |
+            export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+            test/run --verbose --jobs "${MAX_JOBS}" -H unit
+
+  # Execute the test runner for integration tests.
+  # NOTE: integration tests are using the Python driver, hence we have to setup the
+  #  driver and checkout the exact same commit hash as we do for other tests.
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: integration tests
+        uses: ./.github/actions/driver-tests
+        with:
+          driver_name: python
+          driver_dist_dir: /tmp/python-driver/rethinkdb
+          test_command: |
+            export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
+            export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+            test/run --timeout 300 --jobs "${MAX_JOBS}" -H all '!unit' '!cpplint' '!long'
+          upload_artifacts: true
+          upload_artifacts_dir: test/results
+
+  long-running-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: integration tests
+        uses: ./.github/actions/driver-tests
+        with:
+          driver_name: python
+          driver_dist_dir: /tmp/python-driver/rethinkdb
+          test_command: |
+            export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
+            export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+            test/run --timeout 300 --jobs "${MAX_JOBS}" -H long
+          upload_artifacts: true
+          upload_artifacts_dir: test/results
+
+  # Execute the test runner for polyglot tests.
+  # NOTE: We are not running "language group" tests (like `py`, `rb`, or `js`) because
+  #  those interpreter versions listed in the groups are way deprecated. Instead, we
+  #  are running one test per language as a sanity check. We should run language groups
+  #  when we ensured that drivers are supporting never interpreter versions.
+  polyglot-tests-python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - unit-tests
+      - integration-tests
+      - long-running-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: polyglot tests for python
+        uses: ./.github/actions/driver-tests
+        with:
+          driver_name: python
+          driver_dist_dir: /tmp/python-driver/rethinkdb
+          interpreter: py2.7
+          test_target: polyglot
+
+  polyglot-tests-javascript:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - unit-tests
+      - integration-tests
+      - long-running-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: install nvm and node
+        run: |
+          curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+          source $HOME/.nvm/nvm.sh
+          nvm install 5.12
+
+      - name: polyglot tests for javascript
+        uses: ./.github/actions/driver-tests
+        with:
+          driver_name: javascript
+          driver_dist_dir: /tmp/driver/dist
+          repo_url: https://github.com/rethinkdb/rethinkdb-javascript.git
+          # TODO: This commit is pointing after driver extraction, hence it should be the baseline.
+          #  When all tests are passing using this commit hash, update the hash to the latest and
+          #  fix the newly raised issues.
+          commit_hash: c717cb9e2bdab77b55b7a31a5d780ba293c5fadf
+          interpreter: js5
+          test_target: polyglot
+          env_activate: source $HOME/.nvm/nvm.sh && nvm use 5.12
+          install_command: npm install && npm run build
+
+  polyglot-tests-ruby:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - unit-tests
+      - integration-tests
+      - long-running-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: install rvm and ruby
+        run: |
+          sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y software-properties-common
+          sudo apt-add-repository -y ppa:rael-gc/rvm
+          sudo apt update && sudo apt install -y rvm
+          source /etc/profile.d/rvm.sh
+          rvm install 2.5 && rvm use 2.5
+          gem install bundler
+
+      - name: polyglot tests for ruby
+        uses: ./.github/actions/driver-tests
+        with:
+          driver_name: ruby
+          driver_dist_dir: /tmp/driver/lib
+          repo_url: https://github.com/rethinkdb/rethinkdb-ruby.git
+          commit_hash: 25781763f1af4e85116c80fd0cc988927e9c6829
+          interpreter: rb2.5
+          test_target: polyglot
+          env_activate: source /etc/profile.d/rvm.sh && rvm use 2.5
+          install_command: bundle install && rake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,12 +102,13 @@ jobs:
       - name: integration tests
         uses: ./.github/actions/driver-tests
         with:
+          kind: integration-tests
           driver_name: python
           driver_dist_dir: /tmp/python-driver/rethinkdb
           test_command: |
             export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
-            test/run --timeout 300 --jobs "${MAX_JOBS}" -H all '!unit' '!cpplint' '!long'
+            test/run --timeout 300 --jobs "${MAX_JOBS}" -H all '!unit' '!cpplint' '!long' '!disabled'
           upload_artifacts: true
           upload_artifacts_dir: test/results
 
@@ -117,15 +118,16 @@ jobs:
     needs: unit-tests
     steps:
       - uses: actions/checkout@v3
-      - name: integration tests
+      - name: long running tests
         uses: ./.github/actions/driver-tests
         with:
+          kind: long-running-tests
           driver_name: python
           driver_dist_dir: /tmp/python-driver/rethinkdb
           test_command: |
             export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
-            test/run --timeout 300 --jobs "${MAX_JOBS}" -H long
+            test/run --timeout 300 --jobs "${MAX_JOBS}" -H long '!disabled'
           upload_artifacts: true
           upload_artifacts_dir: test/results
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
-      - unit-tests
       - integration-tests
       - long-running-tests
     steps:
@@ -197,7 +196,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
-      - unit-tests
       - integration-tests
       - long-running-tests
     steps:
@@ -239,7 +237,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
-      - unit-tests
       - integration-tests
       - long-running-tests
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,18 @@ jobs:
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
             test/run --verbose --jobs "${MAX_JOBS}" -H unit
 
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job }}.tar.gz test/results
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz
+
   # Execute the test runner for integration tests.
   # NOTE: integration tests are using the Python driver, hence we have to setup the
   #  driver and checkout the exact same commit hash as we do for other tests.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,13 @@ jobs:
 
       - name: compress build artifacts for upload
         if: always()
-        run: tar -czf ${{ github.job_id }}.tar.gz build
+        run: tar -czf ${{ github.job }}.tar.gz build
 
       - name: upload build artifact
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ github.job_id }}-artifacts
+          name: ${{ github.job }}-artifacts
           path: |
             config.mk
             build.tar.gz
@@ -110,14 +110,14 @@ jobs:
       - name: compress test artifacts for upload
         if: always()
         shell: bash
-        run: tar -czf ${{ github.job_id }}.tar.gz test/results
+        run: tar -czf ${{ github.job }}.tar.gz test/results
 
       - name: upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job_id }}.tar.gz
-          path: ${{ github.job_id }}.tar.gz
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz
 
   long-running-tests:
     runs-on: ubuntu-latest
@@ -138,14 +138,14 @@ jobs:
       - name: compress test artifacts for upload
         if: always()
         shell: bash
-        run: tar -czf ${{ github.job_id }}.tar.gz test/results
+        run: tar -czf ${{ github.job }}.tar.gz test/results
 
       - name: upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job_id }}.tar.gz
-          path: ${{ github.job_id }}.tar.gz
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz
 
   # Execute the test runner for polyglot tests.
   # NOTE: We are not running "language group" tests (like `py`, `rb`, or `js`) because
@@ -172,14 +172,14 @@ jobs:
       - name: compress test artifacts for upload
         if: always()
         shell: bash
-        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+        run: tar -czf ${{ github.job }}.tar.gz test/rql_test/build
 
       - name: upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job_id }}.tar.gz
-          path: ${{ github.job_id }}.tar.gz
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz
 
   polyglot-tests-javascript:
     runs-on: ubuntu-latest
@@ -214,14 +214,14 @@ jobs:
       - name: compress test artifacts for upload
         if: always()
         shell: bash
-        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+        run: tar -czf ${{ github.job }}.tar.gz test/rql_test/build
 
       - name: upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job_id }}.tar.gz
-          path: ${{ github.job_id }}.tar.gz
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz
 
   polyglot-tests-ruby:
     runs-on: ubuntu-latest
@@ -256,11 +256,11 @@ jobs:
       - name: compress test artifacts for upload
         if: always()
         shell: bash
-        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+        run: tar -czf ${{ github.job }}.tar.gz test/rql_test/build
 
       - name: upload test artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job_id }}.tar.gz
-          path: ${{ github.job_id }}.tar.gz
+          name: ${{ github.job }}.tar.gz
+          path: ${{ github.job }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,6 @@ jobs:
       - name: unit tests
         uses: ./.github/actions/tests
         with:
-          kind: unit
           command: |
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
             test/run --verbose --jobs "${MAX_JOBS}" -H unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,8 @@ jobs:
       - name: cpplint
         uses: ./.github/actions/tests
         with:
-          kind: cpplint
           command: ./scripts/check_style.sh
           download_artifacts: false
-          upload_artifacts: false
 
   # Build job runs after the preflight finished successfully. It configures the
   # build system, then builds the DB.
@@ -64,16 +62,17 @@ jobs:
         run: make DEBUG=1 -j $(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 
       - name: compress build artifacts for upload
-        run: tar -cvzf build.tar.gz build
+        if: always()
+        run: tar -czf ${{ github.job_id }}.tar.gz build
 
       - name: upload build artifact
         uses: actions/upload-artifact@v3
+        if: always()
         with:
-          name: build-artifacts
+          name: ${{ github.job_id }}-artifacts
           path: |
             config.mk
             build.tar.gz
-          if-no-files-found: error
 
   # Execute the test runner for unit tests.
   unit-tests:
@@ -102,15 +101,24 @@ jobs:
       - name: integration tests
         uses: ./.github/actions/driver-tests
         with:
-          kind: integration-tests
           driver_name: python
           driver_dist_dir: /tmp/python-driver/rethinkdb
           test_command: |
             export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
             test/run --timeout 300 --jobs "${MAX_JOBS}" -H all '!unit' '!cpplint' '!long' '!disabled'
-          upload_artifacts: true
-          upload_artifacts_dir: test/results
+
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job_id }}.tar.gz test/results
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job_id }}.tar.gz
+          path: ${{ github.job_id }}.tar.gz
 
   long-running-tests:
     runs-on: ubuntu-latest
@@ -121,15 +129,24 @@ jobs:
       - name: long running tests
         uses: ./.github/actions/driver-tests
         with:
-          kind: long-running-tests
           driver_name: python
           driver_dist_dir: /tmp/python-driver/rethinkdb
           test_command: |
             export PYTHON_DRIVER=/tmp/python-driver/rethinkdb
             export MAX_JOBS=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
             test/run --timeout 900 --jobs "${MAX_JOBS}" -H long '!disabled'
-          upload_artifacts: true
-          upload_artifacts_dir: test/results
+
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job_id }}.tar.gz test/results
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job_id }}.tar.gz
+          path: ${{ github.job_id }}.tar.gz
 
   # Execute the test runner for polyglot tests.
   # NOTE: We are not running "language group" tests (like `py`, `rb`, or `js`) because
@@ -152,6 +169,18 @@ jobs:
           driver_dist_dir: /tmp/python-driver/rethinkdb
           interpreter: py2.7
           test_target: polyglot
+
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job_id }}.tar.gz
+          path: ${{ github.job_id }}.tar.gz
 
   polyglot-tests-javascript:
     runs-on: ubuntu-latest
@@ -183,6 +212,18 @@ jobs:
           env_activate: source $HOME/.nvm/nvm.sh && nvm use 5.12
           install_command: npm install && npm run build
 
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job_id }}.tar.gz
+          path: ${{ github.job_id }}.tar.gz
+
   polyglot-tests-ruby:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -212,3 +253,15 @@ jobs:
           test_target: polyglot
           env_activate: source /etc/profile.d/rvm.sh && rvm use 2.5
           install_command: bundle install && rake build
+
+      - name: compress test artifacts for upload
+        if: always()
+        shell: bash
+        run: tar -czf ${{ github.job_id }}.tar.gz test/rql_test/build
+
+      - name: upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job_id }}.tar.gz
+          path: ${{ github.job_id }}.tar.gz

--- a/test/common/utils.py
+++ b/test/common/utils.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import atexit, collections, fcntl, os, pprint, platform, random, re, shutil, signal
+import inspect
 import socket, string, subprocess, sys, tempfile, threading, time, warnings
 
 import test_exceptions
@@ -180,8 +181,7 @@ def import_python_driver():
         return __loadedPythonDriver
     
     # --
-    
-    loadedDriver = None
+
     driverPath =  driverPaths['Python']['driverPath']
     sourcePath =  driverPaths['Python']['sourcePath']
     
@@ -193,7 +193,7 @@ def import_python_driver():
             loadedDriver = __import__('rethinkdb')
             driverPaths['Python']['driverPath'] = os.path.dirname(loadedDriver.__file__)
             os.environ['PYTHON_DRIVER'] = driverPaths['Python']['driverPath']
-            return loadedDriver
+            return loadedDriver.r if inspect.isclass(loadedDriver) else loadedDriver
         except ImportError as e:
             raise ImportError('Unable to load system-installed `rethinkdb` module - %s' % str(e))
     
@@ -227,8 +227,8 @@ def import_python_driver():
         raise ImportError('Loaded Python driver was %s, rather than the expected one from %s' % (loadedDriver.__file__, driverPath))
     
     # -- return the loaded module
-    
-    __loadedPythonDriver = loadedDriver
+
+    __loadedPythonDriver = loadedDriver.r if inspect.isclass(loadedDriver) else loadedDriver
     return __loadedPythonDriver
 
 class PerformContinuousAction(threading.Thread):

--- a/test/full_test/disabled.group
+++ b/test/full_test/disabled.group
@@ -1,1 +1,3 @@
 # List tests here to disable them in `default` runs
+regression.known_failures_1774
+interface.artificial_table

--- a/test/rql_test/drivers/driver.py
+++ b/test/rql_test/drivers/driver.py
@@ -26,7 +26,10 @@ start_time=time.time()
 # -- import driver
 
 r = utils.import_python_driver()
-print('Using RethinkDB client from: %s' % r.__file__)
+print(
+    'Using RethinkDB client from:',
+    inspect.getfile(r.__class__) if inspect.isclass(r) else r.__file__
+)
 
 # -- get settings
 

--- a/test/rql_test/importRethinkDB.js
+++ b/test/rql_test/importRethinkDB.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 // -- load rethinkdb from the proper location
 
-rethinkdbLocation = process.env.JAVASCRIPT_DRIVER_DIR || path.join(__dirname, '..', '..', 'build', 'packages', 'js');
+rethinkdbLocation = process.env.JAVASCRIPT_DRIVER || path.join(__dirname, '..', '..', 'build', 'packages', 'js');
 if (fs.existsSync(path.resolve(rethinkdbLocation, 'rethinkdb.js')) == false) {
     process.stdout.write('Could not locate the javascript drivers at the expected location: ' + rethinkdbLocation);
     process.exit(1);
@@ -47,4 +47,3 @@ if (require.main === module) {
     module.exports.r = r;
     module.exports.protodef = protodef;
 }
-    

--- a/test/rql_test/importRethinkDB.rb
+++ b/test/rql_test/importRethinkDB.rb
@@ -3,7 +3,7 @@
 
 # -- get the location of the driver
 
-rethinkdbDriverPath = File.expand_path(ENV['RUBY_DRIVER_DIR'] || File.join(File.dirname(__FILE__), '..', '..', 'build', 'drivers', 'ruby', 'lib'))
+rethinkdbDriverPath = File.expand_path(ENV['RUBY_DRIVER'] || File.join(File.dirname(__FILE__), '..', '..', 'build', 'drivers', 'ruby', 'lib'))
 
 # -- import the RethinkDB driver
 

--- a/test/rql_test/src/arity.yaml
+++ b/test/rql_test/src/arity.yaml
@@ -55,9 +55,7 @@ tests:
         py3.5: err_regex('TypeError', '.* missing 1 required positional argument.*', [])
         py: err_regex('TypeError', ".* takes at least 1 (?:positional )?argument \(0 given\)", [])
         js: err("ReqlCompileError", "Expected between 1 and 2 arguments but found 0.", [])
-        rb: err("ArgumentError", 'wrong number of arguments (0 for 1)', [])
-        rb2: err("ArgumentError", 'wrong number of arguments (0 for 1..2)', [])
-        rb2.3: err("ArgumentError", 'wrong number of arguments (given 0, expected 1..2)', [])
+        rb: err("ArgumentError", 'wrong number of arguments (given 0, expected 1..2)', [])
 
     - ot: err("ReqlCompileError", "Expected 2 arguments but found 1.", [])
       cd:
@@ -214,8 +212,7 @@ tests:
       ot:
         js: err('ReqlCompileError', "Expected 1 argument but found 2.", [])
         py: err('ReqlQueryLogicError', 'Expected NUMBER or STRING as second argument to `bracket` but found ARRAY.')
-        rb: err('ArgumentError', 'wrong number of arguments (2 for 1)')
-        rb2.3: err('ArgumentError', 'wrong number of arguments (given 2, expected 1)')
+        rb: err('ArgumentError', 'wrong number of arguments (given 2, expected 1)')
 
     - cd: tbl.insert([{'id':0},{'id':1},{'id':2},{'id':3},{'id':4},{'id':5},{'id':6},{'id':7},{'id':8},{'id':9}]).get_field('inserted')
       ot: 10

--- a/test/rql_test/src/control.yaml
+++ b/test/rql_test/src/control.yaml
@@ -162,7 +162,7 @@ tests:
       ot: err("ReqlQueryLogicError", "Query result must be of type DATUM, GROUPED_DATA, or STREAM (got FUNCTION).", [0])
 
     - cd: r.js('function() { return 1; }')
-      ot: err("ReqlQueryLogicError", "SyntaxError: Unexpected token (", [0])
+      ot: err("ReqlQueryLogicError", "SyntaxError: function name expected")
 
     # Play with the number of arguments in the JS function
     - cd: r.do(1, 2, r.js('(function(a) { return a; })'))

--- a/test/rql_test/src/meta/grant.yaml
+++ b/test/rql_test/src/meta/grant.yaml
@@ -48,22 +48,22 @@ tests:
     - cd: r.db("rethinkdb").table("permissions").filter({"user": "test_user"}).delete()
     - cd: r.grant("test_user", {"read": true})
       runopts:
-        user: "test_user"
+        user: test_user
       ot: err("ReqlPermissionError", "User `test_user` does not have the required `read` permission.", [])
     - cd: r.grant("test_user", {"read": true, "write": true})
     - cd: r.grant("test_user", {"read": true})
       runopts:
-        user: "test_user"
+        user: test_user
       ot: err("ReqlPermissionError", "User `test_user` does not have the required `read` permission.", [])
     - cd: r.grant("test_user", {"read": null, "write": null})
     - cd: r.db("rethinkdb").grant("test_user", {"read": true, "write": true})
     - cd: r.grant("test_user", {"read": true})
       runopts:
-        user: "test_user"
+        user: test_user
       ot: {"granted": 1, "permissions_changes": [{"old_val": null, "new_val": {"read": true}}]}
     - cd: r.db("rethinkdb").grant("test_user", {"read": null, "write": null})
     - cd: r.db("rethinkdb").table("permissions").grant("test_user", {"read": true, "write": true})
     - cd: r.grant("test_user", {"write": true})
       runopts:
-        user: "test_user"
+        user: test_user
       ot: {"granted": 1, "permissions_changes": [{"old_val": {"read": true}, "new_val": {"read": true, "write": true}}]}

--- a/test/rql_test/test-runner
+++ b/test/rql_test/test-runner
@@ -548,36 +548,27 @@ class JrbLang(RbLang):
         self.interpreter_name_exe_names.append('jruby')
 
 interpreters = {
-    'js':     [JsLang('0.10'), JsLang('0.12'), JsLang('4.0'), JsLang('4.1'), JsLang('4.2'), JsLang('5.0'), JsLang('5.1'), JsLang('5.2'), JsLang('5.3')],
-    'py':     [PyLang('2.6'), PyLang('2.7'), PyLang('3.0'), PyLang('3.1'), PyLang('3.2'), PyLang('3.3'), PyLang('3.4'), PyLang('3.5')],
-    'rb':     [RbLang('1.9'), RbLang('2.0'), RbLang('2.1'), RbLang('2.3'), JrbLang('9.0')],
+    'js':     [JsLang('5.12'), JsLang('5.16')],
+    'py':     [PyLang('2.7'), PyLang('3.6'), PyLang('3.8')],
+    'rb':     [RbLang('2.5'), RbLang('2.6'), RbLang('2.7'), JrbLang('9.2')],
     'jrb':    [JrbLang('9.0')],
+
+    'js5':    [JsLang('5.12')],
+    'js16':    [JsLang('16')],
     
-    'js0':    [JsLang('0.10'), JsLang('0.12')],
-    'js4':    [JsLang('4.0'), JsLang('4.1'), JsLang('4.2')],
-    'js5':    [JsLang('5.0'), JsLang('5.1'), JsLang('5.2'), JsLang('5.3')],
-    
-    'py2':    [PyLang('2.6'), PyLang('2.7')],
-    'py2.6':  [PyLang('2.6')],
+    'py2':    [PyLang('2.7')],
     'py2.7':  [PyLang('2.7')],
     
-    'py3':    [PyLang('3.0'), PyLang('3.1'), PyLang('3.2'), PyLang('3.3'), PyLang('3.4'), PyLang('3.5')],
-    'py3.0':  [PyLang('3.0')],
-    'py3.1':  [PyLang('3.1')],
-    'py3.2':  [PyLang('3.2')],
-    'py3.3':  [PyLang('3.3')],
-    'py3.4':  [PyLang('3.4')],
-    'py3.5':  [PyLang('3.5')],
+    'py3':    [PyLang('3.6'), PyLang('3.8')],
+    'py3.6':  [PyLang('3.6')],
+    'py3.8':  [PyLang('3.8')],
     
-    'rb1':    [RbLang('1.9')],
-    'rb1.9':  [RbLang('1.9')],
+    'rb2':    [RbLang('2.5'), RbLang('2.6'), RbLang('2.7'), JrbLang('9.2')],
+    'rb2.5':  [RbLang('2.5')],
+    'rb2.6':  [RbLang('2.6')],
+    'rb2.7':  [RbLang('2.7')],
     
-    'rb2':    [RbLang('2.0'), RbLang('2.1'), RbLang('2.2')],
-    'rb2.0':  [RbLang('2.0')],
-    'rb2.1':  [RbLang('2.1')],
-    'rb2.2':  [RbLang('2.2')],
-    
-    'jrb9.0': [JrbLang('9.0')]
+    'jrb9.2': [JrbLang('9.2')]
 }
 
 # Abstracts a set of tests given in a single file

--- a/test/rql_test/test-runner
+++ b/test/rql_test/test-runner
@@ -548,13 +548,13 @@ class JrbLang(RbLang):
         self.interpreter_name_exe_names.append('jruby')
 
 interpreters = {
-    'js':     [JsLang('5.12'), JsLang('5.16')],
+    'js':     [JsLang('5.12'), JsLang('16.14')],
     'py':     [PyLang('2.7'), PyLang('3.6'), PyLang('3.8')],
     'rb':     [RbLang('2.5'), RbLang('2.6'), RbLang('2.7'), JrbLang('9.2')],
     'jrb':    [JrbLang('9.0')],
 
     'js5':    [JsLang('5.12')],
-    'js16':    [JsLang('16')],
+    'js16':    [JsLang('16.14')],
     
     'py2':    [PyLang('2.7')],
     'py2.7':  [PyLang('2.7')],


### PR DESCRIPTION
### Description

resolves https://github.com/rethinkdb/rethinkdb/issues/6871

This PR is a follow-up on the approach introduced at https://github.com/rethinkdb/rethinkdb/pull/7058. We add the following tests to the pipeline grouped as follows:

* Unit tests
* Integration tests
  * [bonus_tests.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/bonus_tests.test)
  * [changefeeds.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/changefeeds.test)
  * [clustering.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/clustering.test)
  * [continuous.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/continuous.test)
  * [error_tolerant.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/error_tolerant.test)
  * [flaky.group](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/flaky.group)
  * [interface.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/interface.test)
  * [regression.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/regression.test)
  * [split_workloads.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/split_workloads.test)
  * [static_cluster.test](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/static_cluster.test)
* Long running tests
  * [long.group](https://github.com/rethinkdb/rethinkdb/blob/v2.4.x/test/full_test/long.group)
* Polyglot
  * For Python
  * For Javascript
  * For Ruby

Some tests were disabled as they failed, hence those should be fixed later on:

* regression.known_failures_1774
* interface.artificial_table

### Screenshots

**A [successful pipeline run](https://github.com/rethinkdb/rethinkdb/actions/runs/2277241303) (and step dependencies)**

<img width="1714" alt="Screenshot 2022-05-05 at 20 29 08" src="https://user-images.githubusercontent.com/19173947/166993365-2a5c5918-dd2e-4ce2-9b99-b839de1daaf7.png">


### Notes

The pipeline will run steps respecting their dependencies. If a step fails, all dependent steps will be canceled. 

**The pipeline is running on `ubuntu-latest` executors which are actually `Ubuntu 20.04` containers.** This means we don't run the pipeline for other distributions, so consider it as a best effort (as of now). This could be changed later, especially if we add a release pipeline to build build packages for all supported distributions, though that's a different discussion.

We have some flaky unit tests (`TimerTest.TestApproximateWaitTimes`, `ClusteringRaft.Failover`) which should be resolved later on. Also, one polyglot test times out sometimes. Other than these 3 tests, we are good.