### PR TITLE
feature: add RISC-V architecture support

### DIFF
--- a/configure
+++ b/configure
@@ -110,6 +110,9 @@ configure_unixlike () {
         arm*|arm64*|aarch64*)
             var_append LDFLAGS -ldl
             final_warning="ARM support is still experimental" ;;
+        riscv64)
+            var_append LDFLAGS -ldl
+            final_warning="RISC-V support is still experimental" ;;
         s390x)
             final_warning="s390x support is still experimental" ;;
         ppc64le|powerpc64le|powerpc64el)

--- a/src/rapidjson/allocators.h
+++ b/src/rapidjson/allocators.h
@@ -107,7 +107,7 @@ public:
 // RethinkDB patch: The MemoryPoolAllocator doesn't currently work properly on
 // ARM. See https://github.com/rethinkdb/rethinkdb/issues/4839
 // and https://github.com/miloyip/rapidjson/issues/388 .
-#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(__riscv)
 #define MAYBE_POOL_ALLOCATOR RAllocator
 #else
 #define MAYBE_POOL_ALLOCATOR MemoryPoolAllocator<>

--- a/src/rpc/connectivity/cluster.cc
+++ b/src/rpc/connectivity/cluster.cc
@@ -102,7 +102,7 @@ static bool resolve_protocol_version(const std::string &remote_version_string,
     return false;
 }
 
-#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__) || defined(__arm64__) || defined(__aarch64__) || defined (__powerpc64__)
+#if defined (__x86_64__) || defined (_WIN64) || defined (__s390x__) || defined(__arm64__) || defined(__aarch64__) || defined(__riscv) || defined (__powerpc64__)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("64bit");
 #elif defined (__i386__) || defined(__arm__) || defined(_WIN32)
 const std::string connectivity_cluster_t::cluster_arch_bitsize("32bit");


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

## Description

### Summary

This PR adds support for the riscv64 architecture to RethinkDB.

### Changes
- Updated `configure` script to detect and handle riscv64 as a supported platform.
- Extended architecture-specific logic in `src/arch/runtime/context_switching.cc` to include riscv64, enabling proper context switching and runtime support.
- Adjusted `src/rapidjson/allocators.h` and `src/rpc/connectivity/cluster.cc` for riscv64 compatibility.
- Ensured all new code paths are conditionally compiled and do not affect existing supported architectures.

### Motivation

RISC-V is an open and rapidly growing CPU architecture. Adding riscv64 support enables RethinkDB to run natively on RISC-V hardware, broadening its usability and aligning with the project's goal of wide platform compatibility.

### Testing

- Successfully built and ran RethinkDB on a **Sophgo SG2042 RISC-V CPU** running Linux.
- Ran `build/debug/rethinkdb-unittest` and **all unit tests passed** on the SG2042 platform.
- Launched a RethinkDB instance and verified basic database operations on riscv64.

<details>
  <summary>rethinkdb-unittest on sophgo SG2042 RISC-V cpu </summary>
  
![image](https://github.com/user-attachments/assets/ebe78a0f-d831-43de-a14a-75232dad3aa7)

</details>

### Checklist

- [x] Code builds and passes tests on riscv64
- [x] All changes are architecture-guarded and do not affect other platforms

### Related

No breaking changes.  
If there are any platform-specific limitations, please mention them here.
