### PR TITLE
Replace some egrep uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ endif
 # Build the list of phony targets
 $(TOP)/mk/gen/phony-list.mk: $(CONFIG)
 	+@MAKEFLAGS= $(MAKE_CMD_LINE) --print-data-base var-MAKEFILE_LIST JUST_SCAN_MAKEFILES=1 \
-	  | egrep '^.PHONY: |^MAKEFILE_LIST = ' \
-	  | egrep -v '\$$' \
+	  | grep -E '^.PHONY: |^MAKEFILE_LIST = ' \
+	  | grep -E -v '\$$' \
 	  | sed 's/^.PHONY:/PHONY_LIST +=/' \
 	  | sed 's|^MAKEFILE_LIST =|$$(TOP)/mk/gen/phony-list.mk: $$(patsubst $(TOP)/%,$$(TOP)/%,$$(filter-out %.d,|;s|$$|))|' \
 	  > $@ 2>/dev/null

--- a/configure
+++ b/configure
@@ -579,7 +579,7 @@ check_cxx () {
     fi
     local description=$($CXX --version 2>/dev/null)$($CXX --help 2>/dev/null)
     local version_string=$(echo "$description" | extract_version_string)
-    local type=$(echo "$description" | egrep -io 'gcc|g\+\+|clang|icc' | head -n 1)
+    local type=$(echo "$description" | grep -E -io 'gcc|g\+\+|clang|icc' | head -n 1)
     case "$(uc $type)" in
         GCC|G++) min_version=$min_gcc_version
                  type=GCC ;;
@@ -606,7 +606,7 @@ check_cxx () {
 # foo --version | extract_version_string
 # find a version string in the output of foo --version
 extract_version_string () {
-    sed 's/([^)]*)//g' | egrep -o '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n 1
+    sed 's/([^)]*)//g' | grep -E -o '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n 1
 }
 
 # read_version "1.2.3" -> 10203

--- a/mk/check-env.mk
+++ b/mk/check-env.mk
@@ -8,7 +8,7 @@
 # Generate the list of variables defined in mk/defaults.mk
 # All variables that can be set by users should be listed and documented in mk/defaults.mk
 $(TOP)/mk/gen/allowed-variables.mk: $(TOP)/mk/defaults.mk
-	-@echo "allowed-variables :=" `cat $< | egrep -o '[ \t]*[A-Z_0-9]+[ \t]*[:?+]?=' | egrep -o '[A-Z_0-9]+'` > $@
+	-@echo "allowed-variables :=" `cat $< | grep -E -o '[ \t]*[A-Z_0-9]+[ \t]*[:?+]?=' | grep -E -o '[A-Z_0-9]+'` > $@
 
 allowed-variables :=
 -include $(TOP)/mk/gen/allowed-variables.mk

--- a/packaging/osx/uninstall.scpt
+++ b/packaging/osx/uninstall.scpt
@@ -42,7 +42,7 @@ else
 	
 	-- run the uninstall
 	if the button returned of result is "Uninstall" then
-		do shell script "set -e; /usr/sbin/pkgutil --files '" & packageIdentifier & "' | sort -r | sed 's/^/" & escapePath(installedPath) & "/' | egrep -vx '/usr|/usr/local|/usr/local/[^/]*' | while read FILE; do rm -fd \"$FILE\"; done && pkgutil --forget '" & packageIdentifier & "'" with administrator privileges
+		do shell script "set -e; /usr/sbin/pkgutil --files '" & packageIdentifier & "' | sort -r | sed 's/^/" & escapePath(installedPath) & "/' | grep -E -vx '/usr|/usr/local|/usr/local/[^/]*' | while read FILE; do rm -fd \"$FILE\"; done && pkgutil --forget '" & packageIdentifier & "'" with administrator privileges
 		display alert "RethinkDB " & installedVersion & " sucessfully removed from:" & return & displayPath giving up after 10
 	end if
 end if

--- a/scripts/gen-version.sh
+++ b/scripts/gen-version.sh
@@ -79,7 +79,7 @@ git_is_dirty () {
 }
 
 release_notes_version () {
-    grep Release "$root/NOTES.md" | egrep -o '[0-9]+(\.[0-9]+)+' | head -n 1
+    grep Release "$root/NOTES.md" | grep -E -o '[0-9]+(\.[0-9]+)+' | head -n 1
 }
 
 main "$@"


### PR DESCRIPTION
Allegedly it is getting obsolete -- ArchLinux is complaining.

Our package dependencies use it, but this does not touch that.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
