### PR TITLE
Update openssl version (if fetched and statically linked) to 3.0.7

### DIFF
--- a/mk/support/pkg/openssl.sh
+++ b/mk/support/pkg/openssl.sh
@@ -1,8 +1,8 @@
-version=3.0.1
+version=3.0.7
 
 src_url="https://www.openssl.org/source/openssl-$version.tar.gz"
 src_url_backup="ftp://ftp.openssl.org/source/openssl-$version.tar.gz"
-src_url_sha1="33b00311e7a910f99ff041deebc6dd7bb9f459de"
+src_url_sha1="f20736d6aae36bcbfa9aba0d358c71601833bf27"
 
 pkg_configure () {
     case $($CXX -dumpmachine) in


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

Updates the version.  See https://www.openssl.org/blog/blog/2022/11/01/email-address-overflows/ .