### PR TITLE
chore: replace CLAs with DoC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,11 @@
-- [ ] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
-
-### Description
+## Description
 <Please fill in the description of your pull request here. Thank you for your contribution!>
+
+## Checklist
+- [ ] I have read and understood the [Developer's Certificate of Origin] and
+  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
+  my name.
+
+<!-- Links -->
+
+[Developer's Certificate of Origin]: https://github.com/rethinkdb/rethinkdb/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,10 @@ To submit a pull request, fork the [RethinkDB repository][3] and then clone your
 
 Make your suggested changes, `git push` and then [submit a pull
 request][4]. Note that before we can accept your pull requests, you
-need to sign our [Contributor License Agreement][5].
+need to accept our [Developer Certificate of Origin][5] and sign your commits.
 
 [4]: https://github.com/rethinkdb/rethinkdb/compare/
-[5]: http://rethinkdb.com/community/cla/
+[5]: https://github.com/rethinkdb/rethinkdb/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
 
 ## Building the admin UI
 
@@ -43,3 +43,24 @@ Some useful resources to get started:
 [7]: src/README.md
 [8]: http://rethinkdb.com/docs/driver-spec/
 [9]: STYLE.md
+
+## Developer's Certificate of Origin
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source
+license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open
+source license and I have the right under that license to submit that work with modifications, whether created in whole
+or in part by me, under the same open source license (unless I am permitted to submit under a different license), as
+indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not
+modified it.
+
+(d) I understand and agree that this project and the contribution are public and that a record of the contribution (
+including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be
+redistributed consistent with this project or the open source license(s) involved.


### PR DESCRIPTION
**Reason for the change**
As per the project [charter](https://rethinkdb.com/community/charter), RethinkDB should use DoC over CLAs.

**Description**
This PR removes CLA and related pages from the website.

**Checklist**
- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/rethinkdb/rethinkdb/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
Anything else related to the change e.g. documentations, RFCs, etc.