### PR TITLE
fix: pass release notes link to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ last_tested_versions
 *.xml
 *.iml
 /.vscode
+/.idea

--- a/admin/static/coffee/body.coffee
+++ b/admin/static/coffee/body.coffee
@@ -194,6 +194,7 @@ class AlertUpdates extends Backbone.View
                 @next_version = last_version  # Save it so users can ignore the update
                 @$el.html @has_update_template
                     last_version: last_version
+                    link_changelog: "https://github.com/rethinkdb/rethinkdb/blob/v#{last_version}/NOTES.md"
                 @$el.slideDown 'fast'
 
     # Compare version with the format %d.%d.%d


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

Fixes https://github.com/rethinkdb/rethinkdb/issues/7068 by passing the missing var to the template. The release notes will always point to the give version tag's `NOTES.md` for the sake of simplicity.

<img width="1085" alt="Screenshot 2022-05-08 at 19 14 30" src="https://user-images.githubusercontent.com/19173947/167307602-67208c68-77c5-4229-a209-6215eebaf282.png">

cc: @srh