### PR TITLE
Fix windows build and point to stripped down quickjspp

### DIFF
--- a/mk/rethinkdb.vcxproj.xsl
+++ b/mk/rethinkdb.vcxproj.xsl
@@ -81,6 +81,7 @@
               WINVER=<xsl:value-of select="/config/target/@winver" />;
               _WIN32_WINNT=<xsl:value-of select="/config/target/@winver" />;
               RETHINKDB_VERSION="<xsl:value-of select="/config/@RethinkDBVersion" />";
+              BUILD_MACHINE="Windows";
               _USE_MATH_DEFINES;
               COMPILER_MSVC;
               RAPIDJSON_HAS_STDSTRING;

--- a/mk/support/pkg/quickjs.sh
+++ b/mk/support/pkg/quickjs.sh
@@ -1,7 +1,8 @@
-version=a2ce903e66fd642c8323aa9542aa5df20ed02abe
+github_user=srh
+version=892b1e3cd5e6c2025c6fc58fa4dbaac734b85d72
 
-src_url=https://github.com/c-smile/quickjspp/archive/${version}.tar.gz
-src_url_sha1=53355a6e495330f10fded79a6de25a79704cacd6
+src_url=https://github.com/${github_user}/quickjspp/archive/${version}.tar.gz
+src_url_sha1=a7da6b2d89624135f1e6c1292855fa85dc84deb6
 
 pkg_configure () {
     ( cd "$build_dir" && sed "s!^prefix=/usr/local\$!prefix=$(niceabspath "$install_dir")!" < Makefile > Makefile.tmp && mv Makefile.tmp Makefile )


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Fixed the Windows build, which was broken by #7060.  This branch become broken when its PR's that added Windows support got rebased.

Also, this points to a stripped down release of quickjspp.  It includes some bug fixes in https://github.com/bellard/quickjs that come after the most recent release.  Generally it has fewer commits than c-smile's quickjspp, omitting the JSX and storage code, and a couple of minor adjustments.