### PR TITLE
fix: correct tautological invariant in raft_core.tcc

### DIFF
--- a/src/clustering/generic/raft_core.tcc
+++ b/src/clustering/generic/raft_core.tcc
@@ -849,7 +849,7 @@ void raft_member_t<state_t>::check_invariants(
         "candidate_and_leader_coro() should be running unless we're a follower");
     guarantee(mode == mode_t::leader || !readiness_for_change.get(),
         "we shouldn't be accepting changes if we're not leader");
-    guarantee(readiness_for_change.get() || !readiness_for_change.get(),
+    guarantee(readiness_for_change.get() || !readiness_for_config_change.get(),
         "we shouldn't be accepting config changes but not regular changes");
 
     switch (mode) {


### PR DESCRIPTION
Hi!

Tiny copy-paste fix in the debug invariant check.

At raft_core.tcc:852, the guarantee checks `readiness_for_change || !readiness_for_change` which is always true. The intended check is `readiness_for_change || !readiness_for_config_change` — i.e. "we shouldn't be accepting config changes but not regular changes". The second variable name just got copied from the first.