### PR TITLE
Generate web_assets.cc in consistent order

### DIFF
--- a/admin/build.mk
+++ b/admin/build.mk
@@ -20,4 +20,4 @@ web-assets: $(ALL_WEB_ASSETS)
 generate-web-assets-cc: web-assets
 	mkdir -p $(TOP)/src/gen
 	$(TOP)/scripts/compile-web-assets.py $(TOP)/build/web_assets > $(TOP)/src/gen/web_assets.cc
-	grep -A 2 '\\"rethinkdb-version\\":\[' $(TOP)/src/gen/web_assets.cc | grep 'module\.exports' | xargs -0 echo -n 'Double-check version:'
+	grep -E 'module\.exports=\\"[0-9]+(\.[0-9]+)+\\";' $(TOP)/src/gen/web_assets.cc | xargs -0 echo -n 'Double-check version:'

--- a/scripts/compile-web-assets.py
+++ b/scripts/compile-web-assets.py
@@ -40,7 +40,8 @@ prelude = """
 #include <string>
 """
 
-def write_assets(asset_root, assets):
+def write_assets(asset_root, unsorted_assets):
+    assets = sorted(unsorted_assets)
 
     print('std::map<std::string, const std::string> static_web_assets = {')
     for i, asset in enumerate(assets):


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This generates the web_assets.cc with its map sorted by file path in alphabetic order, instead of the machine's local directory traversal order.

This makes the output repeatable, with smaller diffs.  Fixes #7133.

Also, we make the "double-check version" output of `make generate`, used to assure the user the final output of the version number was generated correctly, be less sensitive to line wrapping of the preceding rethinkdb-version string, so that it functions more correctly.