### PR TITLE
Avoid some bus erroring unaligned memory accesses.

### DIFF
--- a/src/btree/internal_node.cc
+++ b/src/btree/internal_node.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include "btree/node.hpp"
+#include "containers/unaligned.hpp"
 
 // We comment out this warning, and static_assert that pair_offsets is
 // at an aligned offset.

--- a/src/btree/internal_node.hpp
+++ b/src/btree/internal_node.hpp
@@ -17,11 +17,10 @@ struct internal_node_t;
 #define INTERNAL_EPSILON (sizeof(btree_key_t) + MAX_KEY_SIZE + sizeof(block_id_t))
 
 //Note: This struct is stored directly on disk.  Changing it invalidates old data.
-ATTR_PACKED(struct btree_internal_pair {
+ATTR_PACKED(struct alignas(1) btree_internal_pair {
     block_id_t lnode;
     btree_key_t key;
 });
-
 
 class internal_key_comp;
 

--- a/src/btree/leaf_node.cc
+++ b/src/btree/leaf_node.cc
@@ -9,6 +9,7 @@
 #include <set>
 
 #include "btree/node.hpp"
+#include "containers/unaligned.hpp"
 #include "repli_timestamp.hpp"
 #include "utils.hpp"
 

--- a/src/btree/node.hpp
+++ b/src/btree/node.hpp
@@ -89,4 +89,9 @@ inline void keycpy(btree_key_t *dest, const btree_key_t *src) {
     memcpy(dest, src, sizeof(btree_key_t) + src->size);
 }
 
+template <class T>
+ATTR_PACKED(struct alignas(1) unaligned {
+    T value;
+});
+
 #endif // BTREE_NODE_HPP_

--- a/src/btree/node.hpp
+++ b/src/btree/node.hpp
@@ -89,9 +89,4 @@ inline void keycpy(btree_key_t *dest, const btree_key_t *src) {
     memcpy(dest, src, sizeof(btree_key_t) + src->size);
 }
 
-template <class T>
-ATTR_PACKED(struct alignas(1) unaligned {
-    T value;
-});
-
 #endif // BTREE_NODE_HPP_

--- a/src/buffer_cache/blob.hpp
+++ b/src/buffer_cache/blob.hpp
@@ -14,6 +14,7 @@
 #include "containers/buffer_group.hpp"
 #include "errors.hpp"
 #include "serializer/types.hpp"
+#include "utils.hpp"
 
 class buffer_group_t;
 
@@ -113,9 +114,6 @@ int maxreflen_from_blockid_count(int count);
 // The step size of a blob.
 int64_t stepsize(max_block_size_t block_size, int levels);
 
-// The internal node block ids of an internal node.
-const block_id_t *internal_node_block_ids(const void *buf);
-
 // Returns offset and size, clamped to and relative to the index'th subtree.
 void shrink(max_block_size_t block_size, int levels, int64_t offset, int64_t size, int index, int64_t *suboffset_out, int64_t *subsize_out);
 
@@ -133,9 +131,6 @@ struct ref_info_t {
     int levels;
 };
 ref_info_t ref_info(max_block_size_t block_size, const char *ref, int maxreflen);
-
-// Returns the internal block ids of a non-inlined blob ref.
-const block_id_t *block_ids(const char *ref, int maxreflen);
 
 // Returns the char bytes of a leaf node.
 const char *leaf_node_data(const void *buf);

--- a/src/containers/unaligned.hpp
+++ b/src/containers/unaligned.hpp
@@ -1,0 +1,12 @@
+#ifndef CONTAINERS_UNALIGNED_HPP_
+#define CONTAINERS_UNALIGNED_HPP_
+
+#include "arch/compiler.hpp"
+
+template <class T>
+ATTR_PACKED(struct alignas(1) unaligned {
+    T value;
+    T copy() const { return value; }
+});
+
+#endif  // CONTAINERS_UNALIGNED_HPP_

--- a/src/repli_timestamp.hpp
+++ b/src/repli_timestamp.hpp
@@ -25,13 +25,6 @@ class repli_timestamp_t {
 public:
     uint64_t longtime;
 
-    bool operator==(repli_timestamp_t t) const { return longtime == t.longtime; }
-    bool operator!=(repli_timestamp_t t) const { return longtime != t.longtime; }
-    bool operator<(repli_timestamp_t t) const { return longtime < t.longtime; }
-    bool operator>(repli_timestamp_t t) const { return longtime > t.longtime; }
-    bool operator<=(repli_timestamp_t t) const { return longtime <= t.longtime; }
-    bool operator>=(repli_timestamp_t t) const { return longtime >= t.longtime; }
-
     repli_timestamp_t next() const {
         repli_timestamp_t t;
         t.longtime = longtime + 1;
@@ -41,6 +34,15 @@ public:
     static const repli_timestamp_t distant_past;
     static const repli_timestamp_t invalid;
 };
+
+// These functions specifically make a point of passing by value, because
+// repli_timestamp_t is often used in packed or misaligned structures.
+inline bool operator==(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime == t.longtime; }
+inline bool operator!=(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime != t.longtime; }
+inline bool operator<(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime < t.longtime; }
+inline bool operator>(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime > t.longtime; }
+inline bool operator<=(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime <= t.longtime; }
+inline bool operator>=(repli_timestamp_t s, repli_timestamp_t t) { return s.longtime >= t.longtime; }
 
 // Returns the max of x and y, treating invalid as a negative infinity value.
 repli_timestamp_t superceding_recency(repli_timestamp_t x, repli_timestamp_t y);


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This is a best effort fix to avoid some unaligned memory accesses that have cropped up in testing 32-bit ARM code.  This avoids crashes that occur when running 32-bit ARM binaries on a 64-bit kernel.

This will probably improve the performance of 32-bit ARM on a 32-bit Linux kernel, because supposedly the kernel traps the error and fixes up the memory read.  Or so I've read.  That could matter if anybody has that running on some rPi somewhere.

I checked by disassembly -- this does not affect x86-64 code generation on g++, except maybe for copy() calls in debug mode -- nor would we expect it to.

With this fix I got 32-bit ARM debug binaries to run successfully on a 64-bit ARM system.

For what it's worth, I ran into some unrelated issue with release binaries, possibly some sort of cross-compiling/linking snafu as it was a segfault in libc, so I didn't test that.