### PR TITLE
Fix: Buffer Overflow Vulnerability in cJSON String Parsing Function

### DIFF
--- a/src/cjson/cJSON.cc
+++ b/src/cjson/cJSON.cc
@@ -217,34 +217,42 @@ static unsigned parse_hex4(const char *str)
 /* Parse the input text into an unescaped cstring, and populate item. */
 static const unsigned char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
-static const char *parse_string(cJSON *item,const char *str)
+static const char *parse_string(cJSON *item, const char *str)
 {
     const char *ptr = str+1;
+    const char *end_ptr = str+1;
     char *ptr2;
     char *out;
     int len = 0;
     unsigned uc, uc2;
-
+    
     if (*str != '\"') {
         // Not a string.
         ep = str;
         return 0;
     }
-
-    while (*ptr != '\"' && *ptr && ++len) {
-        // Skip escaped quotes.
-        if (*ptr++ == '\\') ptr++;
+    
+    // Calculate approximate length first
+    while (*end_ptr != '\"' && *end_ptr && ++len) {
+        if (*end_ptr++ == '\\') end_ptr++;  // Skip escaped quotes.
     }
-
+    
     // This is how long we need for the string, roughly.
-    out=(char*)cJSON_malloc(len+1);
+    out = (char*)cJSON_malloc(len+1);
     if (!out) {
         return 0;
     }
-
-    ptr=str+1;
-    ptr2=out;
-    while (*ptr != '\"' && *ptr) {
+    
+    // Set these values early so memory will be properly cleaned up in error cases
+    item->valuestring = out;
+    item->type = cJSON_String;
+    
+    ptr = str+1;
+    ptr2 = out;
+    
+    // Use end_ptr for bounds checking
+    while (ptr < end_ptr)
+    {
         if (*ptr != '\\') {
             *ptr2++ = *ptr++;
         } else {
@@ -257,31 +265,45 @@ static const char *parse_string(cJSON *item,const char *str)
                 case 'r': *ptr2++ = '\r'; break;
                 case 't': *ptr2++ = '\t'; break;
                 case 'u': /* transcode utf16 to utf8. */
-                    /* get the unicode char. */
+                    // Get the unicode char.
                     uc = parse_hex4(ptr+1);
                     ptr += 4;
-
+                    
+                    // Bounds check
+                    if (ptr >= end_ptr) {
+                        ep = str;
+                        return 0;  // Invalid
+                    }
+                    
                     // Fail on invalid Unicode characters, unlike normal cJSON.
                     if ((uc >= 0xDC00 && uc <= 0xDFFF) || uc == 0) {
-                        cJSON_free(out);
+                        ep = str;
                         return 0;
                     }
-
+                    
                     if (uc >= 0xD800 && uc <= 0xDBFF) {
-                        /* UTF16 surrogate pairs. */
+                        // UTF16 surrogate pairs.
+                        if (ptr+6 > end_ptr) {
+                            ep = str;
+                            return 0;  // Invalid
+                        }
+                        
                         if (ptr[1] != '\\' || ptr[2] != 'u') {
-                            /* missing second-half of surrogate. */
+                            // Missing second-half of surrogate.
                             break;
                         }
+                        
                         uc2 = parse_hex4(ptr + 3);
                         ptr += 6;
+                        
                         if (uc2 < 0xDC00 || uc2 > 0xDFFF) {
-                            break;	/* invalid second-half of surrogate. */
+                            break; // Invalid second-half of surrogate.
                         }
+                        
                         uc = 0x10000 + (((uc & 0x3FF) << 10) | (uc2 & 0x3FF));
                     }
-
-                    len=4;
+                    
+                    len = 4;
                     if (uc < 0x80) {
                         len = 1;
                     } else if (uc < 0x800) {
@@ -289,8 +311,8 @@ static const char *parse_string(cJSON *item,const char *str)
                     } else if (uc < 0x10000) {
                         len = 3;
                     }
+                    
                     ptr2 += len;
-
                     switch (len) {
                         case 4: *--ptr2 = ((uc | 0x80) & 0xBF); uc >>= 6;
                             // fallthrough
@@ -307,13 +329,9 @@ static const char *parse_string(cJSON *item,const char *str)
             ptr++;
         }
     }
-
+    
     *ptr2 = 0;
     if (*ptr == '\"') ptr++;
-
-    item->valuestring = out;
-    item->type = cJSON_String;
-
     return ptr;
 }
 


### PR DESCRIPTION
# Fix Buffer Overflow Vulnerability in cJSON String Parsing Function

## Description of the Change:
This PR fixes a **buffer overflow vulnerability** in the `parse_string` function within the **cJSON** library. The issue arises when parsing **UTF-16 surrogate pairs** in JSON strings, where the buffer allocated may not be large enough to accommodate the converted UTF-8 characters. This causes **memory corruption** and potential **arbitrary code execution**.

This fix includes:
1. **Bounds Checking**: Adds proper validation of buffer sizes using an end pointer.
2. **Unicode Validation**: Additional checks for Unicode characters, especially **surrogate pairs**.
3. **Memory Cleanup**: Ensures the valuestring is properly assigned early to prevent memory leaks.
4. **Improved Error Handling**: Enhances error handling to mimic security patches from the original cJSON library.

This vulnerability was identified in the cloned `parse_string` function and was not patched after cJSON's original patch. The original fix for this vulnerability is available in the cJSON library.

## References:
* **CVE-2016-4303**
* **Original Patch**: https://github.com/esnet/iperf/commit/91f2fa59e8ed80dfbf400add0164ee0e508e412a