### PR TITLE
Suppress redundant --server-name warning when names match

### DIFF
--- a/src/clustering/administration/main/command_line.cc
+++ b/src/clustering/administration/main/command_line.cc
@@ -2368,7 +2368,8 @@ int main_rethinkdb_porcelain(int argc, char *argv[]) {
         if (is_new_directory) {
             server_name = parse_server_name_option(opts);
         } else {
-            if (static_cast<bool>(get_optional_option(opts, "--server-name"))) {
+            optional<name_string_t> opt_server_name = get_optional_option(opts, "--server-name");
+            if (static_cast<bool>(opt_server_name) && *opt_server_name != server_name) {
                 fprintf(stderr, "WARNING: ignoring --server-name because this server "
                     "already has a name.\n");
             }


### PR DESCRIPTION
## Description
This change suppresses a redundant startup warning when the configured
--server-name matches the name already stored in server metadata.

The warning is now only emitted when the names differ.

Fixes #6922 

## Checklist
- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/rethinkdb/rethinkdb/blob/main/CONTRIBUTING.md#developers-certificate-of-origin