### PR TITLE
Add warning about using `--initial-password` to cli help text

### DIFF
--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -1377,7 +1377,10 @@ options::help_section_t get_auth_options(std::vector<options::option_t> *options
                                              options::OPTIONAL));
     help.add("--initial-password {auto | password}",
              "sets an initial password for the \"admin\" user on a new server.  If set "
-             "to auto, a random password will be generated.");
+             "to auto, a random password will be generated. Care should be taken when "
+             "using values other than auto as your password can be leaked into system logs "
+             "and process monitors. As a safer alternative, create a file with the content "
+             "initial-password=Y0urP4$$woRd and load it using the --config-file option.");
 
     return help;
 }


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Per https://github.com/rethinkdb/rethinkdb/issues/7061#issuecomment-1119384833, added help text warning about using `--initial-password` cli option and suggesting `--config-file` as an alternative.
