### PR TITLE
Avoid fstat64, which is unnecessary

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -14,6 +14,7 @@ None.
 * Compilation
   * Replace bad zlib URL with working one (#7121)
   * Fix new include errors (#7119)
+  * Avoid using deprecated `fstat64` function (#7141)
 * Web UI
   * Fix data explorer auto-complete (#7111, #7113)
   * Update ReQL documentation link (#7112, #7114)

--- a/src/arch/io/disk/filestat.cc
+++ b/src/arch/io/disk/filestat.cc
@@ -15,15 +15,17 @@ int64_t get_file_size(fd_t fd) {
     guarantee(size.LowPart != INVALID_FILE_SIZE, "GetFileSize failed");
     return size.QuadPart;
 #else
-#if defined(__MACH__) || defined(__FreeBSD__)
+    // No fstat64 -- we pass -D_FILE_OFFSET_BITS=64, musl dropped fstat64, and the static
+    // assertions below check for 64 bit sizes.
+
     struct stat buf;
     int res = fstat(fd, &buf);
-#elif defined(__linux__)
-    struct stat64 buf;
-    int res = fstat64(fd, &buf);
-#endif
+
     // This compile-time assertion is the most important line in the function.
     CT_ASSERT(sizeof(buf.st_size) == sizeof(int64_t));
+
+    // This one also sanity-checks we aren't in any non-_FILE_OFFSET_BITS==64-type regime.
+    static_assert(sizeof(off_t) == sizeof(int64_t), "expecting off_t to be 64 bits");
 
     guarantee_err(res == 0, "fstat failed");
     guarantee(buf.st_size >= 0);


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Compilation had broken on the Alpine linux edge version, using musl instead of glibc.  Further investigation shows that using fstat64 is unnecessary.  We do set `_FILE_OFFSET_BITS` to 64 in the CXXFLAGS.

Compilation has been tested on i386 and amd64 Alpine 3.15-3.18 and Alpine Edge, as well as on i386 Ubuntu 14.04.