### PR TITLE
Some stdint.h include-what-you-use for alpine/musl

### DIFF
--- a/src/arch/runtime/context_switching.hpp
+++ b/src/arch/runtime/context_switching.hpp
@@ -35,9 +35,10 @@ void context_switch(fiber_context_ref_t *current_context_out, fiber_context_ref_
 typedef fiber_stack_t coro_stack_t;
 typedef fiber_context_ref_t coro_context_ref_t;
 
-#else
+#else  // _WIN32
 
 #include <pthread.h>
+#include <stdint.h>
 
 #include "errors.hpp"
 

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -5,11 +5,15 @@
 #define OPTIONAL // This macro is undefined in "windows.hpp" but necessary for <DbgHelp.h>
 #include <DbgHelp.h>
 #include <atomic>
-#else
+#else  // _WIN32
 #include <cxxabi.h>
+
+#if !defined(RDB_NO_BACKTRACE)
 #include <execinfo.h>
-#include <sys/wait.h>
 #endif
+
+#include <sys/wait.h>
+#endif  // _WIN32
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/clustering/administration/auth/authentication_error.hpp
+++ b/src/clustering/administration/auth/authentication_error.hpp
@@ -2,6 +2,8 @@
 #ifndef CLUSTERING_ADMINISTRATION_AUTH_AUTHENTICATION_ERROR_HPP
 #define CLUSTERING_ADMINISTRATION_AUTH_AUTHENTICATION_ERROR_HPP
 
+#include <stdint.h>
+
 #include <stdexcept>
 #include <string>
 

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string>
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -2,6 +2,7 @@
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This adds some stdint.h includes in response to a user report of compilation failure.  The include in errors.hpp is added to generally help reduce the risk of this problem in the future.

It also adds an RDB_NO_BACKTRACE preprocessor conditional around the execinfo.h include.