### PR TITLE
Add boost_0-implicit-defs.patch for Boost 1.60.0 dependency

### DIFF
--- a/mk/support/pkg/patch/boost_0-implicit-defs.patch
+++ b/mk/support/pkg/patch/boost_0-implicit-defs.patch
@@ -1,0 +1,33 @@
+diff -ruN --label original original ./tools/build/src/engine/execcmd.c
+--- original
++++ ./tools/build/src/engine/execcmd.c	2025-10-27 11:58:03.160829376 -0700
+@@ -15,6 +15,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#include "output.h"
+ 
+ /* Internal interrupt counter. */
+ static int intr;
+diff -ruN --label original original ./tools/build/src/engine/make.c
+--- original
++++ ./tools/build/src/engine/make.c	2025-10-27 11:49:42.613667099 -0700
+@@ -39,6 +39,7 @@
+ #include "headers.h"
+ #include "lists.h"
+ #include "object.h"
++#include "output.h"
+ #include "parse.h"
+ #include "rules.h"
+ #include "search.h"
+diff -ruN --label original original ./tools/build/src/engine/modules/path.c
+--- original
++++ ./tools/build/src/engine/modules/path.c	2025-10-27 11:49:57.185746334 -0700
+@@ -5,6 +5,7 @@
+  */
+ 
+ #include "../constants.h"
++#include "../filesys.h"
+ #include "../frames.h"
+ #include "../lists.h"
+ #include "../native.h"


### PR DESCRIPTION
Fixes build errors with the boost dependency (when configuring with `--fetch boost`) that occur with modern GCCs (or our build options for them) on Ubuntu 25.04 (Plucky) and later.

The build errors occurred because a few functions like `out_printf` and `file_query` were not declared, and thus implicit declarations were used.  So we include the header files that have the declarations.