### PR TITLE
Reql error improvements

### DIFF
--- a/src/rdb_protocol/datum.cc
+++ b/src/rdb_protocol/datum.cc
@@ -1411,12 +1411,12 @@ struct datum_rcheckable_t : public rcheckable_t {
 #ifdef RQL_ERROR_BT
                       const char *test, const char *file, int line,
 #endif
-                      std::string msg) const {
+                      std::string&& msg) const {
         datum->runtime_fail(type,
 #ifdef RQL_ERROR_BT
             test, file, line,
 #endif
-            msg);
+            std::move(msg));
     }
     const datum_t *datum;
 };

--- a/src/rdb_protocol/datum.cc
+++ b/src/rdb_protocol/datum.cc
@@ -1408,9 +1408,15 @@ int64_t checked_convert_to_int(const rcheckable_t *target, double d) {
 struct datum_rcheckable_t : public rcheckable_t {
     explicit datum_rcheckable_t(const datum_t *_datum) : datum(_datum) { }
     void runtime_fail(base_exc_t::type_t type,
+#ifdef RQL_ERROR_BT
                       const char *test, const char *file, int line,
+#endif
                       std::string msg) const {
-        datum->runtime_fail(type, test, file, line, msg);
+        datum->runtime_fail(type,
+#ifdef RQL_ERROR_BT
+            test, file, line,
+#endif
+            msg);
     }
     const datum_t *datum;
 };
@@ -1813,9 +1819,15 @@ bool datum_t::operator>(const datum_t &rhs) const { return cmp(rhs) > 0; }
 bool datum_t::operator>=(const datum_t &rhs) const { return cmp(rhs) >= 0; }
 
 void datum_t::runtime_fail(base_exc_t::type_t exc_type,
+#ifdef RQL_ERROR_BT
                            const char *test, const char *file, int line,
+#endif
                            std::string msg) const {
-    ql::runtime_fail(exc_type, test, file, line, msg);
+    ql::runtime_fail(exc_type,
+#ifdef RQL_ERROR_BT
+        test, file, line,
+#endif
+        std::move(msg));
 }
 
 datum_t to_datum(const Datum *d, const configured_limits_t &limits,

--- a/src/rdb_protocol/datum.hpp
+++ b/src/rdb_protocol/datum.hpp
@@ -325,7 +325,9 @@ public:
     bool operator>=(const datum_t &rhs) const;
 
     NORETURN void runtime_fail(base_exc_t::type_t exc_type,
+#ifdef RQL_ERROR_BT
                                const char *test, const char *file, int line,
+#endif
                                std::string msg) const;
 
     static size_t max_trunc_size();

--- a/src/rdb_protocol/error.cc
+++ b/src/rdb_protocol/error.cc
@@ -16,23 +16,28 @@ namespace ql {
 #endif
 
 void runtime_fail(base_exc_t::type_t type,
+#ifdef RQL_ERROR_BT
                   RQL_ERROR_VAR const char *test, RQL_ERROR_VAR const char *file,
                   RQL_ERROR_VAR int line,
-                  std::string msg, backtrace_id_t bt) {
+#endif
+                  std::string&& msg, backtrace_id_t bt) {
 #ifdef RQL_ERROR_BT
     msg = strprintf("%s\nFailed assertion: %s\nAt: %s:%d",
                     msg.c_str(), test, file, line);
 #endif
-    throw exc_t(type, msg, bt);
+    throw exc_t(type, std::move(msg), bt);
 }
 void runtime_fail(base_exc_t::type_t type,
+#ifdef RQL_ERROR_BT
                   RQL_ERROR_VAR const char *test, RQL_ERROR_VAR const char *file,
-                  RQL_ERROR_VAR int line, std::string msg) {
+                  RQL_ERROR_VAR int line,
+#endif
+                  std::string&& msg) {
 #ifdef RQL_ERROR_BT
     msg = strprintf("%s\nFailed assertion: %s\nAt: %s:%d",
                     msg.c_str(), test, file, line);
 #endif
-    throw datum_exc_t(type, msg);
+    throw datum_exc_t(type, std::move(msg));
 }
 
 void runtime_sanity_check_failed(const char *file, int line, const char *test,

--- a/src/rdb_protocol/func.cc
+++ b/src/rdb_protocol/func.cc
@@ -418,7 +418,7 @@ counted_t<const func_t> new_page_func(datum_t method, backtrace_id_t bt) {
         } else {
             std::string msg = strprintf("`page` method '%s' not recognized, "
                                         "only 'link-next' is available.", name.c_str());
-            rcheck_src(bt, false, base_exc_t::LOGIC, msg);
+            rcheck_src(bt, false, base_exc_t::LOGIC, std::move(msg));
         }
     }
     return counted_t<const func_t>();


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Some small improvements to reql error macros.

When RQL_ERROR_BT is not defined, this prevents us from passing unnecessary, unused parameters to runtime_fail.  Also we use a move constructor in some places.

RQL_ERROR_BT is not defined in release mode.

This should minimally improve performance, when certain reql errors happen, or when there is code that throws and catches errors.

