### PR TITLE
Include <time.h> in files using time function

### DIFF
--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -9,6 +9,8 @@
 
 #include "client_protocol/server.hpp" // NOLINT(build/include_order)
 
+#include <time.h>
+
 #include <google/protobuf/stubs/common.h> // NOLINT(build/include_order)
 
 #include <array> // NOLINT(build/include_order)

--- a/src/clustering/administration/metadata.hpp
+++ b/src/clustering/administration/metadata.hpp
@@ -2,6 +2,8 @@
 #ifndef CLUSTERING_ADMINISTRATION_METADATA_HPP_
 #define CLUSTERING_ADMINISTRATION_METADATA_HPP_
 
+#include <time.h>
+
 #include <map>
 #include <string>
 #include <vector>

--- a/src/rpc/semilattice/joins/versioned.hpp
+++ b/src/rpc/semilattice/joins/versioned.hpp
@@ -2,6 +2,8 @@
 #ifndef RPC_SEMILATTICE_JOINS_VERSIONED_HPP_
 #define RPC_SEMILATTICE_JOINS_VERSIONED_HPP_
 
+#include <time.h>
+
 #include <algorithm>
 #include <limits>
 

--- a/src/serializer/translator.cc
+++ b/src/serializer/translator.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/translator.hpp"
 
+#include <time.h>
+
 #include "concurrency/new_mutex.hpp"
 #include "concurrency/pmap.hpp"
 #include "debug.hpp"


### PR DESCRIPTION
kodehawa reports this build error on Arch (Linux?):

```
In file included from ./src/clustering/administration/tables/database_metadata.hpp:14:
./src/rpc/semilattice/joins/versioned.hpp:96:43: error: use of undeclared identifier 'time'
        timestamp = std::max(timestamp+1, time(nullptr));
```

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
