### PR TITLE
Add much include-what-you-use for futureproofing

### DIFF
--- a/src/arch/io/blocker_pool.cc
+++ b/src/arch/io/blocker_pool.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "arch/io/blocker_pool.hpp"
 
+#include <signal.h>
 #include <string.h>
 
 #include "arch/compiler.hpp"

--- a/src/arch/io/disk.cc
+++ b/src/arch/io/disk.cc
@@ -1,7 +1,10 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "arch/io/disk.hpp"
 
+#include <errno.h>
+#include <inttypes.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 #ifndef _WIN32
 #include <sys/ioctl.h>

--- a/src/arch/io/disk/filestat.cc
+++ b/src/arch/io/disk/filestat.cc
@@ -1,7 +1,10 @@
+#include "arch/io/disk/filestat.hpp"
+
+#include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "errors.hpp"
-#include "arch/io/disk/filestat.hpp"
 
 int64_t get_file_size(fd_t fd) {
     guarantee(fd != INVALID_FD);

--- a/src/arch/io/disk/pool.cc
+++ b/src/arch/io/disk/pool.cc
@@ -1,7 +1,9 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "arch/io/disk/pool.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <sys/types.h>
 #include <sys/uio.h>

--- a/src/arch/io/io_utils.cc
+++ b/src/arch/io/io_utils.cc
@@ -7,6 +7,7 @@
 #include <sys/syscall.h>
 #endif
 
+#include <errno.h>
 #include <sys/uio.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/arch/io/network.cc
+++ b/src/arch/io/network.cc
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -20,6 +21,7 @@
 #include <sys/socket.h>
 #endif
 
+#include "arch/io/openssl.hpp"
 #include "arch/runtime/runtime.hpp"
 #include "arch/runtime/thread_pool.hpp"
 #include "arch/timing.hpp"

--- a/src/arch/os_signal.cc
+++ b/src/arch/os_signal.cc
@@ -2,6 +2,8 @@
 
 #include "arch/os_signal.hpp"
 
+#include <signal.h>
+
 #include "arch/runtime/thread_pool.hpp"
 #include "arch/types.hpp"
 #include "do_on_thread.hpp"

--- a/src/arch/runtime/event_queue/poll.cc
+++ b/src/arch/runtime/event_queue/poll.cc
@@ -10,9 +10,11 @@
 #include <errno.h>
 #include <poll.h>
 #include <string.h>
+#include <strings.h>
 
-#include <new>
 #include <algorithm>
+#include <new>
+#include <memory>
 #include <string>
 
 

--- a/src/arch/runtime/runtime_utils.cc
+++ b/src/arch/runtime/runtime_utils.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "arch/runtime/runtime_utils.hpp"
 
+#include <string.h>
 #include <unistd.h>
 
 #include "arch/runtime/context_switching.hpp"

--- a/src/arch/runtime/system_event/eventfd_event.cc
+++ b/src/arch/runtime/system_event/eventfd_event.cc
@@ -3,9 +3,11 @@
 
 #include "arch/runtime/system_event/eventfd_event.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/eventfd.h>
 
 #include "errors.hpp"
 #include "arch/runtime/system_event/eventfd.hpp"

--- a/src/arch/runtime/system_event/pipe_event.cc
+++ b/src/arch/runtime/system_event/pipe_event.cc
@@ -3,6 +3,7 @@
 
 #include "arch/runtime/system_event/pipe_event.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/arch/runtime/thread_pool.cc
+++ b/src/arch/runtime/thread_pool.cc
@@ -2,6 +2,7 @@
 #include "arch/runtime/thread_pool.hpp"
 
 #include <errno.h>
+#include <sched.h>
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/arch/runtime/thread_pool.cc
+++ b/src/arch/runtime/thread_pool.cc
@@ -2,12 +2,12 @@
 #include "arch/runtime/thread_pool.hpp"
 
 #include <errno.h>
-#include <sched.h>
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
 
 #ifndef _WIN32
+#include <sched.h>
 #include <sys/time.h>
 #endif
 

--- a/src/arch/types.cc
+++ b/src/arch/types.cc
@@ -1,5 +1,7 @@
 #include "arch/types.hpp"
 
+#include <errno.h>
+
 #include "utils.hpp"
 
 tcp_socket_exc_t::tcp_socket_exc_t(int errsv, int port) {

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -12,6 +12,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/btree/internal_node.cc
+++ b/src/btree/internal_node.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "btree/internal_node.hpp"
 
+#include <string.h>
+
 #include <algorithm>
 
 #include "btree/node.hpp"

--- a/src/btree/leaf_node.cc
+++ b/src/btree/leaf_node.cc
@@ -2,6 +2,8 @@
 #include "btree/leaf_node.hpp"
 
 #include <inttypes.h>
+#include <stddef.h>
+#include <string.h>
 
 #include <algorithm>
 #include <set>

--- a/src/btree/reql_specific.cc
+++ b/src/btree/reql_specific.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "btree/reql_specific.hpp"
 
+#include <string.h>
+
 #include "btree/secondary_operations.hpp"
 #include "buffer_cache/blob.hpp"
 #include "containers/binary_blob.hpp"

--- a/src/btree/secondary_operations.cc
+++ b/src/btree/secondary_operations.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "btree/secondary_operations.hpp"
 
+#include <string.h>
+
 #include "btree/operations.hpp"
 #include "buffer_cache/alt.hpp"
 #include "buffer_cache/blob.hpp"

--- a/src/buffer_cache/alt.cc
+++ b/src/buffer_cache/alt.cc
@@ -1,5 +1,7 @@
 #include "buffer_cache/alt.hpp"
 
+#include <inttypes.h>
+
 #include <stack>
 
 #include "arch/types.hpp"

--- a/src/buffer_cache/blob.cc
+++ b/src/buffer_cache/blob.cc
@@ -2,6 +2,7 @@
 #include "buffer_cache/blob.hpp"
 
 #include <stdint.h>
+#include <string.h>
 
 #include <algorithm>
 #include <limits>

--- a/src/buffer_cache/page_cache.cc
+++ b/src/buffer_cache/page_cache.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "buffer_cache/page_cache.hpp"
 
+#include <inttypes.h>
+
 #include <algorithm>
 #include <functional>
 #include <iterator>

--- a/src/client_protocol/protocols.cc
+++ b/src/client_protocol/protocols.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "client_protocol/protocols.hpp"
 
+#include <inttypes.h>
+
 #include <limits>
 
 #include "utils.hpp"

--- a/src/client_protocol/server.cc
+++ b/src/client_protocol/server.cc
@@ -9,7 +9,7 @@
 
 #include "client_protocol/server.hpp" // NOLINT(build/include_order)
 
-#include <time.h>
+#include <time.h> // NOLINT(build/include_order)
 
 #include <google/protobuf/stubs/common.h> // NOLINT(build/include_order)
 

--- a/src/clustering/administration/cluster_config.cc
+++ b/src/clustering/administration/cluster_config.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/cluster_config.hpp"
 
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
 #include "clustering/administration/admin_op_exc.hpp"
 #include "clustering/administration/datum_adapter.hpp"
 #include "clustering/administration/metadata.hpp"

--- a/src/clustering/administration/jobs/manager.cc
+++ b/src/clustering/administration/jobs/manager.cc
@@ -1,8 +1,14 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/jobs/manager.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "concurrency/watchable.hpp"
 #include "pprint/js_pprint.hpp"

--- a/src/clustering/administration/logs/log_transfer.cc
+++ b/src/clustering/administration/logs/log_transfer.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "clustering/administration/logs/log_transfer.hpp"
 
+#include <time.h>
+
 #include <functional>
 
 #include "concurrency/promise.hpp"

--- a/src/clustering/administration/logs/log_writer.cc
+++ b/src/clustering/administration/logs/log_writer.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "clustering/administration/logs/log_writer.hpp"
 
+#include <errno.h>
 #include <math.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -11,6 +12,10 @@
 #ifdef _WIN32
 #include <io.h>
 #endif
+
+#include <functional>
+#include <limits>
+#include <utility>
 
 #include "arch/runtime/thread_pool.hpp"
 #include "arch/io/disk/filestat.hpp"

--- a/src/clustering/administration/logs/logs_backend.cc
+++ b/src/clustering/administration/logs/logs_backend.cc
@@ -1,6 +1,17 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "clustering/administration/logs/logs_backend.hpp"
 
+#include <time.h>
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <type_traits>
+#include <utility>
+
+
 #include "clustering/administration/datum_adapter.hpp"
 #include "clustering/administration/logs/log_writer.hpp"
 #include "clustering/administration/logs/log_transfer.hpp"

--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2016 RethinkDB, all rights reserved.
 #include "clustering/administration/main/command_line.hpp"
 
+#include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,8 +35,19 @@
 #include <sys/sysctl.h>
 #endif
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <exception>
 #include <functional>
 #include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <re2/re2.h>
 

--- a/src/clustering/administration/main/directory_lock.cc
+++ b/src/clustering/administration/main/directory_lock.cc
@@ -8,10 +8,12 @@
 #include <sys/file.h>
 #endif
 
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include <stdexcept>
 

--- a/src/clustering/administration/main/memory_checker.cc
+++ b/src/clustering/administration/main/memory_checker.cc
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #ifndef _WIN32
+#include <sys/time.h>
 #include <sys/resource.h>
 #endif
 

--- a/src/clustering/administration/main/options.cc
+++ b/src/clustering/administration/main/options.cc
@@ -1,11 +1,15 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "clustering/administration/main/options.hpp"
 
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <algorithm>
 #include <string>
 #include <set>
+#include <utility>
 
 #include "errors.hpp"
 #include "utils.hpp"

--- a/src/clustering/administration/main/serve.cc
+++ b/src/clustering/administration/main/serve.cc
@@ -2,6 +2,7 @@
 #include "clustering/administration/main/serve.hpp"
 
 #include <stdio.h>
+#include <unistd.h>
 
 #include "arch/arch.hpp"
 #include "arch/io/network.hpp"

--- a/src/clustering/administration/persist/file.cc
+++ b/src/clustering/administration/persist/file.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/persist/file.hpp"
 
+#include <stdlib.h>
+
+#include <utility>
+
 #include "btree/depth_first_traversal.hpp"
 #include "btree/operations.hpp"
 #include "btree/types.hpp"

--- a/src/clustering/administration/persist/migrate/migrate_v1_14.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v1_14.cc
@@ -1,6 +1,17 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/persist/migrate/migrate_v1_14.hpp"
 
+#include <time.h>
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "logger.hpp"
 
 template<class T>

--- a/src/clustering/administration/persist/migrate/migrate_v1_16.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v1_16.cc
@@ -1,6 +1,18 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/persist/migrate/migrate_v1_16.hpp"
 
+#include <time.h>
+
+#include <algorithm>
+#include <deque>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 #include "buffer_cache/alt.hpp"
 #include "buffer_cache/blob.hpp"
 #include "buffer_cache/cache_balancer.hpp"

--- a/src/clustering/administration/persist/migrate/migrate_v2_1.cc
+++ b/src/clustering/administration/persist/migrate/migrate_v2_1.cc
@@ -1,6 +1,14 @@
 // Copyright 2010-2016 RethinkDB, all rights reserved.
 #include "clustering/administration/persist/migrate/migrate_v2_1.hpp"
 
+#include <time.h>
+
+#include <limits>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <utility>
+
 #include "clustering/administration/metadata.hpp"
 #include "clustering/administration/persist/file_keys.hpp"
 #include "clustering/administration/persist/migrate/metadata_v2_1.hpp"

--- a/src/clustering/administration/persist/table_interface.cc
+++ b/src/clustering/administration/persist/table_interface.cc
@@ -1,8 +1,14 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/administration/persist/table_interface.hpp"
 
+#include <errno.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <array>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include "clustering/administration/persist/branch_history_manager.hpp"
 #include "clustering/administration/persist/file_keys.hpp"

--- a/src/clustering/administration/tables/split_points.cc
+++ b/src/clustering/administration/tables/split_points.cc
@@ -1,5 +1,16 @@
 #include "clustering/administration/tables/split_points.hpp"
 
+#include <math.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 #include "clustering/administration/real_reql_cluster_interface.hpp"
 #include "math.hpp"   /* for `clamp()` */
 #include "rdb_protocol/real_table.hpp"

--- a/src/clustering/generic/multi_client_client.cc
+++ b/src/clustering/generic/multi_client_client.cc
@@ -1,6 +1,7 @@
 #include "clustering/generic/multi_client_client.hpp"
 
 #include <functional>
+#include <utility>
 
 #include "clustering/generic/registrant.hpp"
 #include "containers/archive/boost_types.hpp"

--- a/src/clustering/immediate_consistency/backfiller.cc
+++ b/src/clustering/immediate_consistency/backfiller.cc
@@ -1,6 +1,11 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/backfiller.hpp"
 
+#include <algorithm>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
 #include "assignment_sentry.hpp"
 #include "clustering/immediate_consistency/history.hpp"
 #include "rdb_protocol/distribution_progress.hpp"

--- a/src/clustering/immediate_consistency/remote_replicator_client.cc
+++ b/src/clustering/immediate_consistency/remote_replicator_client.cc
@@ -1,6 +1,12 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/remote_replicator_client.hpp"
 
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "clustering/immediate_consistency/backfill_throttler.hpp"
 #include "clustering/immediate_consistency/backfillee.hpp"
 #include "clustering/table_manager/backfill_progress_tracker.hpp"

--- a/src/clustering/immediate_consistency/remote_replicator_server.cc
+++ b/src/clustering/immediate_consistency/remote_replicator_server.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/remote_replicator_server.hpp"
 
+#include <functional>
+
 remote_replicator_server_t::remote_replicator_server_t(
         mailbox_manager_t *_mailbox_manager,
         primary_dispatcher_t *_primary) :

--- a/src/clustering/immediate_consistency/replica.cc
+++ b/src/clustering/immediate_consistency/replica.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/replica.hpp"
 
+#include <functional>
+#include <utility>
+
 #include "rdb_protocol/protocol.hpp"
 #include "store_view.hpp"
 

--- a/src/clustering/immediate_consistency/standard_backfill_throttler.cc
+++ b/src/clustering/immediate_consistency/standard_backfill_throttler.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/immediate_consistency/standard_backfill_throttler.hpp"
 
+#include <iterator>
+
 #include "concurrency/cross_thread_signal.hpp"
 #include "concurrency/wait_any.hpp"
 

--- a/src/clustering/query_routing/direct_query_server.cc
+++ b/src/clustering/query_routing/direct_query_server.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/query_routing/direct_query_server.hpp"
 
+#include <functional>
+
 #include "protocol_api.hpp"
 #include "store_view.hpp"
 

--- a/src/clustering/query_routing/table_query_client.cc
+++ b/src/clustering/query_routing/table_query_client.cc
@@ -1,7 +1,11 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/query_routing/table_query_client.hpp"
 
+#include <algorithm>
 #include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
 
 #include "clustering/query_routing/primary_query_client.hpp"
 #include "clustering/table_contract/cpu_sharding.hpp"

--- a/src/clustering/table_contract/branch_history_gc.cc
+++ b/src/clustering/table_contract/branch_history_gc.cc
@@ -1,6 +1,11 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/branch_history_gc.hpp"
 
+#include <map>
+#include <string>
+#include <type_traits>
+#include <utility>
+
 #include "logger.hpp"
 
 void copy_branch_history_for_branch(

--- a/src/clustering/table_contract/contract_metadata.cc
+++ b/src/clustering/table_contract/contract_metadata.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/contract_metadata.hpp"
 
+#include <type_traits>
+#include <vector>
+
 #include "clustering/table_contract/cpu_sharding.hpp"
 #include "stl_utils.hpp"
 

--- a/src/clustering/table_contract/coordinator/calculate_contracts.cc
+++ b/src/clustering/table_contract/coordinator/calculate_contracts.cc
@@ -1,6 +1,12 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/coordinator/calculate_contracts.hpp"
 
+#include <algorithm>
+#include <list>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
 #include "clustering/table_contract/branch_history_gc.hpp"
 #include "clustering/table_contract/cpu_sharding.hpp"
 #include "logger.hpp"

--- a/src/clustering/table_contract/coordinator/calculate_misc.cc
+++ b/src/clustering/table_contract/coordinator/calculate_misc.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/coordinator/calculate_misc.hpp"
 
+#include <vector>
+
 /* `calculate_server_names()` figures out what changes need to be made to the server
 names stored in the Raft state. When a contract is added that refers to a new server, it
 will copy the server name from the table config; when the last contract that refers to a

--- a/src/clustering/table_contract/coordinator/check_ready.cc
+++ b/src/clustering/table_contract/coordinator/check_ready.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/coordinator/check_ready.hpp"
 
+#include <map>
+#include <set>
+#include <vector>
+
 bool check_all_replicas_ready(
         const table_raft_state_t &table_state,
         watchable_map_t<std::pair<server_id_t, contract_id_t>, contract_ack_t> *acks) {

--- a/src/clustering/table_contract/coordinator/coordinator.cc
+++ b/src/clustering/table_contract/coordinator/coordinator.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/coordinator/coordinator.hpp"
 
+#include <set>
+
 #include "clustering/generic/raft_core.tcc"
 #include "clustering/table_contract/branch_history_gc.hpp"
 #include "clustering/table_contract/coordinator/calculate_contracts.hpp"

--- a/src/clustering/table_contract/emergency_repair.cc
+++ b/src/clustering/table_contract/emergency_repair.cc
@@ -1,6 +1,14 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/emergency_repair.hpp"
 
+#include <algorithm>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+
 /* Returns `true` if `servers` is a subset of `dead`. */
 bool all_dead(
         const std::set<server_id_t> &servers, const std::set<server_id_t> &dead) {

--- a/src/clustering/table_contract/executor/exec_erase.cc
+++ b/src/clustering/table_contract/executor/exec_erase.cc
@@ -1,6 +1,11 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/executor/exec_erase.hpp"
 
+#include <functional>
+#include <map>
+#include <set>
+#include <utility>
+
 #include "concurrency/cross_thread_signal.hpp"
 
 erase_execution_t::erase_execution_t(

--- a/src/clustering/table_contract/executor/exec_secondary.cc
+++ b/src/clustering/table_contract/executor/exec_secondary.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/executor/exec_secondary.hpp"
 
+#include <functional>
+#include <map>
+#include <set>
 #include <utility>
 
 #include "clustering/immediate_consistency/remote_replicator_client.hpp"

--- a/src/clustering/table_contract/executor/executor.cc
+++ b/src/clustering/table_contract/executor/executor.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_contract/executor/executor.hpp"
 
+#include <functional>
+
 #include "clustering/table_contract/branch_history_gc.hpp"
 #include "clustering/table_contract/executor/exec_erase.hpp"
 #include "clustering/table_contract/executor/exec_primary.hpp"

--- a/src/clustering/table_manager/backfill_progress_tracker.cc
+++ b/src/clustering/table_manager/backfill_progress_tracker.cc
@@ -2,6 +2,9 @@
 
 #include "clustering/table_manager/backfill_progress_tracker.hpp"
 
+#include <type_traits>
+#include <utility>
+
 backfill_progress_tracker_t::progress_tracker_t *
 backfill_progress_tracker_t::insert_progress_tracker(const region_t &region) {
     return &progress_trackers.get()->insert(

--- a/src/clustering/table_manager/multi_table_manager.cc
+++ b/src/clustering/table_manager/multi_table_manager.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_manager/multi_table_manager.hpp"
 
+#include <functional>
+#include <string>
+
 #include "clustering/generic/raft_core.tcc"
 #include "clustering/query_routing/metadata.hpp"
 #include "clustering/table_manager/table_manager.hpp"

--- a/src/clustering/table_manager/server_name_cache_updater.cc
+++ b/src/clustering/table_manager/server_name_cache_updater.cc
@@ -2,6 +2,10 @@
 
 #include "clustering/table_manager/server_name_cache_updater.hpp"
 
+#include <functional>
+#include <map>
+#include <utility>
+
 #include "clustering/generic/raft_core.tcc"
 #include "clustering/table_contract/contract_metadata.hpp"
 

--- a/src/clustering/table_manager/sindex_manager.cc
+++ b/src/clustering/table_manager/sindex_manager.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved
 #include "clustering/table_manager/sindex_manager.hpp"
 
+#include <functional>
+#include <set>
+#include <type_traits>
+
 #include "clustering/administration/issues/outdated_index.hpp"
 
 #include "concurrency/cross_thread_signal.hpp"

--- a/src/clustering/table_manager/table_manager.cc
+++ b/src/clustering/table_manager/table_manager.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_manager/table_manager.hpp"
 
+#include <functional>
+#include <set>
+#include <string>
+
 #include "clustering/generic/minidir.tcc"
 #include "clustering/generic/raft_core.tcc"
 #include "clustering/generic/raft_network.tcc"

--- a/src/clustering/table_manager/table_meta_client.cc
+++ b/src/clustering/table_manager/table_meta_client.cc
@@ -1,6 +1,11 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_manager/table_meta_client.hpp"
 
+#include <algorithm>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
 #include "clustering/administration/issues/outdated_index.hpp"
 #include "clustering/administration/servers/config_client.hpp"
 #include "clustering/generic/raft_core.tcc"

--- a/src/clustering/table_manager/table_metadata.cc
+++ b/src/clustering/table_manager/table_metadata.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "clustering/table_manager/table_metadata.hpp"
 
+#include <algorithm>
+#include <type_traits>
+
 #include "clustering/administration/datum_adapter.hpp"
 
 RDB_IMPL_SERIALIZABLE_2_SINCE_v2_1(

--- a/src/concurrency/fifo_checker.cc
+++ b/src/concurrency/fifo_checker.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "concurrency/fifo_checker.hpp"
 
+#include <inttypes.h>
+
 #include <vector>
 
 #include "arch/runtime/runtime.hpp"

--- a/src/containers/archive/buffer_group_stream.cc
+++ b/src/containers/archive/buffer_group_stream.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "containers/buffer_group.hpp"
 
+#include <string.h>
+
 #include <algorithm>
 
 #include "containers/archive/buffer_group_stream.hpp"

--- a/src/containers/archive/file_stream.cc
+++ b/src/containers/archive/file_stream.cc
@@ -2,6 +2,7 @@
 
 #include "containers/archive/file_stream.hpp"
 
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/containers/archive/socket_stream.cc
+++ b/src/containers/archive/socket_stream.cc
@@ -84,16 +84,19 @@ void socket_stream_t::wait_for_pipe_client(signal_t *interruptor) {
     }
 }
 
-#else
+#else  // WIN32
 
 #include "containers/archive/socket_stream.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <cstring>
+#include <string>
+#include <utility>
 
 #include "arch/fd_send_recv.hpp"
 #include "arch/runtime/event_queue.hpp" // format_poll_event
@@ -103,6 +106,7 @@ void socket_stream_t::wait_for_pipe_client(signal_t *interruptor) {
 #include "logger.hpp"  // logERR
 
 // -------------------- blocking_fd_watcher_t --------------------
+
 blocking_fd_watcher_t::blocking_fd_watcher_t()
     : read_open_(true), write_open_(true) {}
 

--- a/src/containers/archive/string_stream.cc
+++ b/src/containers/archive/string_stream.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "containers/archive/string_stream.hpp"
 
+#include <string.h>
+
+#include <utility>
+
 string_stream_t::string_stream_t() { }
 
 string_stream_t::~string_stream_t() { }

--- a/src/containers/archive/vector_stream.cc
+++ b/src/containers/archive/vector_stream.cc
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+#include <utility>
+
 vector_stream_t::vector_stream_t() { }
 
 vector_stream_t::~vector_stream_t() { }

--- a/src/containers/disk_backed_queue.cc
+++ b/src/containers/disk_backed_queue.cc
@@ -1,6 +1,11 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "containers/disk_backed_queue.hpp"
 
+#include <string.h>
+
+#include <string>
+#include <vector>
+
 #include "arch/io/disk.hpp"
 #include "buffer_cache/alt.hpp"
 #include "buffer_cache/blob.hpp"

--- a/src/containers/printf_buffer.cc
+++ b/src/containers/printf_buffer.cc
@@ -1,5 +1,9 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "containers/printf_buffer.hpp"
+
+#include <stdio.h>
+#include <string.h>
+
 #include "math.hpp"
 
 printf_buffer_t::printf_buffer_t() : length_(0), ptr_(data_) {

--- a/src/containers/uuid.cc
+++ b/src/containers/uuid.cc
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <sys/stat.h>
+#include <ctype.h>
 #include <string.h>
 #include <fcntl.h>
 

--- a/src/crypto/base64.cc
+++ b/src/crypto/base64.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2016 RethinkDB, all rights reserved.
 #include "crypto/base64.hpp"
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "crypto/error.hpp"
 
 namespace crypto {

--- a/src/crypto/base64.hpp
+++ b/src/crypto/base64.hpp
@@ -2,6 +2,8 @@
 #ifndef CRYPTO_BASE64_HPP
 #define CRYPTO_BASE64_HPP
 
+#include <stddef.h>
+
 #include <array>
 #include <string>
 

--- a/src/crypto/hash.hpp
+++ b/src/crypto/hash.hpp
@@ -3,6 +3,7 @@
 #define CRYPTO_HASH_HPP
 
 #include <openssl/sha.h>
+#include <stddef.h>
 
 #include <array>
 #include <string>

--- a/src/crypto/pbkcs5_pbkdf2_hmac.hpp
+++ b/src/crypto/pbkcs5_pbkdf2_hmac.hpp
@@ -3,6 +3,8 @@
 #define CRYPTO_PKCS5_PBKDF2_HMAC_HPP
 
 #include <openssl/sha.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include <array>
 #include <string>

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -2,6 +2,9 @@
 #include "debug.hpp"
 
 #include <inttypes.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "arch/runtime/runtime.hpp"
 #include "rdb_protocol/ql2proto.hpp"

--- a/src/extproc/extproc_pool.cc
+++ b/src/extproc/extproc_pool.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
-#include "containers/object_buffer.hpp"
 #include "extproc/extproc_pool.hpp"
+
+#include <functional>
+
+#include "containers/object_buffer.hpp"
 #include "extproc/extproc_spawner.hpp"
 
 extproc_pool_t::extproc_pool_t(size_t worker_count) :

--- a/src/extproc/extproc_spawner.cc
+++ b/src/extproc/extproc_spawner.cc
@@ -7,8 +7,10 @@
 #include <atomic>
 #endif  // _WIN32
 
-#include <sys/types.h>
+#include <errno.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "arch/process.hpp"

--- a/src/extproc/extproc_worker.cc
+++ b/src/extproc/extproc_worker.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include <unistd.h>
 
+#include <sys/types.h>
+#include <signal.h>
+#include <stdlib.h>
+
 #include "logger.hpp"
 
 #include "extproc/extproc_worker.hpp"

--- a/src/extproc/http_job.cc
+++ b/src/extproc/http_job.cc
@@ -2,6 +2,8 @@
 #include "extproc/http_job.hpp"
 
 #include <ctype.h>
+#include <string.h>
+
 #include <re2/re2.h>
 
 #ifdef _WIN32
@@ -9,7 +11,13 @@
 #endif
 #include <curl/curl.h>
 
+#include <algorithm>
+#include <exception>
+#include <map>
 #include <limits>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "containers/archive/boost_types.hpp"
 #include "containers/archive/stl_types.hpp"

--- a/src/extproc/http_runner.cc
+++ b/src/extproc/http_runner.cc
@@ -1,6 +1,10 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "extproc/http_runner.hpp"
 
+#include <inttypes.h>
+
+#include <utility>
+
 #include "arch/timing.hpp"
 #include "containers/archive/stl_types.hpp"
 #include "extproc/http_job.hpp"

--- a/src/extproc/js_job.cc
+++ b/src/extproc/js_job.cc
@@ -16,8 +16,15 @@
 #include <stdint.h>
 #include <limits.h>
 
+#include <algorithm>
+#include <exception>
 #include <limits>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
+
+#include "errors.hpp"
+#include <boost/variant.hpp>
 
 #include "containers/archive/boost_types.hpp"
 #include "containers/archive/stl_types.hpp"

--- a/src/extproc/js_runner.cc
+++ b/src/extproc/js_runner.cc
@@ -1,9 +1,14 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "extproc/js_runner.hpp"
 
-#include <inttypes.h>   // For PRIu64
+#include <inttypes.h>
 
 #include <map>
+#include <set>
+#include <utility>
+
+#include "errors.hpp"
+#include <boost/variant/get.hpp>
 
 #include "extproc/js_job.hpp"
 #include "time.hpp"

--- a/src/http/http.cc
+++ b/src/http/http.cc
@@ -1,7 +1,11 @@
 // Copyright 2010-2012 RethinkDB, all rights reserved.
 #include "http/http.hpp"
 
+#include <errno.h>
+#include <inttypes.h>
 #include <math.h>
+#include <stdlib.h>
+#include <string.h>
 #include <zlib.h>
 
 #include <exception>

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,6 +4,8 @@
 #include <sys/resource.h>
 #endif
 
+#include <stdio.h>
+
 #include <set>
 
 #include "clustering/administration/main/command_line.hpp"

--- a/src/math.cc
+++ b/src/math.cc
@@ -2,6 +2,9 @@
 
 #include <math.h>
 
+// For std.
+#include <iosfwd>
+
 #include "errors.hpp"
 
 int64_t int64_round_up_to_power_of_two(int64_t x) {

--- a/src/paths.cc
+++ b/src/paths.cc
@@ -1,7 +1,10 @@
 #include "paths.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #ifdef _WIN32

--- a/src/pprint/js_pprint.cc
+++ b/src/pprint/js_pprint.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "pprint/js_pprint.hpp"
 
+#include <ctype.h>
 #include <math.h>
 
 #include <vector>

--- a/src/pprint/sexp_pprint.cc
+++ b/src/pprint/sexp_pprint.cc
@@ -1,6 +1,7 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "pprint/sexp_pprint.hpp"
 
+#include <ctype.h>
 #include <math.h>
 
 #include <vector>

--- a/src/rdb_protocol/btree.cc
+++ b/src/rdb_protocol/btree.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/btree.hpp"
 
+#include <stdlib.h>
+#include <string.h>
+
 #include <algorithm>
 #include <functional>
 #include <iterator>

--- a/src/rdb_protocol/changefeed.cc
+++ b/src/rdb_protocol/changefeed.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/changefeed.hpp"
 
+#include <inttypes.h>
+
 #include <queue>
 
 #include "btree/reql_specific.hpp"

--- a/src/rdb_protocol/datum.cc
+++ b/src/rdb_protocol/datum.cc
@@ -2,6 +2,7 @@
 #include "rdb_protocol/datum.hpp"
 
 #include <float.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/rdb_protocol/datum_stream.cc
+++ b/src/rdb_protocol/datum_stream.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/datum_stream.hpp"
 
+#include <inttypes.h>
+
 #include <map>
 
 #include "math.hpp"

--- a/src/rdb_protocol/erase_range.cc
+++ b/src/rdb_protocol/erase_range.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "rdb_protocol/erase_range.hpp"
 
+#include <stdlib.h>
+
 #include "buffer_cache/alt.hpp"
 #include "btree/depth_first_traversal.hpp"
 #include "btree/leaf_node.hpp"

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/func.hpp"
 
+#include <inttypes.h>
+
 #include "pprint/js_pprint.hpp"
 #include "pprint/pprint.hpp"
 #include "rdb_protocol/env.hpp"

--- a/src/rdb_protocol/geo/s2/base/strtoint.cc
+++ b/src/rdb_protocol/geo/s2/base/strtoint.cc
@@ -5,6 +5,7 @@
 //
 
 #include <errno.h>
+#include <limits.h>
 
 #include "rdb_protocol/geo/s2/base/port.h"
 #include "rdb_protocol/geo/s2/base/basictypes.h"

--- a/src/rdb_protocol/query_cache.cc
+++ b/src/rdb_protocol/query_cache.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/query_cache.hpp"
 
+#include <inttypes.h>
+
 #include "rdb_protocol/env.hpp"
 #include "rdb_protocol/datum_stream.hpp"
 #include "rdb_protocol/pseudo_time.hpp"

--- a/src/rdb_protocol/terms/arith.cc
+++ b/src/rdb_protocol/terms/arith.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/terms/terms.hpp"
 
+#include <float.h>
+#include <inttypes.h>
+
 #include <cmath>
 #include <limits>
 

--- a/src/rdb_protocol/terms/case.cc
+++ b/src/rdb_protocol/terms/case.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/terms/terms.hpp"
 
+#include <ctype.h>
+
 #include "rdb_protocol/error.hpp"
 #include "rdb_protocol/op.hpp"
 

--- a/src/rdb_protocol/terms/db_table.cc
+++ b/src/rdb_protocol/terms/db_table.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/terms/terms.hpp"
 
+#include <inttypes.h>
+
 #include <map>
 #include <string>
 

--- a/src/rdb_protocol/terms/json.cc
+++ b/src/rdb_protocol/terms/json.cc
@@ -1,4 +1,7 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
+
+#include <string.h>
+
 #include "cjson/json.hpp"
 #include "rdb_protocol/datum_json.hpp"
 #include "rdb_protocol/op.hpp"

--- a/src/rdb_protocol/terms/sindex.cc
+++ b/src/rdb_protocol/terms/sindex.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/terms/terms.hpp"
 
+#include <string.h>
+
 #include <string>
 
 #include "clustering/administration/admin_op_exc.hpp"

--- a/src/rdb_protocol/terms/type_manip.cc
+++ b/src/rdb_protocol/terms/type_manip.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "rdb_protocol/terms/terms.hpp"
 
+#include <ctype.h>
+#include <stdio.h>
+
 #include <algorithm>
 #include <map>
 #include <string>

--- a/src/rdb_protocol/var_types.cc
+++ b/src/rdb_protocol/var_types.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "rdb_protocol/var_types.hpp"
 
+#include <inttypes.h>
+
 #include "containers/archive/stl_types.hpp"
 #include "rdb_protocol/datum.hpp"
 #include "rdb_protocol/error.hpp"

--- a/src/region/region.cc
+++ b/src/region/region.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "region/region.hpp"
 
+#include <inttypes.h>
+
 #include <algorithm>
 
 void debug_print(printf_buffer_t *buf, const hash_range_t &hr) {

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -5,6 +5,8 @@
 #include <netinet/in.h>
 #endif
 
+#include <inttypes.h>
+
 #include <algorithm>
 #include <functional>
 

--- a/src/rpc/mailbox/raw_mailbox.cc
+++ b/src/rpc/mailbox/raw_mailbox.cc
@@ -1,5 +1,7 @@
 #include "rpc/mailbox/raw_mailbox.hpp"
 
+#include <inttypes.h>
+
 #include "rpc/mailbox/mailbox.hpp"
 #include "utils.hpp"
 

--- a/src/serializer/buf_ptr.cc
+++ b/src/serializer/buf_ptr.cc
@@ -1,5 +1,7 @@
 #include "serializer/buf_ptr.hpp"
 
+#include <string.h>
+
 #include <algorithm>
 
 #include "math.hpp"

--- a/src/serializer/log/data_block_manager.cc
+++ b/src/serializer/log/data_block_manager.cc
@@ -2,6 +2,8 @@
 #include "serializer/log/data_block_manager.hpp"
 
 #include <inttypes.h>
+#include <limits.h>
+#include <string.h>
 #include <sys/uio.h>
 
 #include <functional>

--- a/src/serializer/log/lba/disk_extent.cc
+++ b/src/serializer/log/lba/disk_extent.cc
@@ -1,6 +1,9 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/log/lba/disk_extent.hpp"
 
+#include <stddef.h>
+#include <string.h>
+
 #include <limits>
 
 #include "arch/arch.hpp"

--- a/src/serializer/log/lba/disk_structure.cc
+++ b/src/serializer/log/lba/disk_structure.cc
@@ -1,7 +1,12 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/log/lba/disk_structure.hpp"
 
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <algorithm>
+#include <vector>
 
 #include "containers/scoped.hpp"
 #include "math.hpp"

--- a/src/serializer/log/lba/extent.cc
+++ b/src/serializer/log/lba/extent.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/log/lba/extent.hpp"
 
+#include <string.h>
+
 #include <vector>
 
 #include "arch/arch.hpp"

--- a/src/serializer/log/lba/lba_list.cc
+++ b/src/serializer/log/lba/lba_list.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/log/lba/lba_list.hpp"
 
+#include <string.h>
+
 #include "utils.hpp"
 #include "serializer/log/lba/disk_format.hpp"
 #include "arch/arch.hpp"

--- a/src/serializer/log/log_serializer.cc
+++ b/src/serializer/log/log_serializer.cc
@@ -1,7 +1,11 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/log/log_serializer.hpp"
 
+#include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/serializer/log/metablock_manager.cc
+++ b/src/serializer/log/metablock_manager.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "serializer/log/metablock_manager.hpp"
 
+#include <inttypes.h>
+#include <stddef.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/serializer/log/static_header.cc
+++ b/src/serializer/log/static_header.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2013 RethinkDB, all rights reserved.
 #include "serializer/log/static_header.hpp"
 
+#include <string.h>
+
 #include <functional>
 #include <vector>
 

--- a/src/serializer/serializer.cc
+++ b/src/serializer/serializer.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "serializer/serializer.hpp"
 
+#include <inttypes.h>
+
 #include "arch/arch.hpp"
 #include "math.hpp"
 

--- a/src/unittest/rpc_connectivity.cc
+++ b/src/unittest/rpc_connectivity.cc
@@ -1,4 +1,8 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
+#include "unittest/gtest.hpp"
+
+#include <limits.h>
+
 #include <functional>
 
 #ifdef _WIN32
@@ -14,7 +18,6 @@
 #include "unittest/clustering_utils.hpp"
 #include "unittest/unittest_utils.hpp"
 #include "rpc/connectivity/cluster.hpp"
-#include "unittest/gtest.hpp"
 
 namespace unittest {
 

--- a/src/unittest/rpc_connectivity.cc
+++ b/src/unittest/rpc_connectivity.cc
@@ -1,9 +1,9 @@
 // Copyright 2010-2014 RethinkDB, all rights reserved.
 #include "unittest/gtest.hpp"
 
-#include <limits.h>
+#include <limits.h>  // NOLINT(build/include_order)
 
-#include <functional>
+#include <functional>  // NOLINT(build/include_order)
 
 #ifdef _WIN32
 #include "windows.hpp"

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,6 +1,8 @@
 // Copyright 2010-2015 RethinkDB, all rights reserved.
 #include "utils.hpp"
 
+#include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <locale.h>
 #include <signal.h>


### PR DESCRIPTION
In reaction to #7091, this change adds a bunch of includes of system headers or library headers.  This is NOT a blindly obedient change that has everything from include-what-you-use.  It's probably too eager about including C++ headers.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
