### PR TITLE
Switch PHP driver in README back to danielmewes' php-rql

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Besides our four official drivers, we also have many [third-party drivers](https
 * **Elixir:** [rethinkdb-elixir](https://github.com/rethinkdb/rethinkdb-elixir)
 * **Go:** [GoRethink](https://github.com/dancannon/gorethink)
 * **Haskell:** [haskell-rethinkdb](https://github.com/atnnn/haskell-rethinkdb)
-* **PHP:** [php-rethink-ql](https://github.com/tbolier/php-rethink-ql)
+* **PHP:** [php-rql](https://github.com/danielmewes/php-rql)
 * **Rust:** [reql](https://github.com/rust-rethinkdb/reql)
 * **Scala:** [rethink-scala](https://github.com/kclay/rethink-scala)
 


### PR DESCRIPTION
The tbolier driver is incomplete, according to its [roadmap](https://github.com/tbolier/php-rethink-ql/blob/master/docs/roadmap.md),
and a quick perusal of the codebase.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

There is some discussion at https://github.com/rethinkdb/rethinkdb/commit/327e8aace86fd132a27c48e6dbca935a3a9679d1

@tbolier
@ForbiddenEra